### PR TITLE
feat(courses): confirm delete, prefill update, show managers

### DIFF
--- a/src/app/@theme/services/circle.service.ts
+++ b/src/app/@theme/services/circle.service.ts
@@ -5,6 +5,7 @@ import { environment } from 'src/environments/environment';
 import {
   ApiResponse,
   FilteredResultRequestDto,
+  LookUpUserDto,
   PagedResultDto
 } from './lookup.service';
 
@@ -12,15 +13,23 @@ export interface CircleDto {
   id: number;
   name: string;
   teacherId?: number;
-  teacherName?: string;
-  managers?: number[];
+  teacher?: LookUpUserDto;
+  managers?: CircleManagerDto[];
   studentsIds?: number[];
   students?: CircleStudentDto[];
 }
 
+export interface CircleManagerDto {
+  managerId: number;
+  manager?: LookUpUserDto;
+  circleId?: number;
+}
+
 export interface CircleStudentDto {
-  id: number;
-  fullName: string;
+  id?: number;
+  studentId?: number;
+  student?: LookUpUserDto;
+  fullName?: string;
   [key: string]: unknown;
 }
 

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
@@ -10,6 +10,9 @@ import {
   FilteredResultRequestDto
 } from 'src/app/@theme/services/lookup.service';
 import {
+  CircleDto,
+  CircleManagerDto,
+  CircleStudentDto,
   CircleService,
   UpdateCircleDto
 } from 'src/app/@theme/services/circle.service';
@@ -42,8 +45,22 @@ export class CoursesUpdateComponent implements OnInit {
       managers: [[]],
       studentsIds: [[]]
     });
-
     const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
+
+    const course = history.state.course as CircleDto | undefined;
+    if (course?.managers?.length) {
+      this.managers = course.managers.map((m: CircleManagerDto) =>
+        m.manager ? (m.manager as LookUpUserDto) : (m as unknown as LookUpUserDto)
+      );
+    }
+    if (course?.students?.length) {
+      this.students = course.students.map((s: CircleStudentDto) =>
+        (s as CircleStudentDto).student
+          ? ((s as CircleStudentDto).student as LookUpUserDto)
+          : (s as unknown as LookUpUserDto)
+      );
+    }
+
     this.lookup
       .getUsersByUserType(filter, Number(UserTypesEnum.Teacher))
       .subscribe((res) => {
@@ -52,28 +69,98 @@ export class CoursesUpdateComponent implements OnInit {
     this.lookup
       .getUsersByUserType(filter, Number(UserTypesEnum.Manager))
       .subscribe((res) => {
-        if (res.isSuccess) this.managers = res.data.items;
+        if (res.isSuccess) {
+          const existing = new Map(this.managers.map((m) => [m.id, m]));
+          res.data.items.forEach((m) => existing.set(m.id, m));
+          this.managers = Array.from(existing.values());
+        }
       });
     this.lookup
       .getUsersByUserType(filter, Number(UserTypesEnum.Student))
       .subscribe((res) => {
-        if (res.isSuccess) this.students = res.data.items;
-      });
-
-    this.id = Number(this.route.snapshot.paramMap.get('id'));
-    if (this.id) {
-      this.circle.get(this.id).subscribe((res) => {
         if (res.isSuccess) {
-          this.circleForm.patchValue({
-            name: res.data.name,
-            teacherId: res.data.teacherId,
-            managers: res.data.managers || [],
-            studentsIds: res.data.students
-              ? res.data.students.map((s) => s.id)
-              : []
-          });
+          const existing = new Map(this.students.map((s) => [s.id, s]));
+          res.data.items.forEach((s) => existing.set(s.id, s));
+          this.students = Array.from(existing.values());
         }
       });
+
+    if (course) {
+      this.id = course.id;
+      const studentIds = course.students
+        ? course.students
+            .map((s: CircleStudentDto) =>
+              s.id ?? s.studentId ?? s.student?.id
+            )
+            .filter((id): id is number => id !== undefined)
+        : course.studentsIds ?? [];
+      this.circleForm.patchValue({
+        name: course.name,
+        teacherId: course.teacherId,
+        managers:
+          course.managers?.map((m: CircleManagerDto | number) =>
+            typeof m === 'number' ? m : m.managerId
+          ) ?? [],
+        studentsIds: studentIds
+      });
+      if (!studentIds.length) {
+        this.circle.get(this.id).subscribe((res) => {
+          if (res.isSuccess) {
+            const fetchedStudents = res.data.students
+              ? res.data.students
+                  .map((s: CircleStudentDto) =>
+                    s.id ?? s.studentId ?? s.student?.id
+                  )
+                  .filter((id): id is number => id !== undefined)
+              : res.data.studentsIds ?? [];
+            this.circleForm.patchValue({ studentsIds: fetchedStudents });
+            if (res.data.students?.length) {
+              const courseStudents = res.data.students.map((s: CircleStudentDto) =>
+                (s as CircleStudentDto).student
+                  ? ((s as CircleStudentDto).student as LookUpUserDto)
+                  : (s as unknown as LookUpUserDto)
+              );
+              const existing = new Map(this.students.map((st) => [st.id, st]));
+              courseStudents.forEach((st) => existing.set(st.id, st));
+              this.students = Array.from(existing.values());
+            }
+          }
+        });
+      }
+    } else {
+      this.id = Number(this.route.snapshot.paramMap.get('id'));
+      if (this.id) {
+        this.circle.get(this.id).subscribe((res) => {
+          if (res.isSuccess) {
+            const fetchedStudents = res.data.students
+              ? res.data.students.map((s: CircleStudentDto) =>
+                  s.id ?? s.studentId ?? s.student?.id
+                )
+              : res.data.studentsIds ?? [];
+            this.circleForm.patchValue({
+              name: res.data.name,
+              teacherId: res.data.teacherId,
+              managers: res.data.managers
+                ? res.data.managers.map((m: CircleManagerDto | number) =>
+                    typeof m === 'number' ? m : m.managerId
+                  )
+                : [],
+              studentsIds: fetchedStudents
+                .filter((id): id is number => id !== undefined)
+            });
+            if (res.data.students?.length) {
+              const courseStudents = res.data.students.map((s: CircleStudentDto) =>
+                (s as CircleStudentDto).student
+                  ? ((s as CircleStudentDto).student as LookUpUserDto)
+                  : (s as unknown as LookUpUserDto)
+              );
+              const existing = new Map(this.students.map((st) => [st.id, st]));
+              courseStudents.forEach((st) => existing.set(st.id, st));
+              this.students = Array.from(existing.values());
+            }
+          }
+        });
+      }
     }
   }
 

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
@@ -26,7 +26,15 @@
               </ng-container>
               <ng-container matColumnDef="teacher">
                 <th mat-header-cell *matHeaderCellDef>TEACHER</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.teacherId }}</td>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  {{ element.teacher?.fullName || element.teacherName || element.teacherId }}
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="managers">
+                <th mat-header-cell *matHeaderCellDef>MANAGERS</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  {{ displayManagers(element.managers) }}
+                </td>
               </ng-container>
               <ng-container matColumnDef="action">
                 <th mat-header-cell *matHeaderCellDef class="text-center">ACTIONS</th>
@@ -34,7 +42,11 @@
                   <div class="text-center text-nowrap">
                     <ul class="list-inline p-l-0">
                       <li class="list-inline-item m-r-10" matTooltip="Edit">
-                        <a (click)="editCircle(element.id)" class="avatar avatar-xs text-muted">
+                        <a
+                          [routerLink]="['/online-course/courses/edit', element.id]"
+                          [state]="{ course: element }"
+                          class="avatar avatar-xs text-muted"
+                        >
                           <i class="ti ti-edit-circle f-18"></i>
                         </a>
                       </li>
@@ -50,7 +62,7 @@
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
               <tr class="mat-row" *matNoDataRow>
-                <td class="mat-cell" colspan="3">No data matching the filter "{{ input.value }}"</td>
+                <td class="mat-cell" colspan="4">No data matching the filter "{{ input.value }}"</td>
               </tr>
             </table>
             <mat-paginator


### PR DESCRIPTION
## Summary
- prompt user to confirm course deletion before removing it
- fill course edit form with existing data for smoother updates
- pass selected course data to the update page so fields pre-populate without extra fetches
- handle nested teacher/manager data from course API responses
- ensure students list pre-selects existing members when editing
- merge provided managers into lookup results and show manager names in the course list

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8267994a8832298ec1730788ff37b