### PR TITLE
feat: open select on typing in user forms

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
@@ -24,7 +24,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Mobile</mat-label>
-              <mat-select formControlName="mobileCountryDialCode" matPrefix>
+              <mat-select formControlName="mobileCountryDialCode" matPrefix appOpenSelectOnType>
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -45,7 +45,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Second Mobile</mat-label>
-              <mat-select formControlName="secondMobileCountryDialCode" matPrefix>
+              <mat-select formControlName="secondMobileCountryDialCode" matPrefix appOpenSelectOnType>
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -73,7 +73,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Nationality</mat-label>
-              <mat-select formControlName="nationalityId" placeholder="Select Nationality">
+              <mat-select formControlName="nationalityId" placeholder="Select Nationality" appOpenSelectOnType>
                 <mat-option *ngFor="let n of nationalities" [value]="n.id">{{ n.name }}</mat-option>
               </mat-select>
               @if (basicInfoForm.get('nationalityId')?.touched && basicInfoForm.get('nationalityId')?.invalid) {
@@ -84,7 +84,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Governorate</mat-label>
-              <mat-select formControlName="governorateId" placeholder="Select Governorate">
+              <mat-select formControlName="governorateId" placeholder="Select Governorate" appOpenSelectOnType>
                 <mat-option *ngFor="let g of governorates" [value]="g.id">{{ g.name }}</mat-option>
               </mat-select>
               @if (basicInfoForm.get('governorateId')?.touched && basicInfoForm.get('governorateId')?.invalid) {

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
@@ -24,7 +24,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Mobile</mat-label>
-              <mat-select formControlName="mobileCountryDialCode" matPrefix>
+              <mat-select formControlName="mobileCountryDialCode" matPrefix appOpenSelectOnType>
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -45,7 +45,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Second Mobile</mat-label>
-              <mat-select formControlName="secondMobileCountryDialCode" matPrefix>
+              <mat-select formControlName="secondMobileCountryDialCode" matPrefix appOpenSelectOnType>
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -72,7 +72,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Nationality</mat-label>
-              <mat-select formControlName="nationalityId" placeholder="Select Nationality">
+              <mat-select formControlName="nationalityId" placeholder="Select Nationality" appOpenSelectOnType>
                 <mat-option *ngFor="let n of nationalities" [value]="n.id">{{ n.name }}</mat-option>
               </mat-select>
               @if (basicInfoForm.get('nationalityId')?.touched && basicInfoForm.get('nationalityId')?.invalid) {
@@ -83,7 +83,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Governorate</mat-label>
-              <mat-select formControlName="governorateId" placeholder="Select Governorate">
+              <mat-select formControlName="governorateId" placeholder="Select Governorate" appOpenSelectOnType>
                 <mat-option *ngFor="let g of governorates" [value]="g.id">{{ g.name }}</mat-option>
               </mat-select>
               @if (basicInfoForm.get('governorateId')?.touched && basicInfoForm.get('governorateId')?.invalid) {

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
@@ -24,7 +24,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Mobile</mat-label>
-              <mat-select formControlName="mobileCountryDialCode" matPrefix>
+              <mat-select formControlName="mobileCountryDialCode" matPrefix appOpenSelectOnType>
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -45,7 +45,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Second Mobile</mat-label>
-              <mat-select formControlName="secondMobileCountryDialCode" matPrefix>
+              <mat-select formControlName="secondMobileCountryDialCode" matPrefix appOpenSelectOnType>
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -72,7 +72,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Nationality</mat-label>
-              <mat-select formControlName="nationalityId" placeholder="Select Nationality">
+              <mat-select formControlName="nationalityId" placeholder="Select Nationality" appOpenSelectOnType>
                 <mat-option *ngFor="let n of nationalities" [value]="n.id">{{ n.name }}</mat-option>
               </mat-select>
               @if (basicInfoForm.get('nationalityId')?.touched && basicInfoForm.get('nationalityId')?.invalid) {
@@ -83,7 +83,7 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Governorate</mat-label>
-              <mat-select formControlName="governorateId" placeholder="Select Governorate">
+              <mat-select formControlName="governorateId" placeholder="Select Governorate" appOpenSelectOnType>
                 <mat-option *ngFor="let g of governorates" [value]="g.id">{{ g.name }}</mat-option>
               </mat-select>
               @if (basicInfoForm.get('governorateId')?.touched && basicInfoForm.get('governorateId')?.invalid) {

--- a/src/app/demo/shared/directives/open-select-on-type.directive.ts
+++ b/src/app/demo/shared/directives/open-select-on-type.directive.ts
@@ -1,0 +1,16 @@
+import { Directive, HostListener, inject } from '@angular/core';
+import { MatSelect } from '@angular/material/select';
+
+@Directive({
+  selector: 'mat-select[appOpenSelectOnType]'
+})
+export class OpenSelectOnTypeDirective {
+  private matSelect = inject(MatSelect);
+
+  @HostListener('keydown', ['$event'])
+  handleKeydown(event: KeyboardEvent): void {
+    if (!this.matSelect.panelOpen && event.key.length === 1 && !event.ctrlKey && !event.altKey && !event.metaKey) {
+      this.matSelect.open();
+    }
+  }
+}

--- a/src/app/demo/shared/shared.module.ts
+++ b/src/app/demo/shared/shared.module.ts
@@ -47,6 +47,7 @@ import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
 // project import
 import { CustomTranslateLoader } from './custom-translate-loader';
 import { CardComponent } from 'src/app/@theme/components/card/card.component';
+import { OpenSelectOnTypeDirective } from './directives/open-select-on-type.directive';
 
 const MaterialModules = [
   MatToolbarModule,
@@ -87,7 +88,7 @@ const MaterialModules = [
 ];
 
 @NgModule({
-  declarations: [],
+  declarations: [OpenSelectOnTypeDirective],
   imports: [
     CommonModule,
     MaterialModules,
@@ -102,6 +103,6 @@ const MaterialModules = [
     }),
     CardComponent
   ],
-  exports: [MaterialModules, FormsModule, ReactiveFormsModule, NgScrollbarModule, TranslateModule, CardComponent]
+  exports: [MaterialModules, FormsModule, ReactiveFormsModule, NgScrollbarModule, TranslateModule, CardComponent, OpenSelectOnTypeDirective]
 })
 export class SharedModule {}


### PR DESCRIPTION
## Summary
- add directive to auto-open mat-select when typing
- apply directive in add teacher, manager, and student forms

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6d365d5108322b8c8cdee23a0fba1