### PR TITLE
Add toast notifications for success and errors

### DIFF
--- a/src/app/@theme/services/toast.service.ts
+++ b/src/app/@theme/services/toast.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, inject } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private snackBar = inject(MatSnackBar);
+
+  success(message: string, action: string = 'Close', duration: number = 3000) {
+    this.snackBar.open(message, action, {
+      duration,
+      panelClass: ['toast-success']
+    });
+  }
+
+  error(message: string, action: string = 'Close', duration: number = 3000) {
+    this.snackBar.open(message, action, {
+      duration,
+      panelClass: ['toast-error']
+    });
+  }
+}

--- a/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.ts
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 
 // material import
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { ToastService } from 'src/app/@theme/services/toast.service';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -20,7 +20,7 @@ import { DASHBOARD_PATH } from 'src/app/app-config';
 export class CodeVerificationComponent {
   private authService = inject(AuthenticationService);
   private router = inject(Router);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   codeDigits: string[] = ['', '', '', ''];
 
@@ -31,24 +31,16 @@ export class CodeVerificationComponent {
         .subscribe({
           next: (res) => {
             if (res?.isSuccess) {
-              this.snackBar.open('Verification successful', 'Close', {
-                duration: 3000
-              });
+              this.toast.success('Verification successful');
               this.router.navigate([DASHBOARD_PATH]);
             } else if (res?.errors?.length) {
-              this.snackBar.open(res.errors[0].message, 'Close', {
-                duration: 3000
-              });
+              this.toast.error(res.errors[0].message);
             } else {
-              this.snackBar.open('Verification failed', 'Close', {
-                duration: 3000
-              });
+              this.toast.error('Verification failed');
             }
           },
         error: () => {
-          this.snackBar.open('Verification failed', 'Close', {
-            duration: 3000
-          });
+          this.toast.error('Verification failed');
         }
       });
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -143,3 +143,14 @@
 
 // grid
 @import './app/@theme/styles/grid';
+
+// toast styles
+.toast-success {
+  background-color: #4caf50;
+  color: #fff;
+}
+
+.toast-error {
+  background-color: #f44336;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- provide reusable ToastService wrapping MatSnackBar for success and error toasts
- apply ToastService in code verification flow and add basic toast styles

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68aed536de9083229bdee215182b0d7a