### PR TITLE
fix(select): prevent dropdown reopening when typing in inputs

### DIFF
--- a/src/app/demo/shared/directives/open-select-on-type.directive.ts
+++ b/src/app/demo/shared/directives/open-select-on-type.directive.ts
@@ -10,7 +10,14 @@ export class OpenSelectOnTypeDirective {
 
   @HostListener('keydown', ['$event'])
   handleKeydown(event: KeyboardEvent): void {
-    if (!this.matSelect.panelOpen && event.key.length === 1 && !event.ctrlKey && !event.altKey && !event.metaKey) {
+    if (
+      this.matSelect.focused &&
+      !this.matSelect.panelOpen &&
+      event.key.length === 1 &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey
+    ) {
       this.matSelect.open();
     }
   }


### PR DESCRIPTION
## Summary
- avoid reopening selects when typing in other inputs by ensuring mat-select is focused before opening

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6d8698508832288a9ddbfbfa918a4