### PR TITLE
feat: add country code selection for registration

### DIFF
--- a/src/app/@theme/services/country.service.ts
+++ b/src/app/@theme/services/country.service.ts
@@ -1,0 +1,40 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { map, Observable } from 'rxjs';
+
+interface RestCountry {
+  name: { common: string };
+  cca2: string;
+  idd: { root: string; suffixes?: string[] };
+}
+
+export interface Country {
+  name: string;
+  dialCode: string;
+  code: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CountryService {
+  private http = inject(HttpClient);
+
+  getCountries(): Observable<Country[]> {
+    return this.http
+      .get<RestCountry[]>(
+        'https://restcountries.com/v3.1/all?fields=name,cca2,idd'
+      )
+      .pipe(
+        map((countries) =>
+          countries
+            .filter((c) => c?.idd?.root)
+            .map((c) => ({
+              name: c.name.common,
+              code: c.cca2,
+              dialCode: `${c.idd.root}${c.idd.suffixes?.[0] ?? ''}`
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name))
+        )
+      );
+  }
+}
+

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.html
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.html
@@ -53,14 +53,26 @@
               </mat-form-field>
             </div>
             <div class="col-12">
+              <label class="f-w-500">Country</label>
+              <mat-form-field appearance="outline" class="w-100 m-t-5">
+                <mat-select formControlName="countryDialCode" placeholder="Select Country">
+                  <mat-option *ngFor="let c of countries" [value]="c.dialCode">
+                    {{ c.name }} ({{ c.dialCode }})
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-12">
               <label class="f-w-500">Mobile</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
+                <span matPrefix>{{ registerForm.value.countryDialCode }}&nbsp;</span>
                 <input matInput formControlName="mobile" placeholder="Mobile" />
               </mat-form-field>
             </div>
             <div class="col-12">
               <label class="f-w-500">Second Mobile</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
+                <span matPrefix>{{ registerForm.value.countryDialCode }}&nbsp;</span>
                 <input matInput formControlName="secondMobile" placeholder="Second Mobile" />
               </mat-form-field>
             </div>

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.ts
@@ -12,6 +12,7 @@ import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { BranchesEnum } from 'src/app/@theme/types/branchesEnum';
 import { LookupService, NationalityDto, GovernorateDto } from 'src/app/@theme/services/lookup.service';
+import { CountryService, Country } from 'src/app/@theme/services/country.service';
 
 @Component({
   selector: 'app-register',
@@ -24,6 +25,7 @@ export class RegisterComponent implements OnInit {
   private userService = inject(UserService);
   private toast = inject(ToastService);
   private lookupService = inject(LookupService);
+  private countryService = inject(CountryService);
     private router = inject(Router);
   authenticationService = inject(AuthenticationService);
 
@@ -34,6 +36,7 @@ export class RegisterComponent implements OnInit {
 
   nationalities: NationalityDto[] = [];
   governorates: GovernorateDto[] = [];
+  countries: Country[] = [];
 
   userTypes = [
     { id: UserTypesEnum.Manager, label: 'مشرف' },
@@ -49,6 +52,7 @@ export class RegisterComponent implements OnInit {
     this.registerForm = this.fb.group({
       fullName: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
+      countryDialCode: [null, Validators.required],
       mobile: ['', Validators.required],
       secondMobile: [''],
       passwordHash: ['', [Validators.required, Validators.minLength(6)]],
@@ -69,6 +73,10 @@ export class RegisterComponent implements OnInit {
       if (res.isSuccess) {
         this.governorates = res.data;
       }
+    });
+
+    this.countryService.getCountries().subscribe((data) => {
+      this.countries = data;
     });
   }
 
@@ -100,8 +108,10 @@ export class RegisterComponent implements OnInit {
     const model: CreateUserDto = {
       fullName: formValue.fullName,
       email: formValue.email,
-      mobile: formValue.mobile,
-      secondMobile: formValue.secondMobile,
+      mobile: `${formValue.countryDialCode}${formValue.mobile}`,
+      secondMobile: formValue.secondMobile
+        ? `${formValue.countryDialCode}${formValue.secondMobile}`
+        : undefined,
       passwordHash: formValue.passwordHash,
       userTypeId: Number(formValue.userTypeId),
       nationalityId: formValue.nationalityId,


### PR DESCRIPTION
## Summary
- add CountryService to pull country calling codes from online API
- extend registration form with country selector and country-code prefix
- prepend selected country code to mobile numbers before sending to backend

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bc0bc2888322b1ee3d161cade92b