### PR TITLE
feat: add circle report creation page

### DIFF
--- a/src/app/@theme/services/circle-report.service.ts
+++ b/src/app/@theme/services/circle-report.service.ts
@@ -1,0 +1,83 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import {
+  ApiResponse,
+  FilteredResultRequestDto,
+  LookUpUserDto,
+  PagedResultDto,
+} from './lookup.service';
+
+export interface CircleReportAddDto {
+  id?: number;
+  minutes?: number;
+  newId?: number;
+  newFrom?: string;
+  newTo?: string;
+  newRate?: string;
+  recentPast?: string;
+  recentPastRate?: string;
+  distantPast?: string;
+  distantPastRate?: string;
+  farthestPast?: string;
+  farthestPastRate?: string;
+  theWordsQuranStranger?: string;
+  intonation?: string;
+  other?: string;
+  creationTime: Date;
+  circleId?: number;
+  studentId?: number;
+  teacherId?: number;
+  attendStatueId?: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CircleReportService {
+  private http = inject(HttpClient);
+
+  create(model: CircleReportAddDto): Observable<ApiResponse<boolean>> {
+    return this.http.post<ApiResponse<boolean>>(
+      `${environment.apiUrl}/api/CircleReport/Create`,
+      model
+    );
+  }
+
+  getUsersForGroup(
+    filter: FilteredResultRequestDto,
+    userTypeId: number,
+    teacherId: number
+  ): Observable<ApiResponse<PagedResultDto<LookUpUserDto>>> {
+    let params = new HttpParams()
+      .set('UserTypeId', userTypeId.toString())
+      .set('teacherId', teacherId.toString());
+
+    if (filter.skipCount !== undefined) {
+      params = params.set('SkipCount', filter.skipCount.toString());
+    }
+    if (filter.maxResultCount !== undefined) {
+      params = params.set('MaxResultCount', filter.maxResultCount.toString());
+    }
+    if (filter.searchTerm) {
+      params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (filter.filter) {
+      params = params.set('Filter', filter.filter);
+    }
+    if (filter.lang) {
+      params = params.set('Lang', filter.lang);
+    }
+    if (filter.sortingDirection) {
+      params = params.set('SortingDirection', filter.sortingDirection);
+    }
+    if (filter.sortBy) {
+      params = params.set('SortBy', filter.sortBy);
+    }
+
+    return this.http.get<ApiResponse<PagedResultDto<LookUpUserDto>>>(
+      `${environment.apiUrl}/api/UsersForGroups/ManagerRequestTeacherAndStudent`,
+      { params }
+    );
+  }
+}
+

--- a/src/app/demo/pages/admin-panel/online-courses/online-courses-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/online-courses-routing.module.ts
@@ -44,6 +44,11 @@ const routes: Routes = [
         data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
       },
       {
+        path: 'report/add',
+        loadComponent: () => import('./report/report-add/report-add.component').then((c) => c.ReportAddComponent),
+        data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }
+      },
+      {
         path: 'setting',
         loadChildren: () => import('./setting/setting.module').then((m) => m.SettingModule),
         data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager,UserTypesEnum.BranchLeader,UserTypesEnum.Student,UserTypesEnum.Teacher] }

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.html
@@ -1,0 +1,134 @@
+<div class="row">
+  <div class="col-12">
+    <app-card cardTitle="Add Circle Report">
+      <form [formGroup]="reportForm" (ngSubmit)="onSubmit()" class="row">
+        <div class="col-md-6" *ngIf="role === UserTypesEnum.Manager">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Teacher</mat-label>
+            <mat-select (selectionChange)="onTeacherChange($event.value)">
+              <mat-option *ngFor="let t of teachers" [value]="t.id">{{ t.fullName }}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Student</mat-label>
+            <mat-select formControlName="studentId">
+              <mat-option *ngFor="let s of students" [value]="s.id">{{ s.fullName }}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Minutes</mat-label>
+            <input matInput type="number" formControlName="minutes" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Circle Id</mat-label>
+            <input matInput type="number" formControlName="circleId" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Attend Statue Id</mat-label>
+            <input matInput type="number" formControlName="attendStatueId" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>New From</mat-label>
+            <input matInput formControlName="newFrom" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>New To</mat-label>
+            <input matInput formControlName="newTo" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>New Rate</mat-label>
+            <input matInput formControlName="newRate" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Recent Past</mat-label>
+            <input matInput formControlName="recentPast" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Recent Past Rate</mat-label>
+            <input matInput formControlName="recentPastRate" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Distant Past</mat-label>
+            <input matInput formControlName="distantPast" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Distant Past Rate</mat-label>
+            <input matInput formControlName="distantPastRate" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Farthest Past</mat-label>
+            <input matInput formControlName="farthestPast" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Farthest Past Rate</mat-label>
+            <input matInput formControlName="farthestPastRate" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>The Words Quran Stranger</mat-label>
+            <input matInput formControlName="theWordsQuranStranger" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Intonation</mat-label>
+            <input matInput formControlName="intonation" />
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-12">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Other</mat-label>
+            <textarea matInput formControlName="other"></textarea>
+          </mat-form-field>
+        </div>
+
+        <div class="col-12">
+          <button mat-flat-button color="primary" type="submit">Create</button>
+        </div>
+      </form>
+    </app-card>
+  </div>
+</div>

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
@@ -1,0 +1,110 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import {
+  CircleReportService,
+  CircleReportAddDto,
+} from 'src/app/@theme/services/circle-report.service';
+import { LookUpUserDto } from 'src/app/@theme/services/lookup.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+
+@Component({
+  selector: 'app-report-add',
+  imports: [CommonModule, SharedModule],
+  templateUrl: './report-add.component.html',
+  styleUrl: './report-add.component.scss'
+})
+export class ReportAddComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private service = inject(CircleReportService);
+  private toast = inject(ToastService);
+  private auth = inject(AuthenticationService);
+
+  reportForm!: FormGroup;
+  teachers: LookUpUserDto[] = [];
+  students: LookUpUserDto[] = [];
+  role = this.auth.getRole();
+  UserTypesEnum = UserTypesEnum;
+
+  ngOnInit(): void {
+    this.reportForm = this.fb.group({
+      minutes: [],
+      newId: [],
+      newFrom: [''],
+      newTo: [''],
+      newRate: [''],
+      recentPast: [''],
+      recentPastRate: [''],
+      distantPast: [''],
+      distantPastRate: [''],
+      farthestPast: [''],
+      farthestPastRate: [''],
+      theWordsQuranStranger: [''],
+      intonation: [''],
+      other: [''],
+      creationTime: [new Date(), Validators.required],
+      circleId: [],
+      studentId: [null, Validators.required],
+      teacherId: [null],
+      attendStatueId: []
+    });
+
+    if (this.role === UserTypesEnum.Manager) {
+      this.loadTeachers();
+    } else if (this.role === UserTypesEnum.Teacher) {
+      const current = this.auth.currentUserValue;
+      const teacherId = current ? Number(current.user.id) : 0;
+      this.reportForm.get('teacherId')?.setValue(teacherId);
+      this.loadStudents(teacherId);
+    }
+  }
+
+  loadTeachers() {
+    this.service
+      .getUsersForGroup({ skipCount: 0, maxResultCount: 100 }, Number(UserTypesEnum.Teacher), 0)
+      .subscribe((res) => {
+        if (res.isSuccess) {
+          this.teachers = res.data.items;
+        }
+      });
+  }
+
+  onTeacherChange(id: number) {
+    this.reportForm.get('teacherId')?.setValue(id);
+    this.loadStudents(id);
+  }
+
+  loadStudents(teacherId: number) {
+    this.service
+      .getUsersForGroup({ skipCount: 0, maxResultCount: 100 }, Number(UserTypesEnum.Student), teacherId)
+      .subscribe((res) => {
+        if (res.isSuccess) {
+          this.students = res.data.items;
+        }
+      });
+  }
+
+  onSubmit() {
+    if (this.reportForm.invalid) {
+      this.reportForm.markAllAsTouched();
+      return;
+    }
+    const model: CircleReportAddDto = this.reportForm.value;
+    this.service.create(model).subscribe({
+      next: (res) => {
+        if (res.isSuccess) {
+          this.toast.success('Report created successfully');
+          this.reportForm.reset();
+        } else {
+          res.errors.forEach((e) => this.toast.error(e.message));
+        }
+      },
+      error: () => this.toast.error('Error creating report')
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add CircleReportService for creating reports and fetching teachers/students
- add report creation component with teacher & student selection
- wire up report add route in online courses module

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68b971d83860832291512f28f11fa539