### PR TITLE
Connect login page to backend API

### DIFF
--- a/src/app/@theme/services/authentication.service.ts
+++ b/src/app/@theme/services/authentication.service.ts
@@ -38,7 +38,7 @@ export class AuthenticationService {
   }
 
   login(email: string, password: string) {
-    return this.http.post<User>(`${environment.apiUrl}/api/account/login`, { email, password }).pipe(
+    return this.http.post<User>(`${environment.apiUrl}/api/Account/Login`, { email, password }).pipe(
       map((user: User) => {
         // Explicitly define the type for 'user'
         // Store user details and JWT token in local storage

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,5 +3,5 @@ import packageInfo from '../../package.json';
 export const environment = {
   appVersion: packageInfo.version,
   production: true,
-  apiUrl: 'https://mock-data-api-nextjs.vercel.app/'
+  apiUrl: 'https://localhost:7260'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,7 +7,7 @@ import packageInfo from '../../package.json';
 export const environment = {
   appVersion: packageInfo.version,
   production: false,
-  apiUrl: 'https://mock-data-api-nextjs.vercel.app'
+  apiUrl: 'https://localhost:7260'
 };
 
 /*


### PR DESCRIPTION
## Summary
- Configure environment API URL for local backend
- Post login requests to backend `/api/Account/Login` endpoint

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adad7335c48322b6362f592a9c36ee