### PR TITLE
Display backend validation via toasts in teacher add form

### DIFF
--- a/src/app/@theme/services/user.service.ts
+++ b/src/app/@theme/services/user.service.ts
@@ -15,11 +15,26 @@ export interface CreateUserDto {
   branchId?: number;
 }
 
+// Generic API response interfaces
+export interface ApiError {
+  fieldName: string;
+  code: string;
+  message: string;
+  fieldLang: string | null;
+}
+
+export interface ApiResponse<T> {
+  isSuccess: boolean;
+  errors: ApiError[];
+  data: T;
+  message?: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class UserService {
   private http = inject(HttpClient);
 
-  createUser(model: CreateUserDto): Observable<unknown> {
-    return this.http.post(`${environment.apiUrl}/api/User/Create`, model);
+  createUser(model: CreateUserDto): Observable<ApiResponse<boolean>> {
+    return this.http.post<ApiResponse<boolean>>(`${environment.apiUrl}/api/User/Create`, model);
   }
 }

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
@@ -38,9 +38,15 @@ export class TeacherAddComponent implements OnInit {
     if (this.basicInfoForm.valid) {
       const model: CreateUserDto = this.basicInfoForm.value;
       this.userService.createUser(model).subscribe({
-        next: () => {
-          this.toast.success('User created successfully');
-          this.basicInfoForm.reset();
+        next: (res) => {
+          if (res?.isSuccess) {
+            this.toast.success(res.message || 'User created successfully');
+            this.basicInfoForm.reset();
+          } else if (res?.errors?.length) {
+            res.errors.forEach((e) => this.toast.error(e.message));
+          } else {
+            this.toast.error('Error creating user');
+          }
         },
         error: () => this.toast.error('Error creating user')
       });


### PR DESCRIPTION
## Summary
- add generic API response types for user service
- show backend success or validation messages with toast notifications when creating a teacher

## Testing
- `npx ng test able-pro` *(fails: Project target does not exist)*
- `npx ng lint able-pro`


------
https://chatgpt.com/codex/tasks/task_e_68aeda15685c83229c4bb261e57d1cf5