### PR TITLE
Allow teacher add form submit with partial phone numbers

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
@@ -41,6 +41,7 @@
                 [mask]="mobileMask"
                 [placeholder]="mobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                [validation]="!!mobileMask"
                 (click)="$event.stopPropagation()"
               />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
@@ -68,6 +69,7 @@
                 [mask]="secondMobileMask"
                 [placeholder]="secondMobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                [validation]="!!secondMobileMask"
                 (click)="$event.stopPropagation()"
               />
             </mat-form-field>

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
@@ -82,11 +82,7 @@ export class TeacherAddComponent implements OnInit {
     control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode'
   ) {
     const code = this.basicInfoForm.get(control)?.value;
-    const format =
-      this.phoneFormats[code] || {
-        mask: '000000000000000',
-        placeholder: '123456789012345'
-      };
+    const format = this.phoneFormats[code] || { mask: '', placeholder: '' };
     if (control === 'mobileCountryDialCode') {
       this.mobileMask = format.mask;
       this.mobilePlaceholder = format.placeholder;


### PR DESCRIPTION
## Summary
- disable phone mask validation unless a country format is defined
- remove default rigid phone mask to allow unknown country codes

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6ea5db9ec83229b870ce9312d4ea9