### PR TITLE
Align add user forms phone fields with register page

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
@@ -24,7 +24,12 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Mobile</mat-label>
-              <mat-select formControlName="mobileCountryDialCode" matPrefix appOpenSelectOnType>
+              <mat-select
+                formControlName="mobileCountryDialCode"
+                (selectionChange)="onCountryCodeChange('mobileCountryDialCode')"
+                matPrefix
+                appOpenSelectOnType
+              >
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -32,10 +37,11 @@
               <input
                 matInput
                 type="text"
-                placeholder="123456789012345"
                 formControlName="mobile"
-                mask="000000000000000"
+                [mask]="mobileMask"
+                [placeholder]="mobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                (click)="$event.stopPropagation()"
               />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
                 <mat-error>Mobile is required</mat-error>
@@ -45,7 +51,12 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Second Mobile</mat-label>
-              <mat-select formControlName="secondMobileCountryDialCode" matPrefix appOpenSelectOnType>
+              <mat-select
+                formControlName="secondMobileCountryDialCode"
+                (selectionChange)="onCountryCodeChange('secondMobileCountryDialCode')"
+                matPrefix
+                appOpenSelectOnType
+              >
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -53,10 +64,11 @@
               <input
                 matInput
                 type="text"
-                placeholder="123456789012345"
                 formControlName="secondMobile"
-                mask="000000000000000"
+                [mask]="secondMobileMask"
+                [placeholder]="secondMobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                (click)="$event.stopPropagation()"
               />
             </mat-form-field>
           </div>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
@@ -32,6 +32,16 @@ export class ManagerAddComponent implements OnInit {
   governorates: GovernorateDto[] = [];
   countries: Country[] = [];
 
+  phoneFormats: Record<string, { mask: string; placeholder: string }> = {
+    '+1': { mask: '000-000-0000', placeholder: '123-456-7890' },
+    '+44': { mask: '0000 000000', placeholder: '7123 456789' },
+    '+966': { mask: '0000000000', placeholder: '5XXXXXXXXX' }
+  };
+  mobileMask = '';
+  mobilePlaceholder = '';
+  secondMobileMask = '';
+  secondMobilePlaceholder = '';
+
   ngOnInit(): void {
     this.basicInfoForm = this.fb.group({
       fullName: ['', Validators.required],
@@ -63,15 +73,34 @@ export class ManagerAddComponent implements OnInit {
     });
   }
 
+  onCountryCodeChange(
+    control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode'
+  ) {
+    const code = this.basicInfoForm.get(control)?.value;
+    const format =
+      this.phoneFormats[code] || {
+        mask: '000000000000000',
+        placeholder: '123456789012345'
+      };
+    if (control === 'mobileCountryDialCode') {
+      this.mobileMask = format.mask;
+      this.mobilePlaceholder = format.placeholder;
+    } else {
+      this.secondMobileMask = format.mask;
+      this.secondMobilePlaceholder = format.placeholder;
+    }
+  }
+
   onSubmit() {
     if (this.basicInfoForm.valid) {
       const formValue = this.basicInfoForm.value;
+      const clean = (v: string) => v.replace(/\D/g, '');
       const model: CreateUserDto = {
         fullName: formValue.fullName,
         email: formValue.email,
-        mobile: `${formValue.mobileCountryDialCode}${formValue.mobile}`,
+        mobile: `${formValue.mobileCountryDialCode}${clean(formValue.mobile)}`,
         secondMobile: formValue.secondMobile
-          ? `${formValue.secondMobileCountryDialCode}${formValue.secondMobile}`
+          ? `${formValue.secondMobileCountryDialCode}${clean(formValue.secondMobile)}`
           : undefined,
         passwordHash: formValue.passwordHash,
         nationalityId: formValue.nationalityId,

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
@@ -24,7 +24,12 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Mobile</mat-label>
-              <mat-select formControlName="mobileCountryDialCode" matPrefix appOpenSelectOnType>
+              <mat-select
+                formControlName="mobileCountryDialCode"
+                (selectionChange)="onCountryCodeChange('mobileCountryDialCode')"
+                matPrefix
+                appOpenSelectOnType
+              >
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -32,10 +37,11 @@
               <input
                 matInput
                 type="text"
-                placeholder="123456789012345"
                 formControlName="mobile"
-                mask="000000000000000"
+                [mask]="mobileMask"
+                [placeholder]="mobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                (click)="$event.stopPropagation()"
               />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
                 <mat-error>Mobile is required</mat-error>
@@ -45,7 +51,12 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Second Mobile</mat-label>
-              <mat-select formControlName="secondMobileCountryDialCode" matPrefix appOpenSelectOnType>
+              <mat-select
+                formControlName="secondMobileCountryDialCode"
+                (selectionChange)="onCountryCodeChange('secondMobileCountryDialCode')"
+                matPrefix
+                appOpenSelectOnType
+              >
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -53,10 +64,11 @@
               <input
                 matInput
                 type="text"
-                placeholder="123456789012345"
                 formControlName="secondMobile"
-                mask="000000000000000"
+                [mask]="secondMobileMask"
+                [placeholder]="secondMobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                (click)="$event.stopPropagation()"
               />
             </mat-form-field>
           </div>

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.ts
@@ -35,6 +35,16 @@ export class StudentAddComponent implements OnInit {
   governorates: GovernorateDto[] = [];
   countries: Country[] = [];
 
+  phoneFormats: Record<string, { mask: string; placeholder: string }> = {
+    '+1': { mask: '000-000-0000', placeholder: '123-456-7890' },
+    '+44': { mask: '0000 000000', placeholder: '7123 456789' },
+    '+966': { mask: '0000000000', placeholder: '5XXXXXXXXX' }
+  };
+  mobileMask = '';
+  mobilePlaceholder = '';
+  secondMobileMask = '';
+  secondMobilePlaceholder = '';
+
   ngOnInit(): void {
     this.basicInfoForm = this.fb.group({
       fullName: ['', Validators.required],
@@ -67,19 +77,38 @@ export class StudentAddComponent implements OnInit {
     });
   }
 
+  onCountryCodeChange(
+    control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode'
+  ) {
+    const code = this.basicInfoForm.get(control)?.value;
+    const format =
+      this.phoneFormats[code] || {
+        mask: '000000000000000',
+        placeholder: '123456789012345'
+      };
+    if (control === 'mobileCountryDialCode') {
+      this.mobileMask = format.mask;
+      this.mobilePlaceholder = format.placeholder;
+    } else {
+      this.secondMobileMask = format.mask;
+      this.secondMobilePlaceholder = format.placeholder;
+    }
+  }
+
   onSubmit() {
     if (this.basicInfoForm.valid) {
 
       const formValue = this.basicInfoForm.value;
+      const clean = (v: string) => v.replace(/\D/g, '');
       const model: CreateUserDto = {
         fullName: formValue.fullName,
         email: formValue.email,
-        mobile: `${formValue.mobileCountryDialCode}${formValue.mobile}`,
+        mobile: `${formValue.mobileCountryDialCode}${clean(formValue.mobile)}`,
         secondMobile: formValue.secondMobile
-          ? `${formValue.secondMobileCountryDialCode}${formValue.secondMobile}`
+          ? `${formValue.secondMobileCountryDialCode}${clean(formValue.secondMobile)}`
           : undefined,
         passwordHash: formValue.passwordHash,
-       
+
         nationalityId: formValue.nationalityId,
         governorateId: formValue.governorateId,
         branchId: formValue.branchId,

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
@@ -24,7 +24,12 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Mobile</mat-label>
-              <mat-select formControlName="mobileCountryDialCode" matPrefix appOpenSelectOnType>
+              <mat-select
+                formControlName="mobileCountryDialCode"
+                (selectionChange)="onCountryCodeChange('mobileCountryDialCode')"
+                matPrefix
+                appOpenSelectOnType
+              >
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -32,10 +37,11 @@
               <input
                 matInput
                 type="text"
-                placeholder="123456789012345"
                 formControlName="mobile"
-                mask="000000000000000"
+                [mask]="mobileMask"
+                [placeholder]="mobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                (click)="$event.stopPropagation()"
               />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
                 <mat-error>Mobile is required</mat-error>
@@ -45,7 +51,12 @@
           <div class="col-md-6">
             <mat-form-field appearance="outline" class="w-100 m-b-10">
               <mat-label>Second Mobile</mat-label>
-              <mat-select formControlName="secondMobileCountryDialCode" matPrefix appOpenSelectOnType>
+              <mat-select
+                formControlName="secondMobileCountryDialCode"
+                (selectionChange)="onCountryCodeChange('secondMobileCountryDialCode')"
+                matPrefix
+                appOpenSelectOnType
+              >
                 <mat-option *ngFor="let c of countries" [value]="c.dialCode">
                   {{ c.name }} ({{ c.dialCode }})
                 </mat-option>
@@ -53,10 +64,11 @@
               <input
                 matInput
                 type="text"
-                placeholder="123456789012345"
                 formControlName="secondMobile"
-                mask="000000000000000"
+                [mask]="secondMobileMask"
+                [placeholder]="secondMobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                (click)="$event.stopPropagation()"
               />
             </mat-form-field>
           </div>

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
@@ -32,6 +32,16 @@ export class TeacherAddComponent implements OnInit {
   governorates: GovernorateDto[] = [];
   countries: Country[] = [];
 
+  phoneFormats: Record<string, { mask: string; placeholder: string }> = {
+    '+1': { mask: '000-000-0000', placeholder: '123-456-7890' },
+    '+44': { mask: '0000 000000', placeholder: '7123 456789' },
+    '+966': { mask: '0000000000', placeholder: '5XXXXXXXXX' }
+  };
+  mobileMask = '';
+  mobilePlaceholder = '';
+  secondMobileMask = '';
+  secondMobilePlaceholder = '';
+
   ngOnInit(): void {
     this.basicInfoForm = this.fb.group({
       fullName: ['', Validators.required],
@@ -64,15 +74,34 @@ export class TeacherAddComponent implements OnInit {
     });
   }
 
+  onCountryCodeChange(
+    control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode'
+  ) {
+    const code = this.basicInfoForm.get(control)?.value;
+    const format =
+      this.phoneFormats[code] || {
+        mask: '000000000000000',
+        placeholder: '123456789012345'
+      };
+    if (control === 'mobileCountryDialCode') {
+      this.mobileMask = format.mask;
+      this.mobilePlaceholder = format.placeholder;
+    } else {
+      this.secondMobileMask = format.mask;
+      this.secondMobilePlaceholder = format.placeholder;
+    }
+  }
+
   onSubmit() {
     if (this.basicInfoForm.valid) {
       const formValue = this.basicInfoForm.value;
+      const clean = (v: string) => v.replace(/\D/g, '');
       const model: CreateUserDto = {
         fullName: formValue.fullName,
         email: formValue.email,
-        mobile: `${formValue.mobileCountryDialCode}${formValue.mobile}`,
+        mobile: `${formValue.mobileCountryDialCode}${clean(formValue.mobile)}`,
         secondMobile: formValue.secondMobile
-          ? `${formValue.secondMobileCountryDialCode}${formValue.secondMobile}`
+          ? `${formValue.secondMobileCountryDialCode}${clean(formValue.secondMobile)}`
           : undefined,
         passwordHash: formValue.passwordHash,
         nationalityId: formValue.nationalityId,


### PR DESCRIPTION
## Summary
- add phone mask and placeholder handling for student, teacher, and manager add forms
- clean and format mobile and second mobile numbers before submission
- update templates to trigger mask updates on country code change

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b6dc27d6c8832288a3bbf5125572bb