### PR TITLE
Handle missing user role in auth guard

### DIFF
--- a/src/app/@theme/helpers/auth.guard.ts
+++ b/src/app/@theme/helpers/auth.guard.ts
@@ -21,10 +21,11 @@ export class AuthGuardChild implements CanActivateChild {
    */
 
   canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    const currentUser = this.authenticationService.currentUserValue;
-    if (currentUser && this.authenticationService.isLoggedIn()) {
+    const userRole = this.authenticationService.getRole();
+
+    if (userRole && this.authenticationService.isLoggedIn()) {
       const { roles } = route.data;
-      if (roles && !roles.includes(currentUser.user.role)) {
+      if (roles && !roles.includes(userRole)) {
         // User not authorized, redirect to unauthorized page
         this.router.navigate(['/unauthorized']);
         return false;
@@ -33,7 +34,7 @@ export class AuthGuardChild implements CanActivateChild {
       return true;
     }
 
-    // User not logged in, redirect to login page
+    // User not logged in or role unavailable, redirect to login page
     this.router.navigate(['/login'], { queryParams: { returnUrl: state.url } });
     return false;
   }

--- a/src/app/@theme/services/authentication.service.ts
+++ b/src/app/@theme/services/authentication.service.ts
@@ -6,6 +6,7 @@ import { Router } from '@angular/router';
 // project import
 import { environment } from 'src/environments/environment';
 import { User } from '../types/user';
+import { Role } from '../types/role';
 
 // Import the 'map' operator from 'rxjs/operators'
 import { map } from 'rxjs/operators';
@@ -22,8 +23,14 @@ export class AuthenticationService {
     // Initialize the signal with the current user from localStorage
     const storedUser = localStorage.getItem('currentUser');
     if (storedUser) {
-      this.currentUserSignal.set(JSON.parse(storedUser) as User);
-      this.isLogin = true;
+      try {
+        this.currentUserSignal.set(JSON.parse(storedUser) as User);
+        this.isLogin = true;
+      } catch (err) {
+        // If stored data is corrupted, remove it and keep the user logged out
+        console.error('Failed to parse stored user', err);
+        localStorage.removeItem('currentUser');
+      }
     }
   }
 
@@ -35,6 +42,16 @@ export class AuthenticationService {
   public get currentUserName(): string | null {
     const currentUser = this.currentUserValue;
     return currentUser ? currentUser.user.name : null;
+  }
+
+  public getRole(): Role | null {
+    try {
+      const currentUser = this.currentUserValue;
+      return currentUser?.user?.role ?? null;
+    } catch (err) {
+      console.error('Error retrieving user role', err);
+      return null;
+    }
   }
 
   login(email: string, password: string) {


### PR DESCRIPTION
## Summary
- add safe parsing and role accessor to `AuthenticationService`
- use new role accessor in `AuthGuardChild` and redirect when role missing

## Testing
- `npx ng test` *(fails: Project target does not exist)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb9a6a3f8832294174c680a71cfa2