### PR TITLE
Use UsersForGroups endpoint for user selects

### DIFF
--- a/src/app/@theme/services/lookup.service.ts
+++ b/src/app/@theme/services/lookup.service.ts
@@ -59,7 +59,7 @@ export interface GovernorateDto {
 export class LookupService {
   private http = inject(HttpClient);
 
-  getUsersByUserType(
+  getUsersForSelects(
     filter: FilteredResultRequestDto,
     userTypeId: number
   ): Observable<ApiResponse<PagedResultDto<LookUpUserDto>>> {
@@ -87,7 +87,7 @@ export class LookupService {
     }
 
     return this.http.get<ApiResponse<PagedResultDto<LookUpUserDto>>>(
-      `${environment.apiUrl}/api/LookUp/GetUsersByUserType`,
+      `${environment.apiUrl}/api/UsersForGroups/GetUsersForSelects`,
       { params }
     );
   }

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
@@ -44,17 +44,17 @@ export class CoursesAddComponent implements OnInit {
 
     const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
     this.lookup
-      .getUsersByUserType(filter, Number(UserTypesEnum.Teacher))
+      .getUsersForSelects(filter, Number(UserTypesEnum.Teacher))
       .subscribe((res) => {
         if (res.isSuccess) this.teachers = res.data.items;
       });
     this.lookup
-      .getUsersByUserType(filter, Number(UserTypesEnum.Manager))
+      .getUsersForSelects(filter, Number(UserTypesEnum.Manager))
       .subscribe((res) => {
         if (res.isSuccess) this.managers = res.data.items;
       });
     this.lookup
-      .getUsersByUserType(filter, Number(UserTypesEnum.Student))
+      .getUsersForSelects(filter, Number(UserTypesEnum.Student))
       .subscribe((res) => {
         if (res.isSuccess) this.students = res.data.items;
       });

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
@@ -62,12 +62,12 @@ export class CoursesUpdateComponent implements OnInit {
     }
 
     this.lookup
-      .getUsersByUserType(filter, Number(UserTypesEnum.Teacher))
+      .getUsersForSelects(filter, Number(UserTypesEnum.Teacher))
       .subscribe((res) => {
         if (res.isSuccess) this.teachers = res.data.items;
       });
     this.lookup
-      .getUsersByUserType(filter, Number(UserTypesEnum.Manager))
+      .getUsersForSelects(filter, Number(UserTypesEnum.Manager))
       .subscribe((res) => {
         if (res.isSuccess) {
           const existing = new Map(this.managers.map((m) => [m.id, m]));
@@ -76,7 +76,7 @@ export class CoursesUpdateComponent implements OnInit {
         }
       });
     this.lookup
-      .getUsersByUserType(filter, Number(UserTypesEnum.Student))
+      .getUsersForSelects(filter, Number(UserTypesEnum.Student))
       .subscribe((res) => {
         if (res.isSuccess) {
           const existing = new Map(this.students.map((s) => [s.id, s]));

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.ts
@@ -50,7 +50,7 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
 
   private loadManagers() {
     this.lookupService
-      .getUsersByUserType(this.filter, Number(UserTypesEnum.Manager))
+      .getUsersForSelects(this.filter, Number(UserTypesEnum.Manager))
       .subscribe((res) => {
         if (res.isSuccess && res.data?.items) {
           this.dataSource.data = res.data.items;

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
@@ -50,7 +50,7 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
 
   private loadStudents() {
     this.lookupService
-      .getUsersByUserType(this.filter, Number(UserTypesEnum.Student))
+      .getUsersForSelects(this.filter, Number(UserTypesEnum.Student))
       .subscribe((res) => {
         if (res.isSuccess && res.data?.items) {
           this.dataSource.data = res.data.items;

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
@@ -50,7 +50,7 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
 
   private loadTeachers() {
     this.lookupService
-      .getUsersByUserType(this.filter, Number(UserTypesEnum.Teacher))
+      .getUsersForSelects(this.filter, Number(UserTypesEnum.Teacher))
       .subscribe((res) => {
         if (res.isSuccess && res.data?.items) {
           this.dataSource.data = res.data.items;


### PR DESCRIPTION
## Summary
- replace user lookup API with UsersForGroups/GetUsersForSelects
- update student/manager/teacher lists and circle forms to use new lookup

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*


------
https://chatgpt.com/codex/tasks/task_e_68bbfbe068b08322a9a4bf8b7c11a95f