### PR TITLE
fix: stop phone input clicks opening country picker

### DIFF
--- a/src/app/demo/pages/auth/authentication-1/register/register.component.html
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.html
@@ -71,6 +71,7 @@
                   formControlName="mobile"
                   [mask]="mobileMask"
                   [placeholder]="mobilePlaceholder"
+                  (click)="$event.stopPropagation()"
                 />
               </mat-form-field>
             </div>
@@ -94,6 +95,7 @@
                   formControlName="secondMobile"
                   [mask]="secondMobileMask"
                   [placeholder]="secondMobilePlaceholder"
+                  (click)="$event.stopPropagation()"
                 />
               </mat-form-field>
             </div>

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.scss
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.scss
@@ -1,5 +1,11 @@
 // This file is intentionally left empty to allow customers to add custom CSS if needed.
 
+:host ::ng-deep .mat-mdc-form-field-prefix,
 :host ::ng-deep .dial-code-select {
-  width: 90px;
+  width: 90px !important;
+  flex: 0 0 90px;
+}
+
+:host ::ng-deep .mat-mdc-text-field-wrapper {
+  padding: 0 !important;
 }


### PR DESCRIPTION
## Summary
- prevent mobile inputs from triggering the dial-code dropdown by stopping click propagation
- limit prefix width and remove extra padding for dial-code select in register form

## Testing
- `npx ng test able-pro` *(fails: Project target does not exist)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6ce9ab2c08322bd461fd56fb72440