### PR TITLE
fix(select): prevent dropdown reopening when typing in inputs

### DIFF
--- a/src/app/demo/shared/directives/open-select-on-type.directive.ts
+++ b/src/app/demo/shared/directives/open-select-on-type.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, HostListener, inject } from '@angular/core';
+import { Directive, ElementRef, HostListener, inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { MatSelect } from '@angular/material/select';
 
 @Directive({
@@ -7,10 +8,22 @@ import { MatSelect } from '@angular/material/select';
 })
 export class OpenSelectOnTypeDirective {
   private matSelect = inject(MatSelect);
+  private document = inject(DOCUMENT);
+  private host = inject<ElementRef<HTMLElement>>(ElementRef);
 
   @HostListener('keydown', ['$event'])
   handleKeydown(event: KeyboardEvent): void {
-    if (!this.matSelect.panelOpen && event.key.length === 1 && !event.ctrlKey && !event.altKey && !event.metaKey) {
+    const activeElement = this.document.activeElement;
+    const hostElement = this.host.nativeElement;
+
+    if (
+      activeElement === hostElement &&
+      !this.matSelect.panelOpen &&
+      event.key.length === 1 &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey
+    ) {
       this.matSelect.open();
     }
   }


### PR DESCRIPTION
## Summary
- open select on typing only if the select trigger is the active element

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6d8698508832288a9ddbfbfa918a4