### PR TITLE
Fetch nationality and governorate options from lookup endpoints

### DIFF
--- a/src/app/@theme/services/lookup.service.ts
+++ b/src/app/@theme/services/lookup.service.ts
@@ -44,10 +44,25 @@ export interface PagedResultDto<T> {
   items: T[];
 }
 
+export interface NationalityDto {
+  id: number;
+  name: string;
+  telCode: number;
+}
+
+export interface GovernorateDto {
+  id: number;
+  name: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class LookupService {
   private http = inject(HttpClient);
-  getUsersByUserType(filter: FilteredResultRequestDto, userTypeId: number): Observable<ApiResponse<PagedResultDto<LookUpUserDto>>> {
+
+  getUsersByUserType(
+    filter: FilteredResultRequestDto,
+    userTypeId: number
+  ): Observable<ApiResponse<PagedResultDto<LookUpUserDto>>> {
     let params = new HttpParams().set('UserTypeId', userTypeId.toString());
     if (filter.skipCount !== undefined) {
       params = params.set('SkipCount', filter.skipCount.toString());
@@ -74,6 +89,18 @@ export class LookupService {
     return this.http.get<ApiResponse<PagedResultDto<LookUpUserDto>>>(
       `${environment.apiUrl}/api/LookUp/GetUsersByUserType`,
       { params }
+    );
+  }
+
+  getAllNationalities(): Observable<ApiResponse<NationalityDto[]>> {
+    return this.http.get<ApiResponse<NationalityDto[]>>(
+      `${environment.apiUrl}/api/LookUp/GetAllNationality`
+    );
+  }
+
+  getAllGovernorates(): Observable<ApiResponse<GovernorateDto[]>> {
+    return this.http.get<ApiResponse<GovernorateDto[]>>(
+      `${environment.apiUrl}/api/LookUp/GetAllGovernorate`
     );
   }
 }

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
@@ -48,8 +48,10 @@
          
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Nationality Id</mat-label>
-              <input matInput type="number" placeholder="Enter Nationality Id" formControlName="nationalityId" />
+              <mat-label>Nationality</mat-label>
+              <mat-select formControlName="nationalityId" placeholder="Select Nationality">
+                <mat-option *ngFor="let n of nationalities" [value]="n.id">{{ n.name }}</mat-option>
+              </mat-select>
               @if (basicInfoForm.get('nationalityId')?.touched && basicInfoForm.get('nationalityId')?.invalid) {
                 <mat-error>Nationality id is required</mat-error>
               }
@@ -57,8 +59,10 @@
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Governorate Id</mat-label>
-              <input matInput type="number" placeholder="Enter Governorate Id" formControlName="governorateId" />
+              <mat-label>Governorate</mat-label>
+              <mat-select formControlName="governorateId" placeholder="Select Governorate">
+                <mat-option *ngFor="let g of governorates" [value]="g.id">{{ g.name }}</mat-option>
+              </mat-select>
               @if (basicInfoForm.get('governorateId')?.touched && basicInfoForm.get('governorateId')?.invalid) {
                 <mat-error>Governorate id is required</mat-error>
               }

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
@@ -1,16 +1,18 @@
 // angular import
 import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { UserService, CreateUserDto } from 'src/app/@theme/services/user.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
+import { LookupService, NationalityDto, GovernorateDto } from 'src/app/@theme/services/lookup.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 
 @Component({
   selector: 'app-manager-add',
-  imports: [SharedModule],
+  imports: [CommonModule, SharedModule],
   templateUrl: './manager-add.component.html',
   styleUrl: './manager-add.component.scss'
 })
@@ -18,8 +20,12 @@ export class ManagerAddComponent implements OnInit {
   private fb = inject(FormBuilder);
   private userService = inject(UserService);
   private toast = inject(ToastService);
+  private lookupService = inject(LookupService);
 
   basicInfoForm!: FormGroup;
+
+  nationalities: NationalityDto[] = [];
+  governorates: GovernorateDto[] = [];
 
   ngOnInit(): void {
     this.basicInfoForm = this.fb.group({
@@ -31,6 +37,18 @@ export class ManagerAddComponent implements OnInit {
       nationalityId: [null, Validators.required],
       governorateId: [null, Validators.required],
       branchId: [null, Validators.required]
+    });
+
+    this.lookupService.getAllNationalities().subscribe((res) => {
+      if (res.isSuccess) {
+        this.nationalities = res.data;
+      }
+    });
+
+    this.lookupService.getAllGovernorates().subscribe((res) => {
+      if (res.isSuccess) {
+        this.governorates = res.data;
+      }
     });
   }
 

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
@@ -56,8 +56,10 @@
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Nationality Id</mat-label>
-              <input matInput type="number" placeholder="Enter Nationality Id" formControlName="nationalityId" />
+              <mat-label>Nationality</mat-label>
+              <mat-select formControlName="nationalityId" placeholder="Select Nationality">
+                <mat-option *ngFor="let n of nationalities" [value]="n.id">{{ n.name }}</mat-option>
+              </mat-select>
               @if (basicInfoForm.get('nationalityId')?.touched && basicInfoForm.get('nationalityId')?.invalid) {
                 <mat-error>Nationality id is required</mat-error>
               }
@@ -65,8 +67,10 @@
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Governorate Id</mat-label>
-              <input matInput type="number" placeholder="Enter Governorate Id" formControlName="governorateId" />
+              <mat-label>Governorate</mat-label>
+              <mat-select formControlName="governorateId" placeholder="Select Governorate">
+                <mat-option *ngFor="let g of governorates" [value]="g.id">{{ g.name }}</mat-option>
+              </mat-select>
               @if (basicInfoForm.get('governorateId')?.touched && basicInfoForm.get('governorateId')?.invalid) {
                 <mat-error>Governorate id is required</mat-error>
               }

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.ts
@@ -1,15 +1,17 @@
 // angular import
 import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { UserService, CreateUserDto } from 'src/app/@theme/services/user.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
+import { LookupService, NationalityDto, GovernorateDto } from 'src/app/@theme/services/lookup.service';
 
 @Component({
   selector: 'app-student-add',
-  imports: [SharedModule],
+  imports: [CommonModule, SharedModule],
   templateUrl: './student-add.component.html',
   styleUrl: './student-add.component.scss'
 })
@@ -17,8 +19,12 @@ export class StudentAddComponent implements OnInit {
   private fb = inject(FormBuilder);
   private userService = inject(UserService);
   private toast = inject(ToastService);
+  private lookupService = inject(LookupService);
 
   basicInfoForm!: FormGroup;
+
+  nationalities: NationalityDto[] = [];
+  governorates: GovernorateDto[] = [];
 
   ngOnInit(): void {
     this.basicInfoForm = this.fb.group({
@@ -31,6 +37,18 @@ export class StudentAddComponent implements OnInit {
       nationalityId: [null, Validators.required],
       governorateId: [null, Validators.required],
       branchId: [null, Validators.required]
+    });
+
+    this.lookupService.getAllNationalities().subscribe((res) => {
+      if (res.isSuccess) {
+        this.nationalities = res.data;
+      }
+    });
+
+    this.lookupService.getAllGovernorates().subscribe((res) => {
+      if (res.isSuccess) {
+        this.governorates = res.data;
+      }
     });
   }
 

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
@@ -56,8 +56,10 @@
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Nationality Id</mat-label>
-              <input matInput type="number" placeholder="Enter Nationality Id" formControlName="nationalityId" />
+              <mat-label>Nationality</mat-label>
+              <mat-select formControlName="nationalityId" placeholder="Select Nationality">
+                <mat-option *ngFor="let n of nationalities" [value]="n.id">{{ n.name }}</mat-option>
+              </mat-select>
               @if (basicInfoForm.get('nationalityId')?.touched && basicInfoForm.get('nationalityId')?.invalid) {
                 <mat-error>Nationality id is required</mat-error>
               }
@@ -65,8 +67,10 @@
           </div>
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
-              <mat-label>Governorate Id</mat-label>
-              <input matInput type="number" placeholder="Enter Governorate Id" formControlName="governorateId" />
+              <mat-label>Governorate</mat-label>
+              <mat-select formControlName="governorateId" placeholder="Select Governorate">
+                <mat-option *ngFor="let g of governorates" [value]="g.id">{{ g.name }}</mat-option>
+              </mat-select>
               @if (basicInfoForm.get('governorateId')?.touched && basicInfoForm.get('governorateId')?.invalid) {
                 <mat-error>Governorate id is required</mat-error>
               }

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
@@ -1,15 +1,17 @@
 // angular import
 import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { UserService, CreateUserDto } from 'src/app/@theme/services/user.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
+import { LookupService, NationalityDto, GovernorateDto } from 'src/app/@theme/services/lookup.service';
 
 @Component({
   selector: 'app-teacher-add',
-  imports: [SharedModule],
+  imports: [CommonModule, SharedModule],
   templateUrl: './teacher-add.component.html',
   styleUrl: './teacher-add.component.scss'
 })
@@ -17,8 +19,12 @@ export class TeacherAddComponent implements OnInit {
   private fb = inject(FormBuilder);
   private userService = inject(UserService);
   private toast = inject(ToastService);
+  private lookupService = inject(LookupService);
 
   basicInfoForm!: FormGroup;
+
+  nationalities: NationalityDto[] = [];
+  governorates: GovernorateDto[] = [];
 
   ngOnInit(): void {
     this.basicInfoForm = this.fb.group({
@@ -31,6 +37,18 @@ export class TeacherAddComponent implements OnInit {
       nationalityId: [null, Validators.required],
       governorateId: [null, Validators.required],
       branchId: [null, Validators.required]
+    });
+
+    this.lookupService.getAllNationalities().subscribe((res) => {
+      if (res.isSuccess) {
+        this.nationalities = res.data;
+      }
+    });
+
+    this.lookupService.getAllGovernorates().subscribe((res) => {
+      if (res.isSuccess) {
+        this.governorates = res.data;
+      }
     });
   }
 

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.html
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.html
@@ -97,15 +97,19 @@
               </mat-form-field>
             </div>
             <div class="col-12">
-              <label class="f-w-500">Nationality Id</label>
+              <label class="f-w-500">Nationality</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <input matInput formControlName="nationalityId" type="number" placeholder="Nationality Id" />
+                <mat-select formControlName="nationalityId" placeholder="Select nationality">
+                  <mat-option *ngFor="let n of nationalities" [value]="n.id">{{ n.name }}</mat-option>
+                </mat-select>
               </mat-form-field>
             </div>
             <div class="col-12">
-              <label class="f-w-500">Governorate Id</label>
+              <label class="f-w-500">Governorate</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <input matInput formControlName="governorateId" type="number" placeholder="Governorate Id" />
+                <mat-select formControlName="governorateId" placeholder="Select governorate">
+                  <mat-option *ngFor="let g of governorates" [value]="g.id">{{ g.name }}</mat-option>
+                </mat-select>
               </mat-form-field>
             </div>
             <div class="col-12">

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.ts
@@ -11,6 +11,7 @@ import { UserService, CreateUserDto } from 'src/app/@theme/services/user.service
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { BranchesEnum } from 'src/app/@theme/types/branchesEnum';
+import { LookupService, NationalityDto, GovernorateDto } from 'src/app/@theme/services/lookup.service';
 
 @Component({
   selector: 'app-register',
@@ -22,12 +23,17 @@ export class RegisterComponent implements OnInit {
   private fb = inject(FormBuilder);
   private userService = inject(UserService);
   private toast = inject(ToastService);
+  private lookupService = inject(LookupService);
+    private router = inject(Router);
   authenticationService = inject(AuthenticationService);
 
   // public props
   hide = true;
   coHide = true;
   registerForm!: FormGroup;
+
+  nationalities: NationalityDto[] = [];
+  governorates: GovernorateDto[] = [];
 
   userTypes = [
     { id: UserTypesEnum.Manager, label: 'مشرف' },
@@ -39,7 +45,6 @@ export class RegisterComponent implements OnInit {
     { id: BranchesEnum.Mens, label: 'الرجال' },
     { id: BranchesEnum.Women, label: 'النساء' },
   ];
-constructor(private router:Router ) {}
   ngOnInit(): void {
     this.registerForm = this.fb.group({
       fullName: ['', Validators.required],
@@ -52,6 +57,18 @@ constructor(private router:Router ) {}
       nationalityId: [null, Validators.required],
       governorateId: [null, Validators.required],
       branchId: [null, Validators.required]
+    });
+
+    this.lookupService.getAllNationalities().subscribe((res) => {
+      if (res.isSuccess) {
+        this.nationalities = res.data;
+      }
+    });
+
+    this.lookupService.getAllGovernorates().subscribe((res) => {
+      if (res.isSuccess) {
+        this.governorates = res.data;
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- add LookupService utilities to retrieve nationalities and governorates
- replace numeric nationality/governorate inputs with selects across registration and admin add forms
- populate selection lists from lookup endpoints
- import CommonModule for add forms so `*ngFor` directives on nationality/governorate selects work correctly

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*


------
https://chatgpt.com/codex/tasks/task_e_68b6b778b6688322b4dd464a0a1b603e