### PR TITLE
Add international phone mask and placeholder

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
@@ -29,7 +29,14 @@
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
               </mat-select>
-              <input matInput type="text" placeholder="Enter Mobile" formControlName="mobile" />
+              <input
+                matInput
+                type="text"
+                placeholder="123456789012345"
+                formControlName="mobile"
+                mask="000000000000000"
+                [dropSpecialCharacters]="false"
+              />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
                 <mat-error>Mobile is required</mat-error>
               }
@@ -43,7 +50,14 @@
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
               </mat-select>
-              <input matInput type="text" placeholder="Enter Second Mobile" formControlName="secondMobile" />
+              <input
+                matInput
+                type="text"
+                placeholder="123456789012345"
+                formControlName="secondMobile"
+                mask="000000000000000"
+                [dropSpecialCharacters]="false"
+              />
             </mat-form-field>
           </div>
           <div class="col-md-6">

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
@@ -2,6 +2,7 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -13,9 +14,10 @@ import { CountryService, Country } from 'src/app/@theme/services/country.service
 
 @Component({
   selector: 'app-manager-add',
-  imports: [CommonModule, SharedModule],
+  imports: [CommonModule, SharedModule, NgxMaskDirective],
   templateUrl: './manager-add.component.html',
-  styleUrl: './manager-add.component.scss'
+  styleUrl: './manager-add.component.scss',
+  providers: [provideNgxMask()]
 })
 export class ManagerAddComponent implements OnInit {
   private fb = inject(FormBuilder);

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
@@ -29,7 +29,14 @@
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
               </mat-select>
-              <input matInput type="text" placeholder="Enter Mobile" formControlName="mobile" />
+              <input
+                matInput
+                type="text"
+                placeholder="123456789012345"
+                formControlName="mobile"
+                mask="000000000000000"
+                [dropSpecialCharacters]="false"
+              />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
                 <mat-error>Mobile is required</mat-error>
               }
@@ -43,7 +50,14 @@
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
               </mat-select>
-              <input matInput type="text" placeholder="Enter Second Mobile" formControlName="secondMobile" />
+              <input
+                matInput
+                type="text"
+                placeholder="123456789012345"
+                formControlName="secondMobile"
+                mask="000000000000000"
+                [dropSpecialCharacters]="false"
+              />
             </mat-form-field>
           </div>
           <div class="col-md-6">

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.ts
@@ -2,6 +2,7 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -16,9 +17,10 @@ import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 
 @Component({
   selector: 'app-student-add',
-  imports: [CommonModule, SharedModule],
+  imports: [CommonModule, SharedModule, NgxMaskDirective],
   templateUrl: './student-add.component.html',
-  styleUrl: './student-add.component.scss'
+  styleUrl: './student-add.component.scss',
+  providers: [provideNgxMask()]
 })
 export class StudentAddComponent implements OnInit {
   private fb = inject(FormBuilder);

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
@@ -29,7 +29,14 @@
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
               </mat-select>
-              <input matInput type="text" placeholder="Enter Mobile" formControlName="mobile" />
+              <input
+                matInput
+                type="text"
+                placeholder="123456789012345"
+                formControlName="mobile"
+                mask="000000000000000"
+                [dropSpecialCharacters]="false"
+              />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
                 <mat-error>Mobile is required</mat-error>
               }
@@ -43,7 +50,14 @@
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
               </mat-select>
-              <input matInput type="text" placeholder="Enter Second Mobile" formControlName="secondMobile" />
+              <input
+                matInput
+                type="text"
+                placeholder="123456789012345"
+                formControlName="secondMobile"
+                mask="000000000000000"
+                [dropSpecialCharacters]="false"
+              />
             </mat-form-field>
           </div>
           <div class="col-md-6">

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
@@ -2,6 +2,7 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -13,9 +14,10 @@ import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 
 @Component({
   selector: 'app-teacher-add',
-  imports: [CommonModule, SharedModule],
+  imports: [CommonModule, SharedModule, NgxMaskDirective],
   templateUrl: './teacher-add.component.html',
-  styleUrl: './teacher-add.component.scss'
+  styleUrl: './teacher-add.component.scss',
+  providers: [provideNgxMask()]
 })
 export class TeacherAddComponent implements OnInit {
   private fb = inject(FormBuilder);

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.html
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.html
@@ -71,6 +71,7 @@
                   formControlName="mobile"
                   [mask]="mobileMask"
                   [placeholder]="mobilePlaceholder"
+                  [dropSpecialCharacters]="false"
                   (click)="$event.stopPropagation()"
                 />
               </mat-form-field>
@@ -95,6 +96,7 @@
                   formControlName="secondMobile"
                   [mask]="secondMobileMask"
                   [placeholder]="secondMobilePlaceholder"
+                  [dropSpecialCharacters]="false"
                   (click)="$event.stopPropagation()"
                 />
               </mat-form-field>

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.ts
@@ -112,8 +112,8 @@ export class RegisterComponent implements OnInit {
     const code = this.registerForm.get(control)?.value;
     const format =
       this.phoneFormats[code] || {
-        mask: '0000000000',
-        placeholder: '##########'
+        mask: '000000000000000',
+        placeholder: '123456789012345'
       };
     if (control === 'mobileCountryDialCode') {
       this.mobileMask = format.mask;

--- a/src/app/demo/pages/contact-us/contact-us.component.html
+++ b/src/app/demo/pages/contact-us/contact-us.component.html
@@ -37,7 +37,14 @@
             <div class="col-12">
               <label for="phone" class="f-w-500">Phone Number</label>
               <mat-form-field appearance="outline" class="w-100 m-t-5">
-                <input type="number" matInput placeholder="Phone Number" />
+                <input
+                  matInput
+                  type="text"
+                  mask="000000000000000"
+                  prefix="+"
+                  [dropSpecialCharacters]="false"
+                  placeholder="+123456789012345"
+                />
               </mat-form-field>
             </div>
             <div class="col-12">

--- a/src/app/demo/pages/contact-us/contact-us.component.ts
+++ b/src/app/demo/pages/contact-us/contact-us.component.ts
@@ -3,13 +3,15 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, Validators } from '@angular/forms';
 import { BreakpointObserver } from '@angular/cdk/layout';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 // project import
 import { SharedModule } from '../../shared/shared.module';
 
 @Component({
   selector: 'app-contact-us',
-  imports: [CommonModule, SharedModule],
+  imports: [CommonModule, SharedModule, NgxMaskDirective],
+  providers: [provideNgxMask()],
   templateUrl: './contact-us.component.html',
   styleUrls: ['./contact-us.component.scss']
 })

--- a/src/app/demo/pages/forms/forms-validation/forms-validation.component.html
+++ b/src/app/demo/pages/forms/forms-validation/forms-validation.component.html
@@ -127,15 +127,17 @@
                 matInput
                 type="text"
                 name="validation-phone"
-                placeholder="Enter Contact Number"
+                mask="000000000000000"
+                prefix="+"
+                [dropSpecialCharacters]="false"
+                placeholder="+123456789012345"
                 [ngClass]="{
                   'is-invalid': !phone.valid && (phone.dirty || phone.touched || isSubmit)
                 }"
                 #phone="ngModel"
                 required
-                maxlength="12"
                 minlength="10"
-                phone="IN"
+                maxlength="15"
                 [(ngModel)]="formInput.phone"
               />
               @if (!phone.valid && (phone.dirty || phone.touched || isSubmit)) {

--- a/src/app/demo/pages/forms/forms-validation/forms-validation.component.ts
+++ b/src/app/demo/pages/forms/forms-validation/forms-validation.component.ts
@@ -7,6 +7,7 @@ import { SharedModule } from 'src/app/demo/shared/shared.module';
 
 // third party
 import { NarikCustomValidatorsModule } from '@narik/custom-validators';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 export class FormInput {
   email!: string;
@@ -23,7 +24,8 @@ export class FormInput {
 
 @Component({
   selector: 'app-forms-validation',
-  imports: [CommonModule, SharedModule, NarikCustomValidatorsModule],
+  imports: [CommonModule, SharedModule, NarikCustomValidatorsModule, NgxMaskDirective],
+  providers: [provideNgxMask()],
   templateUrl: './forms-validation.component.html',
   styleUrls: ['./forms-validation.component.scss']
 })


### PR DESCRIPTION
## Summary
- apply ngx-mask to registration and admin user creation forms
- default to 15-digit phone format with example placeholders

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6d0163b408322972acb99f479c348