### PR TITLE
feat: add user edit pages

### DIFF
--- a/src/app/@theme/services/user.service.ts
+++ b/src/app/@theme/services/user.service.ts
@@ -15,6 +15,17 @@ export interface CreateUserDto {
   branchId?: number;
 }
 
+export interface UpdateUserDto {
+  id: number;
+  fullName?: string;
+  email?: string;
+  mobile?: string;
+  secondMobile?: string;
+  nationalityId?: number;
+  governorateId?: number;
+  branchId?: number;
+}
+
 // Generic API response interfaces
 export interface ApiError {
   fieldName: string;
@@ -36,5 +47,9 @@ export class UserService {
 
   createUser(model: CreateUserDto): Observable<ApiResponse<boolean>> {
     return this.http.post<ApiResponse<boolean>>(`${environment.apiUrl}/api/User/Create`, model);
+  }
+
+  updateUser(model: UpdateUserDto): Observable<ApiResponse<boolean>> {
+    return this.http.put<ApiResponse<boolean>>(`${environment.apiUrl}/api/User/Update`, model);
   }
 }

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.html
@@ -59,7 +59,11 @@
                         </a>
                       </li>
                       <li class="list-inline-item m-r-10" matTooltip="Edit">
-                        <a href="javascript:" class="avatar avatar-xs text-muted">
+                        <a
+                          [routerLink]="['/online-course/manager/edit', element.id]"
+                          [state]="{ user: element }"
+                          class="avatar avatar-xs text-muted"
+                        >
                           <i class="ti ti-edit-circle f-18"></i>
                         </a>
                       </li>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-routing.module.ts
@@ -12,17 +12,30 @@ const routes: Routes = [
       {
         path: 'list',
         loadComponent: () => import('./manager-list/manager-list.component').then((c) => c.ManagerListComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       },
       {
         path: 'add',
         loadComponent: () => import('./manager-add/manager-add.component').then((c) => c.ManagerAddComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
+      },
+      {
+        path: 'edit/:id',
+        loadComponent: () => import('../user-edit/user-edit.component').then((c) => c.UserEditComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       },
       {
         path: 'apply',
         loadComponent: () => import('./manager-apply/manager-apply.component').then((c) => c.ManagerApplyComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       }
     ]
   }

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.html
@@ -3,19 +3,10 @@
     <app-card cardTitle="Student List" padding="0" cardClass="sm-block">
       <ng-template #headerOptionsTemplate>
         <div class="table-options">
-          <button
-            mat-stroked-button
-            color="accent"
-            class="m-r-10"
-            [routerLink]="['/online-course/student/apply']"
-          >
+          <button mat-stroked-button color="accent" class="m-r-10" [routerLink]="['/online-course/student/apply']">
             Apply Student List
           </button>
-          <button
-            mat-flat-button
-            color="primary"
-            [routerLink]="['/online-course/student/add']"
-          >
+          <button mat-flat-button color="primary" [routerLink]="['/online-course/student/add']">
             <div class="flex align-item-center">
               <i class="ti ti-plus f-18 m-r-5"></i>
               Add Student
@@ -27,21 +18,14 @@
         <div class="table-containe table-reponsive">
           <div class="table-search p-t-15 p-x-15">
             <mat-form-field appearance="outline" class="w-100">
-              <input
-                matInput
-                (keyup)="applyFilter($event)"
-                placeholder="Search...."
-                #input
-              />
+              <input matInput (keyup)="applyFilter($event)" placeholder="Search...." #input />
             </mat-form-field>
           </div>
           <div class="table-responsive">
             <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
               <!-- Full Name Column -->
               <ng-container matColumnDef="fullName">
-                <th mat-header-cell *matHeaderCellDef class="p-l-25">
-                  NAME
-                </th>
+                <th mat-header-cell *matHeaderCellDef class="p-l-25">NAME</th>
                 <td mat-cell *matCellDef="let element" class="p-l-25 text-nowrap">
                   {{ element.fullName }}
                 </td>
@@ -73,9 +57,7 @@
 
               <!-- action Column -->
               <ng-container matColumnDef="action">
-                <th mat-header-cell *matHeaderCellDef class="text-center">
-                  ACTIONS
-                </th>
+                <th mat-header-cell *matHeaderCellDef class="text-center">ACTIONS</th>
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
                   <div class="text-center text-nowrap">
                     <ul class="list-inline p-l-0">
@@ -85,7 +67,11 @@
                         </a>
                       </li>
                       <li class="list-inline-item m-r-10" matTooltip="Edit">
-                        <a href="javascript:" class="avatar avatar-xs text-muted">
+                        <a
+                          [routerLink]="['/online-course/student/edit', element.id]"
+                          [state]="{ user: element }"
+                          class="avatar avatar-xs text-muted"
+                        >
                           <i class="ti ti-edit-circle f-18"></i>
                         </a>
                       </li>
@@ -104,9 +90,7 @@
 
               <!-- Row shown when there is no matching data. -->
               <tr class="mat-row" *matNoDataRow>
-                <td class="mat-cell" colspan="5">
-                  No data matching the filter "{{ input.value }}"
-                </td>
+                <td class="mat-cell" colspan="5">No data matching the filter "{{ input.value }}"</td>
               </tr>
             </table>
             <mat-paginator
@@ -121,4 +105,3 @@
     </app-card>
   </div>
 </div>
-

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-routing.module.ts
@@ -12,17 +12,30 @@ const routes: Routes = [
       {
         path: 'list',
         loadComponent: () => import('./student-list/student-list.component').then((c) => c.StudentListComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       },
       {
         path: 'add',
         loadComponent: () => import('./student-add/student-add.component').then((c) => c.StudentAddComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
+      },
+      {
+        path: 'edit/:id',
+        loadComponent: () => import('../user-edit/user-edit.component').then((c) => c.UserEditComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       },
       {
         path: 'apply',
         loadComponent: () => import('./student-apply/student-apply.component').then((c) => c.StudentApplyComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       }
     ]
   }

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.html
@@ -59,7 +59,11 @@
                         </a>
                       </li>
                       <li class="list-inline-item m-r-10" matTooltip="Edit">
-                        <a href="javascript:" class="avatar avatar-xs text-muted">
+                        <a
+                          [routerLink]="['/online-course/teacher/edit', element.id]"
+                          [state]="{ user: element }"
+                          class="avatar avatar-xs text-muted"
+                        >
                           <i class="ti ti-edit-circle f-18"></i>
                         </a>
                       </li>

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-routing.module.ts
@@ -12,17 +12,30 @@ const routes: Routes = [
       {
         path: 'list',
         loadComponent: () => import('./teacher-list/teacher-list.component').then((c) => c.TeacherListComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       },
       {
         path: 'add',
         loadComponent: () => import('./teacher-add/teacher-add.component').then((c) => c.TeacherAddComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
+      },
+      {
+        path: 'edit/:id',
+        loadComponent: () => import('../user-edit/user-edit.component').then((c) => c.UserEditComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       },
       {
         path: 'apply',
         loadComponent: () => import('./teacher-apply/teacher-apply.component').then((c) => c.TeacherApplyComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       }
     ]
   }

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -1,0 +1,115 @@
+<div class="row">
+  <div class="col-12">
+    <app-card cardTitle="Update User">
+      <form [formGroup]="basicInfoForm" (ngSubmit)="onSubmit()">
+        <div class="row">
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Full Name</mat-label>
+              <input matInput type="text" placeholder="Enter Full Name" formControlName="fullName" />
+              @if (basicInfoForm.get('fullName')?.touched && basicInfoForm.get('fullName')?.invalid) {
+                <mat-error>Full name is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Email</mat-label>
+              <input matInput type="email" placeholder="Enter Email" formControlName="email" />
+              @if (basicInfoForm.get('email')?.touched && basicInfoForm.get('email')?.invalid) {
+                <mat-error>Email is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Mobile</mat-label>
+              <mat-select
+                formControlName="mobileCountryDialCode"
+                (selectionChange)="onCountryCodeChange('mobileCountryDialCode')"
+                matPrefix
+                appOpenSelectOnType
+                placeholder="+1"
+              >
+                <mat-option *ngFor="let c of countries" [value]="c.dialCode">{{ c.name }} ({{ c.dialCode }})</mat-option>
+              </mat-select>
+              <input
+                matInput
+                type="text"
+                formControlName="mobile"
+                [mask]="mobileMask"
+                [placeholder]="mobilePlaceholder"
+                [dropSpecialCharacters]="false"
+                [validation]="!!mobileMask"
+                (click)="$event.stopPropagation()"
+              />
+              @if (basicInfoForm.get('mobile')?.touched && basicInfoForm.get('mobile')?.invalid) {
+                <mat-error>Mobile is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Second Mobile</mat-label>
+              <mat-select
+                formControlName="secondMobileCountryDialCode"
+                (selectionChange)="onCountryCodeChange('secondMobileCountryDialCode')"
+                matPrefix
+                appOpenSelectOnType
+                placeholder="+1"
+              >
+                <mat-option *ngFor="let c of countries" [value]="c.dialCode">{{ c.name }} ({{ c.dialCode }})</mat-option>
+              </mat-select>
+              <input
+                matInput
+                type="text"
+                formControlName="secondMobile"
+                [mask]="secondMobileMask"
+                [placeholder]="secondMobilePlaceholder"
+                [dropSpecialCharacters]="false"
+                [validation]="!!secondMobileMask"
+                (click)="$event.stopPropagation()"
+              />
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Nationality</mat-label>
+              <mat-select formControlName="nationalityId" placeholder="Select Nationality" appOpenSelectOnType>
+                <mat-option *ngFor="let n of nationalities" [value]="n.id">{{ n.name }}</mat-option>
+              </mat-select>
+              @if (basicInfoForm.get('nationalityId')?.touched && basicInfoForm.get('nationalityId')?.invalid) {
+                <mat-error>Nationality id is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Governorate</mat-label>
+              <mat-select formControlName="governorateId" placeholder="Select Governorate" appOpenSelectOnType>
+                <mat-option *ngFor="let g of governorates" [value]="g.id">{{ g.name }}</mat-option>
+              </mat-select>
+              @if (basicInfoForm.get('governorateId')?.touched && basicInfoForm.get('governorateId')?.invalid) {
+                <mat-error>Governorate id is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100 m-b-10">
+              <mat-label>Branch</mat-label>
+              <mat-select formControlName="branchId" placeholder="Select Branch" appOpenSelectOnType>
+                <mat-option *ngFor="let b of Branch" [value]="b.id">{{ b.label }}</mat-option>
+              </mat-select>
+              @if (basicInfoForm.get('branchId')?.touched && basicInfoForm.get('branchId')?.invalid) {
+                <mat-error>Branch id is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div class="col-md-12 text-end">
+            <button mat-flat-button color="primary" [disabled]="basicInfoForm.invalid">Update</button>
+          </div>
+        </div>
+      </form>
+    </app-card>
+  </div>
+</div>

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.scss
@@ -1,0 +1,39 @@
+form {
+  .mat-mdc-form-field {
+    width: 100%;
+    margin-bottom: 1rem;
+
+    .mdc-floating-label {
+      font-weight: 500;
+    }
+  }
+}
+
+.file-upload {
+  display: block;
+  border: 1px solid var(--accent-300);
+  width: 100%;
+  margin-bottom: 24px;
+  border-radius: 4px;
+  overflow: hidden;
+
+  &:not(:disabled):not([readonly]) {
+    cursor: pointer;
+  }
+  &::file-selector-button {
+    padding: 0.8rem 0.75rem;
+    margin-right: 8px;
+    color: var(--accent-800);
+    pointer-events: none;
+    border-color: var(--accent-300);
+    border-style: solid;
+    border-width: 0px;
+    border-inline-end-width: 1px;
+    border-radius: 0;
+    background: var(--accent-100);
+  }
+
+  &:hover:not(:disabled):not([readonly])::file-selector-button {
+    background: var(--accent-200);
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
@@ -1,0 +1,150 @@
+// angular import
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
+
+// project import
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import { UserService, UpdateUserDto } from 'src/app/@theme/services/user.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+import { LookupService, NationalityDto, GovernorateDto, LookUpUserDto } from 'src/app/@theme/services/lookup.service';
+import { CountryService, Country } from 'src/app/@theme/services/country.service';
+import { BranchesEnum } from 'src/app/@theme/types/branchesEnum';
+
+@Component({
+  selector: 'app-user-edit',
+  imports: [CommonModule, SharedModule, NgxMaskDirective],
+  templateUrl: './user-edit.component.html',
+  styleUrl: './user-edit.component.scss',
+  providers: [provideNgxMask()]
+})
+export class UserEditComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private userService = inject(UserService);
+  private toast = inject(ToastService);
+  private lookupService = inject(LookupService);
+  private countryService = inject(CountryService);
+
+  basicInfoForm!: FormGroup;
+  userId!: number;
+
+  nationalities: NationalityDto[] = [];
+  governorates: GovernorateDto[] = [];
+  countries: Country[] = [];
+  Branch = [
+    { id: BranchesEnum.Mens, label: 'الرجال' },
+    { id: BranchesEnum.Women, label: 'النساء' }
+  ];
+
+  phoneFormats: Record<string, { mask: string; placeholder: string }> = {
+    '+1': { mask: '000-000-0000', placeholder: '123-456-7890' },
+    '+44': { mask: '0000 000000', placeholder: '7123 456789' },
+    '+966': { mask: '0000000000', placeholder: '5XXXXXXXXX' }
+  };
+  mobileMask = '';
+  mobilePlaceholder = '';
+  secondMobileMask = '';
+  secondMobilePlaceholder = '';
+
+  ngOnInit(): void {
+    this.basicInfoForm = this.fb.group({
+      fullName: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
+      mobileCountryDialCode: [null, Validators.required],
+      mobile: ['', Validators.required],
+      secondMobileCountryDialCode: [''],
+      secondMobile: [''],
+      nationalityId: [null, Validators.required],
+      governorateId: [null, Validators.required],
+      branchId: [null, Validators.required]
+    });
+
+    this.lookupService.getAllNationalities().subscribe((res) => {
+      if (res.isSuccess) {
+        this.nationalities = res.data;
+      }
+    });
+
+    this.lookupService.getAllGovernorates().subscribe((res) => {
+      if (res.isSuccess) {
+        this.governorates = res.data;
+      }
+    });
+
+    this.countryService.getCountries().subscribe((data) => {
+      this.countries = data;
+    });
+
+    const user = history.state['user'] as LookUpUserDto | undefined;
+    if (user) {
+      this.userId = user.id;
+      const parsePhone = (phone: string) => {
+        const match = phone.match(/^(\+\d{1,3})(\d+)$/);
+        return match ? { dialCode: match[1], number: match[2] } : { dialCode: '', number: phone };
+      };
+      const mobile = parsePhone(user.mobile);
+      const second = user.secondMobile ? parsePhone(user.secondMobile) : { dialCode: '', number: '' };
+      this.basicInfoForm.patchValue({
+        fullName: user.fullName,
+        email: user.email,
+        mobileCountryDialCode: mobile.dialCode || null,
+        mobile: mobile.number,
+        secondMobileCountryDialCode: second.dialCode || null,
+        secondMobile: second.number,
+        nationalityId: user.nationalityId,
+        governorateId: user.governorateId,
+        branchId: user.branchId
+      });
+      if (mobile.dialCode) {
+        this.onCountryCodeChange('mobileCountryDialCode');
+      }
+      if (user.secondMobile && second.dialCode) {
+        this.onCountryCodeChange('secondMobileCountryDialCode');
+      }
+    }
+  }
+
+  onCountryCodeChange(control: 'mobileCountryDialCode' | 'secondMobileCountryDialCode') {
+    const code = this.basicInfoForm.get(control)?.value;
+    const format = this.phoneFormats[code] || { mask: '', placeholder: '' };
+    if (control === 'mobileCountryDialCode') {
+      this.mobileMask = format.mask;
+      this.mobilePlaceholder = format.placeholder;
+    } else {
+      this.secondMobileMask = format.mask;
+      this.secondMobilePlaceholder = format.placeholder;
+    }
+  }
+
+  onSubmit() {
+    if (this.basicInfoForm.valid) {
+      const formValue = this.basicInfoForm.value;
+      const clean = (v: string) => v.replace(/\D/g, '');
+      const model: UpdateUserDto = {
+        id: this.userId,
+        fullName: formValue.fullName,
+        email: formValue.email,
+        mobile: `${formValue.mobileCountryDialCode}${clean(formValue.mobile)}`,
+        secondMobile: formValue.secondMobile ? `${formValue.secondMobileCountryDialCode}${clean(formValue.secondMobile)}` : undefined,
+        nationalityId: formValue.nationalityId,
+        governorateId: formValue.governorateId,
+        branchId: formValue.branchId
+      };
+      this.userService.updateUser(model).subscribe({
+        next: (res) => {
+          if (res?.isSuccess) {
+            this.toast.success(res.message || 'User updated successfully');
+          } else if (res?.errors?.length) {
+            res.errors.forEach((e) => this.toast.error(e.message));
+          } else {
+            this.toast.error('Error updating user');
+          }
+        },
+        error: () => this.toast.error('Error updating user')
+      });
+    } else {
+      this.basicInfoForm.markAllAsTouched();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- support updating users via new UpdateUserDto and service method
- add shared user edit component and routes for student, manager and teacher
- link list edit actions to the update form

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7ecf32d188322a5ff9349eb8aca84