### PR TITLE
Add international phone mask and placeholder

### DIFF
--- a/src/app/demo/pages/contact-us/contact-us.component.html
+++ b/src/app/demo/pages/contact-us/contact-us.component.html
@@ -37,7 +37,14 @@
             <div class="col-12">
               <label for="phone" class="f-w-500">Phone Number</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <input type="number" matInput placeholder="Phone Number" />
+                <input
+                  matInput
+                  type="text"
+                  mask="000000000000000"
+                  prefix="+"
+                  [dropSpecialCharacters]="false"
+                  placeholder="+123456789012345"
+                />
               </mat-form-field>
             </div>
             <div class="col-12">

--- a/src/app/demo/pages/contact-us/contact-us.component.ts
+++ b/src/app/demo/pages/contact-us/contact-us.component.ts
@@ -3,13 +3,15 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, Validators } from '@angular/forms';
 import { BreakpointObserver } from '@angular/cdk/layout';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 // project import
 import { SharedModule } from '../../shared/shared.module';
 
 @Component({
   selector: 'app-contact-us',
-  imports: [CommonModule, SharedModule],
+  imports: [CommonModule, SharedModule, NgxMaskDirective],
+  providers: [provideNgxMask()],
   templateUrl: './contact-us.component.html',
   styleUrls: ['./contact-us.component.scss']
 })

--- a/src/app/demo/pages/forms/forms-validation/forms-validation.component.html
+++ b/src/app/demo/pages/forms/forms-validation/forms-validation.component.html
@@ -127,15 +127,17 @@
                 matInput
                 type="text"
                 name="validation-phone"
-                placeholder="Enter Contact Number"
+                mask="000000000000000"
+                prefix="+"
+                [dropSpecialCharacters]="false"
+                placeholder="+123456789012345"
                 [ngClass]="{
                   'is-invalid': !phone.valid && (phone.dirty || phone.touched || isSubmit)
                 }"
                 #phone="ngModel"
                 required
-                maxlength="12"
                 minlength="10"
-                phone="IN"
+                maxlength="15"
                 [(ngModel)]="formInput.phone"
               />
               @if (!phone.valid && (phone.dirty || phone.touched || isSubmit)) {

--- a/src/app/demo/pages/forms/forms-validation/forms-validation.component.ts
+++ b/src/app/demo/pages/forms/forms-validation/forms-validation.component.ts
@@ -7,6 +7,7 @@ import { SharedModule } from 'src/app/demo/shared/shared.module';
 
 // third party
 import { NarikCustomValidatorsModule } from '@narik/custom-validators';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 export class FormInput {
   email!: string;
@@ -23,7 +24,8 @@ export class FormInput {
 
 @Component({
   selector: 'app-forms-validation',
-  imports: [CommonModule, SharedModule, NarikCustomValidatorsModule],
+  imports: [CommonModule, SharedModule, NarikCustomValidatorsModule, NgxMaskDirective],
+  providers: [provideNgxMask()],
   templateUrl: './forms-validation.component.html',
   styleUrls: ['./forms-validation.component.scss']
 })


### PR DESCRIPTION
## Summary
- apply ngx-mask to phone fields with international placeholder
- import ngx-mask in contact and form validation components

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6d0163b408322972acb99f479c348