### PR TITLE
Connect list pages to GetUsersForSelects endpoint

### DIFF
--- a/src/app/@theme/services/lookup.service.ts
+++ b/src/app/@theme/services/lookup.service.ts
@@ -61,9 +61,16 @@ export class LookupService {
 
   getUsersForSelects(
     filter: FilteredResultRequestDto,
-    userTypeId: number
+    userTypeId: number,
+    managerId = 0,
+    teacherId = 0,
+    branchId = 0
   ): Observable<ApiResponse<PagedResultDto<LookUpUserDto>>> {
-    let params = new HttpParams().set('UserTypeId', userTypeId.toString());
+    let params = new HttpParams()
+      .set('UserTypeId', userTypeId.toString())
+      .set('managerId', managerId.toString())
+      .set('teacherId', teacherId.toString())
+      .set('branchId', branchId.toString());
     if (filter.skipCount !== undefined) {
       params = params.set('SkipCount', filter.skipCount.toString());
     }

--- a/src/app/demo/pages/admin-panel/online-courses/branch-manager/branch-manager-list/branch-manager-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/branch-manager/branch-manager-list/branch-manager-list.component.ts
@@ -44,7 +44,15 @@ export class BranchManagerListComponent implements OnInit, AfterViewInit {
   }
 
   private loadBranchManagers() {
-    this.lookupService.getUsersForSelects(this.filter, Number(UserTypesEnum.BranchLeader)).subscribe((res) => {
+    this.lookupService
+      .getUsersForSelects(
+        this.filter,
+        Number(UserTypesEnum.BranchLeader),
+        0,
+        0,
+        0
+      )
+      .subscribe((res) => {
       if (res.isSuccess && res.data?.items) {
         this.dataSource.data = res.data.items;
         this.totalCount = res.data.totalCount;

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.ts
@@ -50,7 +50,13 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
 
   private loadManagers() {
     this.lookupService
-      .getUsersForSelects(this.filter, Number(UserTypesEnum.Manager))
+      .getUsersForSelects(
+        this.filter,
+        Number(UserTypesEnum.Manager),
+        0,
+        0,
+        0
+      )
       .subscribe((res) => {
         if (res.isSuccess && res.data?.items) {
           this.dataSource.data = res.data.items;

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
@@ -50,7 +50,13 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
 
   private loadStudents() {
     this.lookupService
-      .getUsersForSelects(this.filter, Number(UserTypesEnum.Student))
+      .getUsersForSelects(
+        this.filter,
+        Number(UserTypesEnum.Student),
+        0,
+        0,
+        0
+      )
       .subscribe((res) => {
         if (res.isSuccess && res.data?.items) {
           this.dataSource.data = res.data.items;

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
@@ -50,7 +50,13 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
 
   private loadTeachers() {
     this.lookupService
-      .getUsersForSelects(this.filter, Number(UserTypesEnum.Teacher))
+      .getUsersForSelects(
+        this.filter,
+        Number(UserTypesEnum.Teacher),
+        0,
+        0,
+        0
+      )
       .subscribe((res) => {
         if (res.isSuccess && res.data?.items) {
           this.dataSource.data = res.data.items;


### PR DESCRIPTION
## Summary
- extend lookup service to pass manager, teacher and branch IDs to GetUsersForSelects API
- update manager, teacher, student and branch manager list pages to use new parameters

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1f04b88c832294136e2b4376fb99