### PR TITLE
feat: restrict OTP page after logout

### DIFF
--- a/src/app/@theme/helpers/pending-email.guard.ts
+++ b/src/app/@theme/helpers/pending-email.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable, inject } from '@angular/core';
+import { CanActivate, UrlTree, Router } from '@angular/router';
+import { AuthenticationService } from '../services/authentication.service';
+import { DASHBOARD_PATH } from 'src/app/app-config';
+
+@Injectable({ providedIn: 'root' })
+export class PendingEmailGuard implements CanActivate {
+  private authService = inject(AuthenticationService);
+  private router = inject(Router);
+
+  canActivate(): boolean | UrlTree {
+    if (this.authService.isLoggedIn()) {
+      return this.router.parseUrl(DASHBOARD_PATH);
+    }
+
+    if (this.authService.pendingEmail) {
+      return true;
+    }
+
+    return this.router.parseUrl('/login');
+  }
+}

--- a/src/app/@theme/services/authentication.service.ts
+++ b/src/app/@theme/services/authentication.service.ts
@@ -123,6 +123,7 @@ export class AuthenticationService {
     // Remove user from local storage to log user out
     localStorage.removeItem('currentUser');
     this.isLogin = false;
+    this.pendingEmail = null;
     // Update the signal to null
     this.currentUserSignal.set(null);
     this.router.navigate(['/login']);

--- a/src/app/demo/pages/auth/authentication-1/authentication-1-routing.module.ts
+++ b/src/app/demo/pages/auth/authentication-1/authentication-1-routing.module.ts
@@ -1,6 +1,7 @@
 // angular import
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { PendingEmailGuard } from 'src/app/@theme/helpers/pending-email.guard';
 
 // type
 import { Role } from 'src/app/@theme/types/role';
@@ -37,6 +38,7 @@ const routes: Routes = [
       {
         path: 'code-verify',
         loadComponent: () => import('./code-verification/code-verification.component').then((c) => c.CodeVerificationComponent),
+        canActivate: [PendingEmailGuard],
         data: { roles: [Role.Admin, Role.User] }
       }
     ]


### PR DESCRIPTION
## Summary
- add guard to block code verification page unless a login is pending
- clear pending email on logout
- secure code-verify route with new guard

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb9c94144832297e83e193fc2c8f2