### PR TITLE
feat: add manager pages and navigation

### DIFF
--- a/src/app/demo/data/menu.ts
+++ b/src/app/demo/data/menu.ts
@@ -108,6 +108,33 @@ export const menus: Navigation[] = [
     role: [UserTypesEnum.Admin.toString(), UserTypesEnum.Manager.toString(), UserTypesEnum.BranchLeader.toString(), UserTypesEnum.Student.toString(), UserTypesEnum.Teacher.toString()],
           },
           {
+            id: 'manager',
+            title: 'Manager',
+            type: 'collapse',
+            role: [UserTypesEnum.Admin.toString(), UserTypesEnum.Manager.toString(), UserTypesEnum.BranchLeader.toString(), UserTypesEnum.Student.toString(), UserTypesEnum.Teacher.toString()],
+            children: [
+              {
+                id: 'list',
+                title: 'List',
+                type: 'item',
+                url: '/online-course/manager/list'
+              },
+              {
+                id: 'apply',
+                title: 'Apply',
+                type: 'item',
+                url: '/online-course/manager/apply'
+              },
+              {
+                id: 'add',
+                title: 'Add',
+                type: 'item',
+                url: '/online-course/manager/add',
+    role: [UserTypesEnum.Admin.toString(), UserTypesEnum.Manager.toString(), UserTypesEnum.BranchLeader.toString(), UserTypesEnum.Student.toString(), UserTypesEnum.Teacher.toString()],
+              }
+            ]
+          },
+          {
             id: 'teacher',
             title: 'Teacher',
             type: 'collapse',

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
@@ -1,0 +1,91 @@
+<div class="row">
+  <div class="col-12">
+    <app-card cardTitle="Basic Information">
+      <form [formGroup]="basicInfoForm" (ngSubmit)="onSubmit()">
+        <div class="row">
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Full Name</mat-label>
+              <input matInput type="text" placeholder="Enter Full Name" formControlName="fullName" />
+              @if (basicInfoForm.get('fullName')?.touched && basicInfoForm.get('fullName')?.invalid) {
+                <mat-error>Full name is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Email</mat-label>
+              <input matInput type="email" placeholder="Enter Email" formControlName="email" />
+              @if (basicInfoForm.get('email')?.touched && basicInfoForm.get('email')?.invalid) {
+                <mat-error>Email is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Mobile</mat-label>
+              <input matInput type="text" placeholder="Enter Mobile" formControlName="mobile" />
+              @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
+                <mat-error>Mobile is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Second Mobile</mat-label>
+              <input matInput type="text" placeholder="Enter Second Mobile" formControlName="secondMobile" />
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Password</mat-label>
+              <input matInput type="password" placeholder="Enter Password" formControlName="passwordHash" />
+              @if (basicInfoForm.get('passwordHash')?.touched && basicInfoForm.get('passwordHash')?.invalid) {
+                <mat-error>Password is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>User Type Id</mat-label>
+              <input matInput type="number" placeholder="Enter User Type Id" formControlName="userTypeId" />
+              @if (basicInfoForm.get('userTypeId')?.touched && basicInfoForm.get('userTypeId')?.invalid) {
+                <mat-error>User type id is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Nationality Id</mat-label>
+              <input matInput type="number" placeholder="Enter Nationality Id" formControlName="nationalityId" />
+              @if (basicInfoForm.get('nationalityId')?.touched && basicInfoForm.get('nationalityId')?.invalid) {
+                <mat-error>Nationality id is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Governorate Id</mat-label>
+              <input matInput type="number" placeholder="Enter Governorate Id" formControlName="governorateId" />
+              @if (basicInfoForm.get('governorateId')?.touched && basicInfoForm.get('governorateId')?.invalid) {
+                <mat-error>Governorate id is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Branch Id</mat-label>
+              <input matInput type="number" placeholder="Enter Branch Id" formControlName="branchId" />
+              @if (basicInfoForm.get('branchId')?.touched && basicInfoForm.get('branchId')?.invalid) {
+                <mat-error>Branch id is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-12 text-end">
+            <button mat-flat-button color="primary" [disabled]="!basicInfoForm.valid">Submit</button>
+          </div>
+        </div>
+      </form>
+    </app-card>
+  </div>
+</div>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.scss
@@ -1,0 +1,28 @@
+.file-upload {
+  display: block;
+  border: 1px solid var(--accent-300);
+  width: 100%;
+  margin-bottom: 24px;
+  border-radius: 4px;
+  overflow: hidden;
+
+  &:not(:disabled):not([readonly]) {
+    cursor: pointer;
+  }
+  &::file-selector-button {
+    padding: 0.8rem 0.75rem;
+    margin-right: 8px;
+    color: var(--accent-800);
+    pointer-events: none;
+    border-color: var(--accent-300);
+    border-style: solid;
+    border-width: 0px;
+    border-inline-end-width: 1px;
+    border-radius: 0;
+    background: var(--accent-100);
+  }
+
+  &:hover:not(:disabled):not([readonly])::file-selector-button {
+    background: var(--accent-200);
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
@@ -1,0 +1,57 @@
+// angular import
+import { Component, inject, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+// project import
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import { UserService, CreateUserDto } from 'src/app/@theme/services/user.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+
+@Component({
+  selector: 'app-manager-add',
+  imports: [SharedModule],
+  templateUrl: './manager-add.component.html',
+  styleUrl: './manager-add.component.scss'
+})
+export class ManagerAddComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private userService = inject(UserService);
+  private toast = inject(ToastService);
+
+  basicInfoForm!: FormGroup;
+
+  ngOnInit(): void {
+    this.basicInfoForm = this.fb.group({
+      fullName: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
+      mobile: ['', Validators.required],
+      secondMobile: [''],
+      passwordHash: ['', [Validators.required, Validators.minLength(6)]],
+      userTypeId: [null, Validators.required],
+      nationalityId: [null, Validators.required],
+      governorateId: [null, Validators.required],
+      branchId: [null, Validators.required]
+    });
+  }
+
+  onSubmit() {
+    if (this.basicInfoForm.valid) {
+      const model: CreateUserDto = this.basicInfoForm.value;
+      this.userService.createUser(model).subscribe({
+        next: (res) => {
+          if (res?.isSuccess) {
+            this.toast.success(res.message || 'User created successfully');
+            this.basicInfoForm.reset();
+          } else if (res?.errors?.length) {
+            res.errors.forEach((e) => this.toast.error(e.message));
+          } else {
+            this.toast.error('Error creating user');
+          }
+        },
+        error: () => this.toast.error('Error creating user')
+      });
+    } else {
+      this.basicInfoForm.markAllAsTouched();
+    }
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-apply/manager-apply.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-apply/manager-apply.component.html
@@ -1,0 +1,95 @@
+<div class="row p-t-25">
+  <div class="col-12">
+    <app-card cardTitle="Apply Manager List" padding="0">
+      <div class="p-b-15">
+        <div class="table-containe table-reponsive">
+          <div class="table-search p-t-15 p-x-15">
+            <mat-form-field appearance="outline" class="w-100">
+              <input matInput (keyup)="applyFilter($event)" placeholder="Search...." #input />
+            </mat-form-field>
+          </div>
+          <div class="table-responsive">
+            <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+              <!-- Name Column -->
+              <ng-container matColumnDef="name">
+                <th mat-header-cell *matHeaderCellDef class="p-l-25">NAME</th>
+                <td mat-cell *matCellDef="let element" class="p-l-25 text-nowrap">
+                  <div class="flex align-item-center">
+                    <div class="flex-shrink-0">
+                      <img src="{{ element.img }}" alt="user-image" class="wid-40 border-50" />
+                    </div>
+                    <div class="flex-grow-1 m-l-15">
+                      <div class="f-w-600">{{ element.name }}</div>
+                    </div>
+                  </div>
+                </td>
+              </ng-container>
+
+              <!-- Contact Column -->
+              <ng-container matColumnDef="department">
+                <th mat-header-cell *matHeaderCellDef>DEPARTMENTS</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.department }}</td>
+              </ng-container>
+
+              <!-- order Column -->
+              <ng-container matColumnDef="qualification">
+                <th mat-header-cell *matHeaderCellDef>QUALIFICATION</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.qualification }}</td>
+              </ng-container>
+
+              <!-- spent Column -->
+              <ng-container matColumnDef="mobile">
+                <th mat-header-cell *matHeaderCellDef>mobile</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.mobile }}</td>
+              </ng-container>
+
+              <!-- STATUS Column -->
+              <ng-container matColumnDef="date">
+                <th mat-header-cell *matHeaderCellDef>JOINING DATE</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  {{ element.date }}
+                  <span class="text-muted mat-small block">{{ element.time }}</span>
+                </td>
+              </ng-container>
+
+              <!-- action Column -->
+              <ng-container matColumnDef="action">
+                <th mat-header-cell *matHeaderCellDef class="text-center">ACTIONS</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  <div class="text-center text-nowrap">
+                    <ul class="list-inline p-l-0">
+                      <li class="list-inline-item m-r-10" matTooltip="View">
+                        <a href="javascript:" class="avatar avatar-xs bg-success-50 text-success-500">
+                          <i class="ti ti-check f-20"></i>
+                        </a>
+                      </li>
+                      <li class="list-inline-item m-r-10" matTooltip="Edit">
+                        <a href="javascript:" class="avatar avatar-xs bg-warn-50 text-warn-500">
+                          <i class="ti ti-x f-20"></i>
+                        </a>
+                      </li>
+                      <li class="list-inline-item m-r-10" matTooltip="Delete">
+                        <a href="javascript:" class="avatar avatar-xs text-accent-500 bg-accent-100">
+                          <i class="ti ti-dots-vertical f-20"></i>
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+              <!-- Row shown when there is no matching data. -->
+              <tr class="mat-row" *matNoDataRow>
+                <td class="mat-cell" colspan="4">No data matching the filter "{{ input.value }}"</td>
+              </tr>
+            </table>
+            <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" aria-label="Select page of users"></mat-paginator>
+          </div>
+        </div>
+      </div>
+    </app-card>
+  </div>
+</div>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-apply/manager-apply.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-apply/manager-apply.component.scss
@@ -1,0 +1,1 @@
+// This file is intentionally left empty to allow customers to add custom CSS if needed.

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-apply/manager-apply.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-apply/manager-apply.component.ts
@@ -1,0 +1,56 @@
+// angular import
+import { AfterViewInit, Component, viewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+// angular material
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+
+// project import
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import { managerApply } from 'src/app/fake-data/manager_apply';
+
+export interface managerApply {
+  name: string;
+  img: string;
+  department: string;
+  qualification: string;
+  mobile: string;
+  date: string;
+  time: string;
+}
+
+const ELEMENT_DATA: managerApply[] = managerApply;
+
+@Component({
+  selector: 'app-manager-apply',
+  imports: [SharedModule, CommonModule],
+  templateUrl: './manager-apply.component.html',
+  styleUrl: './manager-apply.component.scss'
+})
+export class ManagerApplyComponent implements AfterViewInit {
+  // public props
+  displayedColumns: string[] = ['name', 'department', 'qualification', 'mobile', 'date', 'action'];
+  dataSource = new MatTableDataSource(ELEMENT_DATA);
+
+  // paginator
+  readonly paginator = viewChild(MatPaginator);
+  readonly sort = viewChild(MatSort);
+
+  // table search filter
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
+  }
+
+  // life cycle event
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator()!;
+    this.dataSource.sort = this.sort()!;
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.html
@@ -1,0 +1,90 @@
+<div class="row p-t-25">
+  <div class="col-12">
+    <app-card cardTitle="Manager List" padding="0" cardClass="sm-block">
+      <ng-template #headerOptionsTemplate>
+        <div class="table-options">
+          <button mat-stroked-button color="accent" class="m-r-10" [routerLink]="['/online-course/manager/apply']">
+            Apply Manager List
+          </button>
+          <button mat-flat-button color="primary" [routerLink]="['/online-course/manager/add']">
+            <div class="flex align-item-center">
+              <i class="ti ti-plus f-18 m-r-5"></i>
+              Add Manager
+            </div>
+          </button>
+        </div>
+      </ng-template>
+      <div class="p-b-15">
+        <div class="table-containe table-reponsive">
+          <div class="table-search p-t-15 p-x-15">
+            <mat-form-field appearance="outline" class="w-100">
+              <input matInput (keyup)="applyFilter($event)" placeholder="Search...." #input />
+            </mat-form-field>
+          </div>
+          <div class="table-responsive">
+            <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+              <!-- Full Name Column -->
+              <ng-container matColumnDef="fullName">
+                <th mat-header-cell *matHeaderCellDef class="p-l-25">NAME</th>
+                <td mat-cell *matCellDef="let element" class="p-l-25 text-nowrap">{{ element.fullName }}</td>
+              </ng-container>
+
+              <!-- Email Column -->
+              <ng-container matColumnDef="email">
+                <th mat-header-cell *matHeaderCellDef>EMAIL</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.email }}</td>
+              </ng-container>
+
+              <!-- Mobile Column -->
+              <ng-container matColumnDef="mobile">
+                <th mat-header-cell *matHeaderCellDef>MOBILE</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.mobile }}</td>
+              </ng-container>
+
+              <!-- Nationality Column -->
+              <ng-container matColumnDef="nationality">
+                <th mat-header-cell *matHeaderCellDef>NATIONALITY</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.nationality }}</td>
+              </ng-container>
+
+              <!-- action Column -->
+              <ng-container matColumnDef="action">
+                <th mat-header-cell *matHeaderCellDef class="text-center">ACTIONS</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  <div class="text-center text-nowrap">
+                    <ul class="list-inline p-l-0">
+                      <li class="list-inline-item m-r-10" matTooltip="View">
+                        <a href="javascript:" class="avatar avatar-xs text-muted">
+                          <i class="ti ti-eye f-18"></i>
+                        </a>
+                      </li>
+                      <li class="list-inline-item m-r-10" matTooltip="Edit">
+                        <a href="javascript:" class="avatar avatar-xs text-muted">
+                          <i class="ti ti-edit-circle f-18"></i>
+                        </a>
+                      </li>
+                      <li class="list-inline-item m-r-10" matTooltip="Delete">
+                        <a href="javascript:" class="avatar avatar-xs text-muted">
+                          <i class="ti ti-trash f-18"></i>
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+              <!-- Row shown when there is no matching data. -->
+              <tr class="mat-row" *matNoDataRow>
+                <td class="mat-cell" colspan="5">No data matching the filter "{{ input.value }}"</td>
+              </tr>
+            </table>
+            <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" aria-label="Select page of users"></mat-paginator>
+          </div>
+        </div>
+      </div>
+    </app-card>
+  </div>
+</div>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.scss
@@ -1,0 +1,11 @@
+.table-options {
+  display: flex;
+  align-items: center;
+
+  @media (max-width: 575px) {
+    display: block;
+    .mdc-button {
+      margin-top: 10px;
+    }
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.ts
@@ -1,0 +1,59 @@
+// angular import
+import { AfterViewInit, Component, OnInit, inject, viewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+// angular material
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+
+// project import
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import { LookupService, LookUpUserDto } from 'src/app/@theme/services/lookup.service';
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+
+@Component({
+  selector: 'app-manager-list',
+  imports: [CommonModule, SharedModule, RouterModule],
+  templateUrl: './manager-list.component.html',
+  styleUrl: './manager-list.component.scss'
+})
+export class ManagerListComponent implements OnInit, AfterViewInit {
+  private lookupService = inject(LookupService);
+
+  // public props
+  displayedColumns: string[] = ['fullName', 'email', 'mobile', 'nationality', 'action'];
+  dataSource = new MatTableDataSource<LookUpUserDto>();
+
+  // paginator
+  readonly paginator = viewChild(MatPaginator);
+  readonly sort = viewChild(MatSort);
+
+  // table search filter
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
+  }
+
+  ngOnInit() {
+    const filter = { skipCount: 0, maxResultCount: 25 };
+    this.lookupService.getUsersByUserType(filter, Number(UserTypesEnum.Manager)).subscribe((res) => {
+      if (res.isSuccess && res.data?.items) {
+        this.dataSource.data = res.data.items;
+      } else {
+        this.dataSource.data = [];
+      }
+    });
+  }
+
+  // life cycle event
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator()!;
+    this.dataSource.sort = this.sort()!;
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-routing.module.ts
@@ -1,0 +1,35 @@
+// angular import
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+//type
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+
+const routes: Routes = [
+  {
+    path: '',
+    children: [
+      {
+        path: 'list',
+        loadComponent: () => import('./manager-list/manager-list.component').then((c) => c.ManagerListComponent),
+        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+      },
+      {
+        path: 'add',
+        loadComponent: () => import('./manager-add/manager-add.component').then((c) => c.ManagerAddComponent),
+        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+      },
+      {
+        path: 'apply',
+        loadComponent: () => import('./manager-apply/manager-apply.component').then((c) => c.ManagerApplyComponent),
+        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+      }
+    ]
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ManagerRoutingModule {}

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ManagerRoutingModule } from './manager-routing.module';
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule, ManagerRoutingModule]
+})
+export class ManagerModule {}

--- a/src/app/demo/pages/admin-panel/online-courses/online-courses-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/online-courses-routing.module.ts
@@ -13,11 +13,16 @@ const routes: Routes = [
         loadComponent: () => import('./online-dashboard/online-dashboard.component').then((c) => c.OnlineDashboardComponent),
         data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
       },
-      {
-        path: 'teacher',
-        loadChildren: () => import('./teacher/teacher.module').then((m) => m.TeacherModule),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
-      },
+        {
+          path: 'manager',
+          loadChildren: () => import('./manager/manager.module').then((m) => m.ManagerModule),
+          data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        },
+        {
+          path: 'teacher',
+          loadChildren: () => import('./teacher/teacher.module').then((m) => m.TeacherModule),
+          data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        },
       {
         path: 'student',
         loadChildren: () => import('./student/student.module').then((m) => m.StudentModule),

--- a/src/app/fake-data/manager_apply.ts
+++ b/src/app/fake-data/manager_apply.ts
@@ -1,0 +1,146 @@
+export const managerApply = [
+  {
+    name: 'Airi Satou',
+    img: 'assets/images/user/avatar-1.png',
+    department: 'Developer',
+    qualification: 'B.COM, M.COM.',
+    mobile: '(123) 4567 890',
+    date: '2023/09/12',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Ashton Cox',
+    img: 'assets/images/user/avatar-2.png',
+    department: 'Junior Technical',
+    qualification: 'B.COM, M.COM.',
+    mobile: '(123) 4567 890',
+    date: '2023/12/24',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Bradley Greer',
+    img: 'assets/images/user/avatar-3.png',
+    department: 'Sales Assistant',
+    qualification: 'B.A, B.C.A',
+    mobile: '(123) 4567 890',
+    date: '2022/09/19',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Brielle Williamson',
+    img: 'assets/images/user/avatar-4.jpg',
+    department: 'JavaScript Developer',
+    qualification: 'B.A, B.C.A',
+    mobile: '(123) 4567 890',
+    date: '2022/08/22',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Airi Satou',
+    img: 'assets/images/user/avatar-5.jpg',
+    department: 'Developer',
+    qualification: 'B.COM, M.COM.',
+    mobile: '(123) 4567 890',
+    date: '2023/09/12',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Ashton Cox',
+    img: 'assets/images/user/avatar-6.jpg',
+    department: 'Junior Technical',
+    qualification: 'B.COM, M.COM.',
+    mobile: '(123) 4567 890',
+    date: '2023/12/24',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Bradley Greer',
+    img: 'assets/images/user/avatar-7.jpg',
+    department: 'Sales Assistant',
+    qualification: 'B.A, B.C.A',
+    mobile: '(123) 4567 890',
+    date: '2022/09/19',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Brielle Williamson',
+    img: 'assets/images/user/avatar-8.jpg',
+    department: 'JavaScript Developer',
+    qualification: 'B.A, B.C.A',
+    mobile: '(123) 4567 890',
+    date: '2022/08/22',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Airi Satou',
+    img: 'assets/images/user/avatar-9.jpg',
+    department: 'Developer',
+    qualification: 'B.COM, M.COM.',
+    mobile: '(123) 4567 890',
+    date: '2023/09/12',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Ashton Cox',
+    img: 'assets/images/user/avatar-10.jpg',
+    department: 'Junior Technical',
+    qualification: 'B.COM, M.COM.',
+    mobile: '(123) 4567 890',
+    date: '2023/12/24',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Bradley Greer',
+    img: 'assets/images/user/avatar-3.png',
+    department: 'Sales Assistant',
+    qualification: 'B.A, B.C.A',
+    mobile: '(123) 4567 890',
+    date: '2022/09/19',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Brielle Williamson',
+    img: 'assets/images/user/avatar-4.jpg',
+    department: 'JavaScript Developer',
+    qualification: 'B.A, B.C.A',
+    mobile: '(123) 4567 890',
+    date: '2022/08/22',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Ashton Cox',
+    img: 'assets/images/user/avatar-6.jpg',
+    department: 'Junior Technical',
+    qualification: 'B.COM, M.COM.',
+    mobile: '(123) 4567 890',
+    date: '2023/12/24',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Bradley Greer',
+    img: 'assets/images/user/avatar-7.jpg',
+    department: 'Sales Assistant',
+    qualification: 'B.A, B.C.A',
+    mobile: '(123) 4567 890',
+    date: '2022/09/19',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Brielle Williamson',
+    img: 'assets/images/user/avatar-8.jpg',
+    department: 'JavaScript Developer',
+    qualification: 'B.A, B.C.A',
+    mobile: '(123) 4567 890',
+    date: '2022/08/22',
+    time: '09:05 PM'
+  },
+  {
+    name: 'Airi Satou',
+    img: 'assets/images/user/avatar-9.jpg',
+    department: 'Developer',
+    qualification: 'B.COM, M.COM.',
+    mobile: '(123) 4567 890',
+    date: '2023/09/12',
+    time: '09:05 PM'
+  }
+];


### PR DESCRIPTION
## Summary
- duplicate teacher module to create manager module with list, apply, and add views
- route and side menu updated to include manager section above teacher
- added fake manager apply data for mock table

## Testing
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68b69ed776808322bc9f3672ed05adea