### PR TITLE
feat: add course detail view with student reports

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
@@ -1,0 +1,44 @@
+<div class="row p-t-25">
+  <div class="col-12">
+    <app-card cardTitle="Course Details" padding="0" cardClass="sm-block">
+      <div class="p-10">
+        <h5 class="m-b-10">{{ course?.name }}</h5>
+        <div *ngIf="course?.teacher">Teacher: {{ course.teacher.fullName || course.teacher.id }}</div>
+      </div>
+      <div class="p-b-15">
+        <div class="table-containe table-reponsive">
+          <div class="table-responsive">
+            <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+              <ng-container matColumnDef="fullName">
+                <th mat-header-cell *matHeaderCellDef class="p-l-25">STUDENT</th>
+                <td mat-cell *matCellDef="let element" class="p-l-25 text-nowrap">
+                  {{ element.student?.fullName || element.fullName }}
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="action">
+                <th mat-header-cell *matHeaderCellDef class="text-center">ACTIONS</th>
+                <td mat-cell *matCellDef="let element" class="text-center">
+                  <ul class="list-inline p-l-0 m-b-0">
+                    <li class="list-inline-item" matTooltip="Add Report">
+                      <a
+                        [routerLink]="['/online-course/student/report/add', element.studentId || element.id]"
+                        class="avatar avatar-xs text-muted"
+                      >
+                        <i class="ti ti-report f-18"></i>
+                      </a>
+                    </li>
+                  </ul>
+                </td>
+              </ng-container>
+              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+              <tr class="mat-row" *ngIf="dataSource.data.length === 0">
+                <td class="mat-cell" colspan="2">No students found</td>
+              </tr>
+            </table>
+          </div>
+        </div>
+      </div>
+    </app-card>
+  </div>
+</div>

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.scss
@@ -1,0 +1,1 @@
+/* Styles for course details */

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { MatTableDataSource } from '@angular/material/table';
+
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import { CircleDto, CircleService, CircleStudentDto } from 'src/app/@theme/services/circle.service';
+
+@Component({
+  selector: 'app-courses-details',
+  imports: [SharedModule, RouterModule],
+  templateUrl: './courses-details.component.html',
+  styleUrl: './courses-details.component.scss'
+})
+export class CoursesDetailsComponent implements OnInit {
+  private circleService = inject(CircleService);
+  private route = inject(ActivatedRoute);
+
+  course?: CircleDto;
+  displayedColumns: string[] = ['fullName', 'action'];
+  dataSource = new MatTableDataSource<CircleStudentDto>();
+
+  ngOnInit() {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    if (id) {
+      this.circleService.get(id).subscribe((res) => {
+        if (res.isSuccess && res.data) {
+          this.course = res.data;
+          this.dataSource.data = res.data.students || [];
+        }
+      });
+    }
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-routing.module.ts
@@ -12,21 +12,34 @@ const routes: Routes = [
       {
         path: 'view',
         loadComponent: () => import('./courses-view/courses-view.component').then((c) => c.CoursesViewComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
+      },
+      {
+        path: 'details/:id',
+        loadComponent: () => import('./courses-details/courses-details.component').then((c) => c.CoursesDetailsComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       },
       {
         path: 'add',
         loadComponent: () => import('./courses-add/courses-add.component').then((c) => c.CoursesAddComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       },
       {
         path: 'edit/:id',
         loadComponent: () => import('./courses-update/courses-update.component').then((c) => c.CoursesUpdateComponent),
-        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       }
-      ]
-    }
-  ];
+    ]
+  }
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
@@ -35,20 +35,23 @@
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
                   {{ displayManagers(element.managers) }}
                 </td>
-
               </ng-container>
               <ng-container matColumnDef="action">
                 <th mat-header-cell *matHeaderCellDef class="text-center">ACTIONS</th>
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
                   <div class="text-center text-nowrap">
                     <ul class="list-inline p-l-0">
+                      <li class="list-inline-item m-r-10" matTooltip="View">
+                        <a [routerLink]="['/online-course/courses/details', element.id]" class="avatar avatar-xs text-muted">
+                          <i class="ti ti-eye f-18"></i>
+                        </a>
+                      </li>
                       <li class="list-inline-item m-r-10" matTooltip="Edit">
                         <a
                           [routerLink]="['/online-course/courses/edit', element.id]"
                           [state]="{ course: element }"
                           class="avatar avatar-xs text-muted"
                         >
-
                           <i class="ti ti-edit-circle f-18"></i>
                         </a>
                       </li>


### PR DESCRIPTION
## Summary
- add view icon on course list linking to detail view
- show course details with student list and report action
- wire routing for course detail page

## Testing
- `npm test` (fails: Cannot determine project or target for command.)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b940245dac8322a5ae078f4bcffd32