### PR TITLE
Connect register page to user creation API

### DIFF
--- a/src/app/demo/pages/auth/authentication-1/register/register.component.html
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.html
@@ -36,41 +36,47 @@
             <span>OR</span>
           </div>
           <div class="text-center m-b-25 f-20 f-w-500">Sign up with your work email.</div>
-          <div class="row text-start">
-            <div class="col-md-6">
-              <mat-label>First Name</mat-label>
+          <form class="row text-start" [formGroup]="registerForm" (ngSubmit)="onSubmit()">
+            <div class="col-12">
+              <label class="f-w-500">Full Name</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <input type="text" matInput placeholder="First Name" />
-              </mat-form-field>
-            </div>
-            <div class="col-md-6">
-              <label for="name" class="f-w-500">Last Name</label>
-              <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <input type="text" matInput placeholder="Last Name" />
+                <input type="text" matInput formControlName="fullName" placeholder="Full Name" />
               </mat-form-field>
             </div>
             <div class="col-12">
-              <label for="name" class="f-w-500">Enter Your Email</label>
+              <label class="f-w-500">Enter Your Email</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <input matInput [formControl]="email" required placeholder="Email Address" />
-                @if (email.invalid) {
+                <input matInput formControlName="email" required placeholder="Email Address" />
+                @if (form['email'].invalid && (form['email'].dirty || form['email'].touched)) {
                   <mat-error>{{ getErrorMessage() }}</mat-error>
                 }
               </mat-form-field>
             </div>
             <div class="col-12">
-              <label for="name" class="f-w-500">Enter your password</label>
+              <label class="f-w-500">Mobile</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <input matInput [type]="hide ? 'password' : 'text'" placeholder="Enter Password" />
+                <input matInput formControlName="mobile" placeholder="Mobile" />
+              </mat-form-field>
+            </div>
+            <div class="col-12">
+              <label class="f-w-500">Second Mobile</label>
+              <mat-form-field appearance="outline" class="w-100 m-t-5">
+                <input matInput formControlName="secondMobile" placeholder="Second Mobile" />
+              </mat-form-field>
+            </div>
+            <div class="col-12">
+              <label class="f-w-500">Enter your password</label>
+              <mat-form-field appearance="outline" class="w-100 m-t-5">
+                <input matInput [type]="hide ? 'password' : 'text'" formControlName="passwordHash" placeholder="Enter Password" />
                 <button mat-icon-button matSuffix (click)="hide = !hide" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="hide">
                   <mat-icon>{{ hide ? 'visibility_off' : 'visibility' }}</mat-icon>
                 </button>
               </mat-form-field>
             </div>
             <div class="col-12">
-              <label for="name" class="f-w-500">Enter your Confirm Password</label>
+              <label class="f-w-500">Enter your Confirm Password</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <input matInput [type]="coHide ? 'password' : 'text'" placeholder="Enter Confirm Password" />
+                <input matInput [type]="coHide ? 'password' : 'text'" formControlName="confirmPassword" placeholder="Enter Confirm Password" />
                 <button
                   mat-icon-button
                   matSuffix
@@ -82,13 +88,39 @@
                 </button>
               </mat-form-field>
             </div>
-          </div>
-          <div class="check-me">
-            <mat-checkbox class="float-start" checked color="primary">I agree to all the Terms & Condition</mat-checkbox>
-          </div>
-          <div class="grid">
-            <button mat-flat-button color="primary" class="b-rad-20 m-t-15">Register</button>
-          </div>
+            <div class="col-12">
+              <label class="f-w-500">User Type</label>
+              <mat-form-field appearance="outline" class="w-100 m-t-5">
+                <mat-select formControlName="userTypeId" placeholder="Select user type">
+                  <mat-option *ngFor="let t of userTypes" [value]="t.id">{{ t.label }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-12">
+              <label class="f-w-500">Nationality Id</label>
+              <mat-form-field appearance="outline" class="w-100 m-t-5">
+                <input matInput formControlName="nationalityId" type="number" placeholder="Nationality Id" />
+              </mat-form-field>
+            </div>
+            <div class="col-12">
+              <label class="f-w-500">Governorate Id</label>
+              <mat-form-field appearance="outline" class="w-100 m-t-5">
+                <input matInput formControlName="governorateId" type="number" placeholder="Governorate Id" />
+              </mat-form-field>
+            </div>
+            <div class="col-12">
+              <label class="f-w-500">Branch Id</label>
+              <mat-form-field appearance="outline" class="w-100 m-t-5">
+                <input matInput formControlName="branchId" type="number" placeholder="Branch Id" />
+              </mat-form-field>
+            </div>
+            <div class="check-me">
+              <mat-checkbox class="float-start" color="primary">I agree to all the Terms & Condition</mat-checkbox>
+            </div>
+            <div class="grid">
+              <button mat-flat-button color="primary" class="b-rad-20 m-t-15" type="submit">Register</button>
+            </div>
+          </form>
           <div class="check-me m-t-15">
             <div class="text-muted">Don't have an Account?</div>
             <a class="text-primary-500" [routerLink]="[this.authenticationService.isLoggedIn() ? '/authentication-1/login' : '/login']">

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.ts
@@ -1,12 +1,15 @@
 // angular import
-import { Component, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormControl, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
+import { UserService, CreateUserDto } from 'src/app/@theme/services/user.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 
 @Component({
   selector: 'app-register',
@@ -14,20 +17,89 @@ import { AuthenticationService } from 'src/app/@theme/services/authentication.se
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss', '../authentication-1.scss', '../../authentication.scss']
 })
-export class RegisterComponent {
+export class RegisterComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private userService = inject(UserService);
+  private toast = inject(ToastService);
+  authenticationService = inject(AuthenticationService);
+
   // public props
   hide = true;
   coHide = true;
-  email = new FormControl('', [Validators.required, Validators.email]);
+  registerForm!: FormGroup;
 
-  authenticationService = inject(AuthenticationService);
+  userTypes = [
+    { id: UserTypesEnum.Admin, label: 'Admin' },
+    { id: UserTypesEnum.Manager, label: 'Manager' },
+    { id: UserTypesEnum.BranchLeader, label: 'Branch Leader' },
+    { id: UserTypesEnum.Teacher, label: 'Teacher' },
+    { id: UserTypesEnum.Student, label: 'Student' }
+  ];
+
+  ngOnInit(): void {
+    this.registerForm = this.fb.group({
+      fullName: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
+      mobile: ['', Validators.required],
+      secondMobile: [''],
+      passwordHash: ['', [Validators.required, Validators.minLength(6)]],
+      confirmPassword: ['', Validators.required],
+      userTypeId: [null, Validators.required],
+      nationalityId: [null, Validators.required],
+      governorateId: [null, Validators.required],
+      branchId: [null, Validators.required]
+    });
+  }
+
+  get form() {
+    return this.registerForm.controls;
+  }
 
   // public method
   getErrorMessage() {
-    if (this.email.hasError('required')) {
+    if (this.form['email'].hasError('required')) {
       return 'You must enter an email';
     }
 
-    return this.email.hasError('email') ? 'Not a valid email' : '';
+    return this.form['email'].hasError('email') ? 'Not a valid email' : '';
+  }
+
+  onSubmit() {
+    if (this.registerForm.invalid) {
+      this.registerForm.markAllAsTouched();
+      return;
+    }
+
+    if (this.form['passwordHash'].value !== this.form['confirmPassword'].value) {
+      this.toast.error('Passwords do not match');
+      return;
+    }
+
+    const formValue = this.registerForm.value;
+    const model: CreateUserDto = {
+      fullName: formValue.fullName,
+      email: formValue.email,
+      mobile: formValue.mobile,
+      secondMobile: formValue.secondMobile,
+      passwordHash: formValue.passwordHash,
+      userTypeId: Number(formValue.userTypeId),
+      nationalityId: formValue.nationalityId,
+      governorateId: formValue.governorateId,
+      branchId: formValue.branchId
+    };
+
+    this.userService.createUser(model).subscribe({
+      next: (res) => {
+        if (res.isSuccess) {
+          this.toast.success(res.message || 'User created successfully');
+          this.registerForm.reset();
+        } else if (res.errors?.length) {
+          res.errors.forEach((e) => this.toast.error(e.message));
+        } else {
+          this.toast.error('Error creating user');
+        }
+      },
+      error: () => this.toast.error('Error creating user')
+    });
   }
 }


### PR DESCRIPTION
## Summary
- wire up register form to create user endpoint
- add user type dropdown from enum and collect all required fields

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3fd26ee848322952a9d418feacf62