### PR TITLE
Connect teacher add form with user creation API

### DIFF
--- a/src/app/@theme/services/user.service.ts
+++ b/src/app/@theme/services/user.service.ts
@@ -1,0 +1,25 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface CreateUserDto {
+  fullName?: string;
+  email?: string;
+  mobile?: string;
+  secondMobile?: string;
+  passwordHash?: string;
+  userTypeId?: number;
+  nationalityId?: number;
+  governorateId?: number;
+  branchId?: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  private http = inject(HttpClient);
+
+  createUser(model: CreateUserDto): Observable<unknown> {
+    return this.http.post(`${environment.apiUrl}/api/User/Create`, model);
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
@@ -5,19 +5,10 @@
         <div class="row">
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>First Name</mat-label>
-              <input matInput type="text" placeholder="Enter First Name" formControlName="firstName" />
-              @if (basicInfoForm.get('firstName')?.touched && basicInfoForm.get('firstName')?.invalid) {
-                <mat-error>First Name is required</mat-error>
-              }
-            </mat-form-field>
-          </div>
-          <div class="col-md-6">
-            <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Last Name</mat-label>
-              <input matInput type="text" placeholder="Enter Last Name" formControlName="lastName" />
-              @if (basicInfoForm.get('lastName')?.touched && basicInfoForm.get('lastName')?.invalid) {
-                <mat-error>Last name is required</mat-error>
+              <mat-label>Full Name</mat-label>
+              <input matInput type="text" placeholder="Enter Full Name" formControlName="fullName" />
+              @if (basicInfoForm.get('fullName')?.touched && basicInfoForm.get('fullName')?.invalid) {
+                <mat-error>Full name is required</mat-error>
               }
             </mat-form-field>
           </div>
@@ -32,93 +23,63 @@
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Joining Date</mat-label>
-              <input matInput type="date" placeholder="mm/dd/yyyy" formControlName="joiningDate" />
-              @if (basicInfoForm.get('joiningDate')?.touched && basicInfoForm.get('joiningDate')?.invalid) {
-                <mat-error>Date is required.</mat-error>
+              <mat-label>Mobile</mat-label>
+              <input matInput type="text" placeholder="Enter Mobile" formControlName="mobile" />
+              @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
+                <mat-error>Mobile is required</mat-error>
               }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Second Mobile</mat-label>
+              <input matInput type="text" placeholder="Enter Second Mobile" formControlName="secondMobile" />
             </mat-form-field>
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Password</mat-label>
-              <input matInput type="password" placeholder="Enter Your Password" formControlName="password" />
-              @if (basicInfoForm.get('password')?.touched && basicInfoForm.get('password')?.invalid) {
-                <mat-error>Password is required.</mat-error>
+              <input matInput type="password" placeholder="Enter Password" formControlName="passwordHash" />
+              @if (basicInfoForm.get('passwordHash')?.touched && basicInfoForm.get('passwordHash')?.invalid) {
+                <mat-error>Password is required</mat-error>
               }
             </mat-form-field>
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Confirm Password</mat-label>
-              <input matInput type="password" placeholder="Enter Your Confirm Password" formControlName="confirmPassword" />
-              @if (basicInfoForm.get('confirmPassword')?.touched && basicInfoForm.get('confirmPassword')?.invalid) {
-                <mat-error>Confirm Password is required.</mat-error>
+              <mat-label>User Type Id</mat-label>
+              <input matInput type="number" placeholder="Enter User Type Id" formControlName="userTypeId" />
+              @if (basicInfoForm.get('userTypeId')?.touched && basicInfoForm.get('userTypeId')?.invalid) {
+                <mat-error>User type id is required</mat-error>
               }
             </mat-form-field>
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Mobile Number</mat-label>
-              <input matInput type="number" placeholder="Enter Mobile Number" formControlName="mobileNumber" maxlength="10" />
-              @if (basicInfoForm.get('mobileNumber')?.touched && basicInfoForm.get('mobileNumber')?.invalid) {
-                <mat-error>Mobile Number is required.</mat-error>
+              <mat-label>Nationality Id</mat-label>
+              <input matInput type="number" placeholder="Enter Nationality Id" formControlName="nationalityId" />
+              @if (basicInfoForm.get('nationalityId')?.touched && basicInfoForm.get('nationalityId')?.invalid) {
+                <mat-error>Nationality id is required</mat-error>
               }
             </mat-form-field>
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Gender</mat-label>
-              <mat-select formControlName="gender">
-                <mat-option value="male">Male</mat-option>
-                <mat-option value="female">Female</mat-option>
-              </mat-select>
-              @if (basicInfoForm.get('gender')?.touched && basicInfoForm.get('gender')?.invalid) {
-                <mat-error>Gender is required.</mat-error>
+              <mat-label>Governorate Id</mat-label>
+              <input matInput type="number" placeholder="Enter Governorate Id" formControlName="governorateId" />
+              @if (basicInfoForm.get('governorateId')?.touched && basicInfoForm.get('governorateId')?.invalid) {
+                <mat-error>Governorate id is required</mat-error>
               }
             </mat-form-field>
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Designation</mat-label>
-              <input matInput type="text" placeholder="Enter Designation" formControlName="designation" />
-              @if (basicInfoForm.get('designation')?.touched && basicInfoForm.get('designation')?.invalid) {
-                <mat-error>Designation is required.</mat-error>
+              <mat-label>Branch Id</mat-label>
+              <input matInput type="number" placeholder="Enter Branch Id" formControlName="branchId" />
+              @if (basicInfoForm.get('branchId')?.touched && basicInfoForm.get('branchId')?.invalid) {
+                <mat-error>Branch id is required</mat-error>
               }
             </mat-form-field>
-          </div>
-          <div class="col-md-6">
-            <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Department</mat-label>
-              <mat-select formControlName="department">
-                <mat-option value="department-1">Department 1</mat-option>
-                <mat-option value="department-2">Department 2</mat-option>
-              </mat-select>
-              @if (basicInfoForm.get('department')?.touched && basicInfoForm.get('department')?.invalid) {
-                <mat-error>Department is required.</mat-error>
-              }
-            </mat-form-field>
-          </div>
-          <div class="col-md-6">
-            <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Date of Birth</mat-label>
-              <input matInput type="date" placeholder="mm/dd/yyyy" formControlName="dateOfBirth" />
-              @if (basicInfoForm.get('dateOfBirth')?.touched && basicInfoForm.get('dateOfBirth')?.invalid) {
-                <mat-error>DOB is required.</mat-error>
-              }
-            </mat-form-field>
-          </div>
-          <div class="col-md-6">
-            <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Education</mat-label>
-              <input matInput type="text" placeholder="Enter Education" formControlName="education" />
-              @if (basicInfoForm.get('education')?.touched && basicInfoForm.get('education')?.invalid) {
-                <mat-error>Education is required.</mat-error>
-              }
-            </mat-form-field>
-          </div>
-          <div class="col-md-12">
-            <input type="file" class="file-upload" (change)="basicInfoForm.get('file')?.setValue($event.target.files[0])" />
           </div>
           <div class="col-md-12 text-end">
             <button mat-flat-button color="primary" [disabled]="!basicInfoForm.valid">Submit</button>

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
+import { UserService, CreateUserDto } from 'src/app/@theme/services/user.service';
 
 @Component({
   selector: 'app-teacher-add',
@@ -13,41 +14,31 @@ import { SharedModule } from 'src/app/demo/shared/shared.module';
 })
 export class TeacherAddComponent implements OnInit {
   private fb = inject(FormBuilder);
+  private userService = inject(UserService);
 
   basicInfoForm!: FormGroup;
 
   ngOnInit(): void {
-    this.basicInfoForm = this.fb.group(
-      {
-        firstName: ['', Validators.required],
-        lastName: ['', Validators.required],
-        email: ['', [Validators.required, Validators.email]],
-        joiningDate: ['', Validators.required],
-        password: ['', [Validators.required, Validators.minLength(6)]],
-        confirmPassword: ['', Validators.required],
-        mobileNumber: ['', [Validators.required, Validators.pattern('^[0-9]{10}$'), Validators.minLength(10), Validators.maxLength(10)]],
-        gender: ['', Validators.required],
-        designation: ['', Validators.required],
-        department: ['', Validators.required],
-        dateOfBirth: ['', Validators.required],
-        education: ['', Validators.required],
-        file: [null, Validators.required]
-      },
-      {
-        validators: this.matchPasswords // custom validator for password match
-      }
-    );
-  }
-
-  matchPasswords(group: FormGroup) {
-    const pass = group.get('password')?.value;
-    const confirmPass = group.get('confirmPassword')?.value;
-    return pass === confirmPass ? null : { passwordMismatch: true };
+    this.basicInfoForm = this.fb.group({
+      fullName: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
+      mobile: ['', Validators.required],
+      secondMobile: [''],
+      passwordHash: ['', [Validators.required, Validators.minLength(6)]],
+      userTypeId: [null, Validators.required],
+      nationalityId: [null, Validators.required],
+      governorateId: [null, Validators.required],
+      branchId: [null, Validators.required]
+    });
   }
 
   onSubmit() {
     if (this.basicInfoForm.valid) {
-      console.log(this.basicInfoForm.value);
+      const model: CreateUserDto = this.basicInfoForm.value;
+      this.userService.createUser(model).subscribe({
+        next: (res) => console.log('User created', res),
+        error: (err) => console.error('Error creating user', err)
+      });
     } else {
       this.basicInfoForm.markAllAsTouched();
     }


### PR DESCRIPTION
## Summary
- Simplify teacher add page to capture backend CreateUserDto fields
- Add user service to call `/api/User/Create`
- Wire form submission to backend and remove unused fields

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68aed039a1c88322a6f30f7b4eddfd84