### PR TITLE
Connect login with backend and add OTP verification

### DIFF
--- a/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.ts
@@ -26,24 +26,30 @@ export class CodeVerificationComponent {
 
   verify() {
     const code = this.codeDigits.join('');
-    this.authService.verifyCode(code).subscribe({
-      next: (res) => {
-        if (res?.isSuccess && res?.data?.passwordIsCorrect) {
-          this.snackBar.open('Verification successful', 'Close', {
-            duration: 3000
-          });
-          this.router.navigate([DASHBOARD_PATH]);
-        } else {
+    this.authService
+      .verifyCode(code, this.authService.pendingEmail ?? undefined)
+      .subscribe({
+        next: (res) => {
+          if (res?.isSuccess && res?.data?.passwordIsCorrect) {
+            this.snackBar.open('Verification successful', 'Close', {
+              duration: 3000
+            });
+            this.router.navigate([DASHBOARD_PATH]);
+          } else if (res?.errors?.length) {
+            this.snackBar.open(res.errors[0].message, 'Close', {
+              duration: 3000
+            });
+          } else {
+            this.snackBar.open('Verification failed', 'Close', {
+              duration: 3000
+            });
+          }
+        },
+        error: () => {
           this.snackBar.open('Verification failed', 'Close', {
             duration: 3000
           });
         }
-      },
-      error: () => {
-        this.snackBar.open('Verification failed', 'Close', {
-          duration: 3000
-        });
-      }
-    });
+      });
   }
 }


### PR DESCRIPTION
## Summary
- handle backend responses in authentication service and store pending email
- show login errors and route to OTP verification on success
- verify OTP codes against backend with user feedback

## Testing
- `npm run lint`
- `npx ng test able-pro` *(fails: Project target does not exist)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeaae48590832283b4382fa60640aa