### PR TITLE
Use API for teacher list with filter DTO

### DIFF
--- a/src/app/@theme/services/lookup.service.ts
+++ b/src/app/@theme/services/lookup.service.ts
@@ -29,15 +29,36 @@ export interface ApiResponse<T> {
   data: T;
 }
 
+export interface FilteredResultRequestDto {
+  skipCount?: number;
+  searchTerm?: string;
+  filter?: string;
+  lang?: string;
+  sortingDirection?: string;
+  sortBy?: string;
+  maxResultCount?: number;
+}
+
+export interface PagedResultDto<T> {
+  totalCount: number;
+  items: T[];
+}
+
 @Injectable({ providedIn: 'root' })
 export class LookupService {
   private http = inject(HttpClient);
-
-  getUsersByUserType(userTypeId: number): Observable<ApiResponse<LookUpUserDto[]>> {
-    return this.http.get<ApiResponse<LookUpUserDto[]>>(
-      `${environment.apiUrl}/api/LookUp/GetUsersByUserType`,
-      { params: { UserTypeId: userTypeId } }
-    );
+  getUsersByUserType(filter: FilteredResultRequestDto, userTypeId: number): Observable<ApiResponse<PagedResultDto<LookUpUserDto>>> {
+    return this.http.get<ApiResponse<PagedResultDto<LookUpUserDto>>>(`${environment.apiUrl}/api/LookUp/GetUsersByUserType`, {
+      params: {
+        UserTypeId: userTypeId,
+        SkipCount: filter.skipCount,
+        MaxResultCount: filter.maxResultCount,
+        SearchTerm: filter.searchTerm,
+        Filter: filter.filter,
+        Lang: filter.lang,
+        SortingDirection: filter.sortingDirection,
+        SortBy: filter.sortBy
+      }
+    });
   }
 }
-

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
@@ -41,9 +41,10 @@ export class TeacherListComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
-    this.lookupService.getUsersByUserType(Number(UserTypesEnum.Teacher)).subscribe((res) => {
-      if (res.isSuccess && res.data) {
-        this.dataSource.data = res.data;
+    const filter = { skipCount: 0, maxResultCount: 25 };
+    this.lookupService.getUsersByUserType(filter, Number(UserTypesEnum.Teacher)).subscribe((res) => {
+      if (res.isSuccess && res.data?.items) {
+        this.dataSource.data = res.data.items;
       } else {
         this.dataSource.data = [];
       }


### PR DESCRIPTION
## Summary
- add FilteredResultRequestDto and PagedResultDto types for lookup service
- connect teacher list to `GetUsersByUserType` with server-side filtering

## Testing
- `npm test`
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a931c7e8832296e2ad3148b6c822