### PR TITLE
Simplify authentication-1 login page

### DIFF
--- a/src/app/demo/pages/auth/authentication-1/login/login.component.html
+++ b/src/app/demo/pages/auth/authentication-1/login/login.component.html
@@ -1,112 +1,68 @@
 <div class="auth-main">
   <div class="auth-wrapper version-1">
     <div class="auth-form">
-      <div class="auth-background">
-        <div class="yellow-circle"></div>
-        <div class="red-circle"></div>
-      </div>
-      @if (!this.authenticationService.isLoggedIn()) {
-        <ul class="admin-role">
-          <div class="row">
-            @for (role of roles; track role.role) {
-              <div class="col-sm-6">
-                <a href="javascript:" class="role-tab" [class.active]="selectedRole === role" (click)="onSelectRole(role)">
-                  {{ role.name }}
-                </a>
-              </div>
+      <app-card [showHeader]="false" class="auth-form-card" padding="40">
+        <div class="text-center">
+          <a href="javascript:">
+            <img src="assets/images/logo-dark.svg" alt="logo" />
+          </a>
+        </div>
+        <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" class="text-start">
+          <label for="email" class="f-w-500 text-start">Enter Username</label>
+          <mat-form-field appearance="outline" class="w-100 m-t-5">
+            <input
+              type="text"
+              matInput
+              formControlName="email"
+              [ngClass]="{ 'is-invalid': submitted && formValues?.['email'].errors }"
+            />
+            @if (submitted && formValues?.['email'].errors) {
+              <mat-hint class="text-warn-500">Email is required</mat-hint>
             }
-          </div>
-        </ul>
-      }
-      <div class="main-form">
-        <app-card [showHeader]="false" class="auth-form-card {{ this.authenticationService.isLoggedIn() ? '' : 'user-role' }}" padding="40">
-          <div class="text-center">
-            <a href="javascript:">
-              <img src="assets/images/logo-dark.svg" alt="logo" />
-            </a>
-            <div class="login-with">
-              <button mat-stroked-button class="m-t-10 text-muted">
-                <div class="flex">
-                  <img src="assets/images/authentication/facebook.svg" alt="facebook" />
-                  <span class="mat-body p-l-10">Sign In with Facebook</span>
-                </div>
-              </button>
-              <button mat-stroked-button class="m-t-10 text-muted">
-                <div class="flex">
-                  <img src="assets/images/authentication/twitter.svg" alt="facebook" />
-                  <span class="mat-body p-l-10">Sign In with Twitter</span>
-                </div>
-              </button>
-              <button mat-stroked-button class="m-t-10 text-muted">
-                <div class="flex">
-                  <img src="assets/images/authentication/google.svg" alt="facebook" />
-                  <span class="mat-body p-l-10">Sign In with Google</span>
-                </div>
-              </button>
-            </div>
-          </div>
-          <div class="separator">
-            <span>OR</span>
-          </div>
-          <div class="text-center m-b-25 f-20 f-w-500">Login With Your Email</div>
-          <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" class="text-start">
-            <label for="name" class="f-w-500 text-start">Enter Username</label>
-            <mat-form-field appearance="outline" class="w-100 m-t-5">
-              <input
-                type="text"
-                matInput
-                [(ngModel)]="selectedRole.email"
-                formControlName="email"
-                [ngClass]="{ 'is-invalid': submitted && formValues?.['email'].errors }"
-              />
-              @if (submitted && formValues?.['email'].errors) {
-                <mat-hint class="text-warn-500">Email is required</mat-hint>
-              }
-            </mat-form-field>
-            <label for="name" class="f-w-500 text-start">Enter Your Password</label>
-            <mat-form-field appearance="outline" class="w-100 m-t-5">
-              <input
-                [type]="hide ? 'password' : 'text'"
-                id="password"
-                matInput
-                [(ngModel)]="selectedRole.password"
-                formControlName="password"
-                [ngClass]="{ 'is-invalid': submitted && formValues?.['password'].errors }"
-              />
-              @if (submitted && formValues?.['password'].errors) {
-                <mat-hint class="text-warn-500">Password is required</mat-hint>
-              }
-              <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
-                <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
-              </button>
-            </mat-form-field>
-            <div class="check-me">
-              <mat-checkbox class="float-start" checked color="primary">Remember me?</mat-checkbox>
-              <a
-                class="f-w-400 text-primary-500 m-b-0"
-                [routerLink]="[this.authenticationService.isLoggedIn() ? '/authentication-1/forgot-password' : '/forgot-password']"
-              >
-                Forgot Password
-              </a>
-            </div>
-            <div class="grid">
-              <button mat-flat-button color="primary" class="b-rad-20 m-t-15">Login</button>
-            </div>
-            @if (error) {
-              <div class="bg-warn-50 text-warn-500 p-10 m-t-15 mb-0">{{ error }}</div>
+          </mat-form-field>
+          <label for="password" class="f-w-500 text-start">Enter Your Password</label>
+          <mat-form-field appearance="outline" class="w-100 m-t-5">
+            <input
+              [type]="hide ? 'password' : 'text'"
+              id="password"
+              matInput
+              formControlName="password"
+              [ngClass]="{ 'is-invalid': submitted && formValues?.['password'].errors }"
+            />
+            @if (submitted && formValues?.['password'].errors) {
+              <mat-hint class="text-warn-500">Password is required</mat-hint>
             }
-          </form>
-          <div class="check-me m-t-20">
-            <div class="text-muted">Don't have an Account?</div>
-            <a
-              [routerLink]="[this.authenticationService.isLoggedIn() ? '/authentication-1/register' : '/register']"
-              class="text-primary-500"
+            <button
+              mat-icon-button
+              matSuffix
+              (click)="hide = !hide"
+              [attr.aria-label]="'Hide password'"
+              [attr.aria-pressed]="hide"
             >
-              Create Account
+              <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
+            </button>
+          </mat-form-field>
+          <div class="check-me">
+            <mat-checkbox class="float-start" color="primary">Remember me?</mat-checkbox>
+            <a class="f-w-400 text-primary-500 m-b-0" [routerLink]="['/forgot-password']">
+              Forgot Password
             </a>
           </div>
-        </app-card>
-      </div>
+          <div class="grid">
+            <button mat-flat-button color="primary" class="b-rad-20 m-t-15">Login</button>
+          </div>
+          @if (error) {
+            <div class="bg-warn-50 text-warn-500 p-10 m-t-15 mb-0">{{ error }}</div>
+          }
+        </form>
+        <div class="check-me m-t-20">
+          <div class="text-muted">Don't have an Account?</div>
+          <a [routerLink]="['/register']" class="text-primary-500">
+            Create Account
+          </a>
+        </div>
+      </app-card>
     </div>
   </div>
 </div>
+


### PR DESCRIPTION
## Summary
- streamline Authentication-1 login component into a basic username/password form

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb70ff9bc83229ae0fed3595fc08e