### PR TITLE
feat: honor return URL after login

### DIFF
--- a/src/app/demo/pages/auth/authentication-1/login/login.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/login/login.component.ts
@@ -51,8 +51,8 @@ export class LoginComponent implements OnInit {
       }
     }
 
-    // get return url from route parameters or default to '/'
-    this.returnUrl = this.route.snapshot.queryParams['returnUrl'];
+    // get return url from route parameters or fall back to code verification
+    this.returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/authentication-1/code-verify';
   }
 
   // convenience getter for easy access to form fields
@@ -77,7 +77,7 @@ export class LoginComponent implements OnInit {
           this.loading = false;
           if (res?.isSuccess && res?.data?.passwordIsCorrect) {
             this.authenticationService.pendingEmail = res.data.email;
-            this.router.navigate(['/authentication-1/code-verify']);
+            this.router.navigateByUrl(this.returnUrl);
           } else if (res?.errors?.length) {
             this.error = res.errors[0].message;
           } else {


### PR DESCRIPTION
## Summary
- route to `returnUrl` after login or default to code verification

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeb0b013048322b4e0bd7587662697