### PR TITLE
feat: add verification success message and redirect

### DIFF
--- a/src/app/@theme/services/authentication.service.ts
+++ b/src/app/@theme/services/authentication.service.ts
@@ -11,6 +11,16 @@ import { Role } from '../types/role';
 // Import the 'map' operator from 'rxjs/operators'
 import { map } from 'rxjs/operators';
 
+interface VerifyCodeResponse {
+  isSuccess: boolean;
+  errors: string[];
+  data: {
+    email: string;
+    code: string;
+    passwordIsCorrect: boolean;
+  };
+}
+
 @Injectable({ providedIn: 'root' })
 export class AuthenticationService {
   private router = inject(Router);
@@ -66,6 +76,10 @@ export class AuthenticationService {
         return user;
       })
     );
+  }
+
+  verifyCode(code: string, email?: string) {
+    return this.http.post<VerifyCodeResponse>(`${environment.apiUrl}/api/Account/verify-code`, { email, code });
   }
 
   isLoggedIn() {

--- a/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.html
+++ b/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.html
@@ -20,27 +20,27 @@
           <div class="row text-center">
             <div class="col-3 g-0">
               <mat-form-field appearance="fill" class="otp-input wid-80">
-                <input matInput #input maxlength="1" placeholder="0" />
+                <input matInput maxlength="1" placeholder="0" [(ngModel)]="codeDigits[0]" />
               </mat-form-field>
             </div>
             <div class="col-3">
               <mat-form-field appearance="fill" class="otp-input wid-80">
-                <input matInput #input maxlength="1" placeholder="0" />
+                <input matInput maxlength="1" placeholder="0" [(ngModel)]="codeDigits[1]" />
               </mat-form-field>
             </div>
             <div class="col-3">
               <mat-form-field appearance="fill" class="otp-input wid-80">
-                <input matInput #input maxlength="1" placeholder="0" />
+                <input matInput maxlength="1" placeholder="0" [(ngModel)]="codeDigits[2]" />
               </mat-form-field>
             </div>
             <div class="col-3">
               <mat-form-field appearance="fill" class="otp-input wid-80">
-                <input matInput #input maxlength="1" placeholder="0" />
+                <input matInput maxlength="1" placeholder="0" [(ngModel)]="codeDigits[3]" />
               </mat-form-field>
             </div>
           </div>
           <div class="grid">
-            <button mat-flat-button color="primary" class="b-rad-20 m-t-20">Reset Password</button>
+            <button mat-flat-button color="primary" class="b-rad-20 m-t-20" (click)="verify()">Verify</button>
           </div>
           <div class="flex m-t-20">
             <p class="text-muted m-b-0">Did not receive the email?</p>

--- a/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.ts
@@ -1,9 +1,15 @@
 // angular import
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+
+// material import
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
+import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
+import { DASHBOARD_PATH } from 'src/app/app-config';
 
 @Component({
   selector: 'app-code-verification',
@@ -11,4 +17,33 @@ import { SharedModule } from 'src/app/demo/shared/shared.module';
   templateUrl: './code-verification.component.html',
   styleUrls: ['./code-verification.component.scss', '../authentication-1.scss', '../../authentication.scss']
 })
-export class CodeVerificationComponent {}
+export class CodeVerificationComponent {
+  private authService = inject(AuthenticationService);
+  private router = inject(Router);
+  private snackBar = inject(MatSnackBar);
+
+  codeDigits: string[] = ['', '', '', ''];
+
+  verify() {
+    const code = this.codeDigits.join('');
+    this.authService.verifyCode(code).subscribe({
+      next: (res) => {
+        if (res?.isSuccess && res?.data?.passwordIsCorrect) {
+          this.snackBar.open('Verification successful', 'Close', {
+            duration: 3000
+          });
+          this.router.navigate([DASHBOARD_PATH]);
+        } else {
+          this.snackBar.open('Verification failed', 'Close', {
+            duration: 3000
+          });
+        }
+      },
+      error: () => {
+        this.snackBar.open('Verification failed', 'Close', {
+          duration: 3000
+        });
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add verifyCode API call in `AuthenticationService`
- handle code verification success with snackbar and navigation to dashboard
- wire OTP inputs and submit button in code verification template

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68adbe48ecbc8322a41234b43b2e563e