### PR TITLE
feat: add dynamic phone placeholders

### DIFF
--- a/src/app/demo/pages/auth/authentication-1/register/register.component.html
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.html
@@ -53,41 +53,45 @@
               </mat-form-field>
             </div>
             <div class="col-12">
-              <label class="f-w-500">Country</label>
-              <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <mat-select formControlName="countryDialCode" placeholder="Select Country">
-                  <mat-option *ngFor="let c of countries" [value]="c.dialCode">
-                    {{ c.name }} ({{ c.dialCode }})
-                  </mat-option>
-                </mat-select>
-              </mat-form-field>
-            </div>
-            <div class="col-12">
               <label class="f-w-500">Mobile</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-
-                <mat-select formControlName="mobileCountryDialCode" matPrefix>
+                <mat-select
+                  formControlName="mobileCountryDialCode"
+                  (selectionChange)="onCountryCodeChange('mobileCountryDialCode')"
+                  matPrefix
+                  class="dial-code-select"
+                >
                   <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                     {{ c.name }} ({{ c.dialCode }})
                   </mat-option>
                 </mat-select>
-
-                <span matPrefix>{{ registerForm.value.countryDialCode }}&nbsp;</span>
-
-                <input matInput formControlName="mobile" placeholder="Mobile" />
+                <input
+                  matInput
+                  formControlName="mobile"
+                  [mask]="mobileMask"
+                  [placeholder]="mobilePlaceholder"
+                />
               </mat-form-field>
             </div>
             <div class="col-12">
               <label class="f-w-500">Second Mobile</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <mat-select formControlName="secondMobileCountryDialCode" matPrefix>
+                <mat-select
+                  formControlName="secondMobileCountryDialCode"
+                  (selectionChange)="onCountryCodeChange('secondMobileCountryDialCode')"
+                  matPrefix
+                  class="dial-code-select"
+                >
                   <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                     {{ c.name }} ({{ c.dialCode }})
                   </mat-option>
                 </mat-select>
-
-                <span matPrefix>{{ registerForm.value.countryDialCode }}&nbsp;</span>
-                <input matInput formControlName="secondMobile" placeholder="Second Mobile" />
+                <input
+                  matInput
+                  formControlName="secondMobile"
+                  [mask]="secondMobileMask"
+                  [placeholder]="secondMobilePlaceholder"
+                />
               </mat-form-field>
             </div>
             <div class="col-12">

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.scss
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.scss
@@ -1,1 +1,5 @@
 // This file is intentionally left empty to allow customers to add custom CSS if needed.
+
+:host ::ng-deep .dial-code-select {
+  width: 90px;
+}

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -16,9 +17,10 @@ import { CountryService, Country } from 'src/app/@theme/services/country.service
 
 @Component({
   selector: 'app-register',
-  imports: [CommonModule, SharedModule, RouterModule],
+  imports: [CommonModule, SharedModule, RouterModule, NgxMaskDirective],
   templateUrl: './register.component.html',
-  styleUrls: ['./register.component.scss', '../authentication-1.scss', '../../authentication.scss']
+  styleUrls: ['./register.component.scss', '../authentication-1.scss', '../../authentication.scss'],
+  providers: [provideNgxMask()]
 })
 export class RegisterComponent implements OnInit {
   private fb = inject(FormBuilder);
@@ -38,6 +40,16 @@ export class RegisterComponent implements OnInit {
   governorates: GovernorateDto[] = [];
   countries: Country[] = [];
 
+  phoneFormats: Record<string, { mask: string; placeholder: string }> = {
+    '+1': { mask: '000-000-0000', placeholder: '123-456-7890' },
+    '+44': { mask: '0000 000000', placeholder: '7123 456789' },
+    '+966': { mask: '0000000000', placeholder: '5XXXXXXXXX' }
+  };
+  mobileMask = '';
+  mobilePlaceholder = '';
+  secondMobileMask = '';
+  secondMobilePlaceholder = '';
+
   userTypes = [
     { id: UserTypesEnum.Manager, label: 'مشرف' },
     { id: UserTypesEnum.BranchLeader, label: 'مسئول فرع' },
@@ -53,7 +65,6 @@ export class RegisterComponent implements OnInit {
       fullName: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
       mobileCountryDialCode: [null, Validators.required],
-      countryDialCode: [null, Validators.required],
       mobile: ['', Validators.required],
       secondMobileCountryDialCode: [''],
       secondMobile: [''],
@@ -95,6 +106,24 @@ export class RegisterComponent implements OnInit {
     return this.form['email'].hasError('email') ? 'Not a valid email' : '';
   }
 
+  onCountryCodeChange(
+    control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode'
+  ) {
+    const code = this.registerForm.get(control)?.value;
+    const format =
+      this.phoneFormats[code] || {
+        mask: '0000000000',
+        placeholder: '##########'
+      };
+    if (control === 'mobileCountryDialCode') {
+      this.mobileMask = format.mask;
+      this.mobilePlaceholder = format.placeholder;
+    } else {
+      this.secondMobileMask = format.mask;
+      this.secondMobilePlaceholder = format.placeholder;
+    }
+  }
+
   onSubmit() {
     if (this.registerForm.invalid) {
       this.registerForm.markAllAsTouched();
@@ -107,13 +136,13 @@ export class RegisterComponent implements OnInit {
     }
 
     const formValue = this.registerForm.value;
+    const clean = (v: string) => v.replace(/\D/g, '');
     const model: CreateUserDto = {
       fullName: formValue.fullName,
       email: formValue.email,
-      mobile: `${formValue.mobileCountryDialCode}${formValue.mobile}`,
+      mobile: `${formValue.mobileCountryDialCode}${clean(formValue.mobile)}`,
       secondMobile: formValue.secondMobile
-        ? `${formValue.secondMobileCountryDialCode}${formValue.secondMobile}`
-      
+        ? `${formValue.secondMobileCountryDialCode}${clean(formValue.secondMobile)}`
         : undefined,
       passwordHash: formValue.passwordHash,
       userTypeId: Number(formValue.userTypeId),


### PR DESCRIPTION
## Summary
- add dynamic masks and placeholders for primary and secondary phone inputs
- sanitize phone numbers before request submission
- remove standalone country selector and limit country code dropdown width to allow typing

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c6b3864083228d78aa49191dfc10