### PR TITLE
Allow partial phone numbers across creation forms

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.html
@@ -41,6 +41,7 @@
                 [mask]="mobileMask"
                 [placeholder]="mobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                [validation]="!!mobileMask"
                 (click)="$event.stopPropagation()"
               />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
@@ -68,6 +69,7 @@
                 [mask]="secondMobileMask"
                 [placeholder]="secondMobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                [validation]="!!secondMobileMask"
                 (click)="$event.stopPropagation()"
               />
             </mat-form-field>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-add/manager-add.component.ts
@@ -82,11 +82,7 @@ export class ManagerAddComponent implements OnInit {
     control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode'
   ) {
     const code = this.basicInfoForm.get(control)?.value;
-    const format =
-      this.phoneFormats[code] || {
-        mask: '000000000000000',
-        placeholder: '123456789012345'
-      };
+    const format = this.phoneFormats[code] || { mask: '', placeholder: '' };
     if (control === 'mobileCountryDialCode') {
       this.mobileMask = format.mask;
       this.mobilePlaceholder = format.placeholder;

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.html
@@ -41,6 +41,7 @@
                 [mask]="mobileMask"
                 [placeholder]="mobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                [validation]="!!mobileMask"
                 (click)="$event.stopPropagation()"
               />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
@@ -68,6 +69,7 @@
                 [mask]="secondMobileMask"
                 [placeholder]="secondMobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                [validation]="!!secondMobileMask"
                 (click)="$event.stopPropagation()"
               />
             </mat-form-field>

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-add/student-add.component.ts
@@ -85,11 +85,7 @@ export class StudentAddComponent implements OnInit {
     control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode'
   ) {
     const code = this.basicInfoForm.get(control)?.value;
-    const format =
-      this.phoneFormats[code] || {
-        mask: '000000000000000',
-        placeholder: '123456789012345'
-      };
+    const format = this.phoneFormats[code] || { mask: '', placeholder: '' };
     if (control === 'mobileCountryDialCode') {
       this.mobileMask = format.mask;
       this.mobilePlaceholder = format.placeholder;

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.html
@@ -41,6 +41,7 @@
                 [mask]="mobileMask"
                 [placeholder]="mobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                [validation]="!!mobileMask"
                 (click)="$event.stopPropagation()"
               />
               @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
@@ -68,6 +69,7 @@
                 [mask]="secondMobileMask"
                 [placeholder]="secondMobilePlaceholder"
                 [dropSpecialCharacters]="false"
+                [validation]="!!secondMobileMask"
                 (click)="$event.stopPropagation()"
               />
             </mat-form-field>

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-add/teacher-add.component.ts
@@ -82,11 +82,7 @@ export class TeacherAddComponent implements OnInit {
     control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode'
   ) {
     const code = this.basicInfoForm.get(control)?.value;
-    const format =
-      this.phoneFormats[code] || {
-        mask: '000000000000000',
-        placeholder: '123456789012345'
-      };
+    const format = this.phoneFormats[code] || { mask: '', placeholder: '' };
     if (control === 'mobileCountryDialCode') {
       this.mobileMask = format.mask;
       this.mobilePlaceholder = format.placeholder;

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.html
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.html
@@ -72,6 +72,7 @@
                   [mask]="mobileMask"
                   [placeholder]="mobilePlaceholder"
                   [dropSpecialCharacters]="false"
+                  [validation]="!!mobileMask"
                   (click)="$event.stopPropagation()"
                 />
               </mat-form-field>
@@ -97,6 +98,7 @@
                   [mask]="secondMobileMask"
                   [placeholder]="secondMobilePlaceholder"
                   [dropSpecialCharacters]="false"
+                  [validation]="!!secondMobileMask"
                   (click)="$event.stopPropagation()"
                 />
               </mat-form-field>

--- a/src/app/demo/pages/auth/authentication-1/register/register.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/register/register.component.ts
@@ -110,11 +110,7 @@ export class RegisterComponent implements OnInit {
     control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode'
   ) {
     const code = this.registerForm.get(control)?.value;
-    const format =
-      this.phoneFormats[code] || {
-        mask: '000000000000000',
-        placeholder: '123456789012345'
-      };
+    const format = this.phoneFormats[code] || { mask: '', placeholder: '' };
     if (control === 'mobileCountryDialCode') {
       this.mobileMask = format.mask;
       this.mobilePlaceholder = format.placeholder;


### PR DESCRIPTION
## Summary
- allow student, manager, and self-register forms to submit with partial phone numbers
- disable phone mask validation unless a country format exists

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6ea5db9ec83229b870ce9312d4ea9