### PR TITLE
Connect teacher list to backend service

### DIFF
--- a/src/app/@theme/services/lookup.service.ts
+++ b/src/app/@theme/services/lookup.service.ts
@@ -1,0 +1,43 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface LookUpUserDto {
+  id: number;
+  fullName: string;
+  email: string;
+  mobile: string;
+  secondMobile: string;
+  nationality: string;
+  nationalityId: number;
+  governorate: string;
+  governorateId: number;
+  branchId: number;
+}
+
+export interface ApiError {
+  fieldName: string;
+  code: string;
+  message: string;
+  fieldLang: string | null;
+}
+
+export interface ApiResponse<T> {
+  isSuccess: boolean;
+  errors: ApiError[];
+  data: T;
+}
+
+@Injectable({ providedIn: 'root' })
+export class LookupService {
+  private http = inject(HttpClient);
+
+  getUsersByUserType(userTypeId: number): Observable<ApiResponse<LookUpUserDto[]>> {
+    return this.http.get<ApiResponse<LookUpUserDto[]>>(
+      `${environment.apiUrl}/api/LookUp/GetUsersByUserType`,
+      { params: { UserTypeId: userTypeId } }
+    );
+  }
+}
+

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.html
@@ -23,43 +23,28 @@
           </div>
           <div class="table-responsive">
             <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
-              <!-- Name Column -->
-              <ng-container matColumnDef="name">
+              <!-- Full Name Column -->
+              <ng-container matColumnDef="fullName">
                 <th mat-header-cell *matHeaderCellDef class="p-l-25">NAME</th>
-                <td mat-cell *matCellDef="let element" class="p-l-25 text-nowrap">
-                  <div class="flex align-item-center">
-                    <div class="flex-shrink-0">
-                      <img src="{{ element.img }}" alt="user-image" class="wid-40 border-50" />
-                    </div>
-                    <div class="flex-grow-1 m-l-15">
-                      <div class="f-w-600">{{ element.name }}</div>
-                    </div>
-                  </div>
-                </td>
+                <td mat-cell *matCellDef="let element" class="p-l-25 text-nowrap">{{ element.fullName }}</td>
               </ng-container>
 
-              <!-- Contact Column -->
-              <ng-container matColumnDef="department">
-                <th mat-header-cell *matHeaderCellDef>DEPARTMENTS</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.department }}</td>
+              <!-- Email Column -->
+              <ng-container matColumnDef="email">
+                <th mat-header-cell *matHeaderCellDef>EMAIL</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.email }}</td>
               </ng-container>
 
-              <!-- order Column -->
-              <ng-container matColumnDef="qualification">
-                <th mat-header-cell *matHeaderCellDef>QUALIFICATION</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.qualification }}</td>
-              </ng-container>
-
-              <!-- spent Column -->
+              <!-- Mobile Column -->
               <ng-container matColumnDef="mobile">
-                <th mat-header-cell *matHeaderCellDef>mobile</th>
+                <th mat-header-cell *matHeaderCellDef>MOBILE</th>
                 <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.mobile }}</td>
               </ng-container>
 
-              <!-- STATUS Column -->
-              <ng-container matColumnDef="date">
-                <th mat-header-cell *matHeaderCellDef>JOINING DATE</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.date }}</td>
+              <!-- Nationality Column -->
+              <ng-container matColumnDef="nationality">
+                <th mat-header-cell *matHeaderCellDef>NATIONALITY</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.nationality }}</td>
               </ng-container>
 
               <!-- action Column -->
@@ -93,7 +78,7 @@
 
               <!-- Row shown when there is no matching data. -->
               <tr class="mat-row" *matNoDataRow>
-                <td class="mat-cell" colspan="4">No data matching the filter "{{ input.value }}"</td>
+                <td class="mat-cell" colspan="5">No data matching the filter "{{ input.value }}"</td>
               </tr>
             </table>
             <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" aria-label="Select page of users"></mat-paginator>

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
@@ -1,5 +1,5 @@
 // angular import
-import { AfterViewInit, Component, viewChild } from '@angular/core';
+import { AfterViewInit, Component, OnInit, inject, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
@@ -10,18 +10,8 @@ import { MatSort } from '@angular/material/sort';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
-import { teacherList } from 'src/app/fake-data/teacher_list';
-
-export interface teacherList {
-  name: string;
-  img: string;
-  department: string;
-  qualification: string;
-  mobile: string;
-  date: string;
-}
-
-const ELEMENT_DATA: teacherList[] = teacherList;
+import { LookupService, LookUpUserDto } from 'src/app/@theme/services/lookup.service';
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 
 @Component({
   selector: 'app-teacher-list',
@@ -29,10 +19,12 @@ const ELEMENT_DATA: teacherList[] = teacherList;
   templateUrl: './teacher-list.component.html',
   styleUrl: './teacher-list.component.scss'
 })
-export class TeacherListComponent implements AfterViewInit {
+export class TeacherListComponent implements OnInit, AfterViewInit {
+  private lookupService = inject(LookupService);
+
   // public props
-  displayedColumns: string[] = ['name', 'department', 'qualification', 'mobile', 'date', 'action'];
-  dataSource = new MatTableDataSource(ELEMENT_DATA);
+  displayedColumns: string[] = ['fullName', 'email', 'mobile', 'nationality', 'action'];
+  dataSource = new MatTableDataSource<LookUpUserDto>();
 
   // paginator
   readonly paginator = viewChild(MatPaginator);
@@ -46,6 +38,16 @@ export class TeacherListComponent implements AfterViewInit {
     if (this.dataSource.paginator) {
       this.dataSource.paginator.firstPage();
     }
+  }
+
+  ngOnInit() {
+    this.lookupService.getUsersByUserType(Number(UserTypesEnum.Teacher)).subscribe((res) => {
+      if (res.isSuccess && res.data) {
+        this.dataSource.data = res.data;
+      } else {
+        this.dataSource.data = [];
+      }
+    });
   }
 
   // life cycle event


### PR DESCRIPTION
## Summary
- Fetch teacher records from API using new LookupService
- Display teacher data on list page with updated columns

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint` *(fails: existing lint errors in repo)*
- `npx eslint src/app/@theme/services/lookup.service.ts src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts && echo 'eslint passed'`


------
https://chatgpt.com/codex/tasks/task_e_68b5a21c57dc832285fb053cce4012f6