### PR TITLE
feat(manager): allow assigning teachers and students

### DIFF
--- a/src/app/@theme/services/user.service.ts
+++ b/src/app/@theme/services/user.service.ts
@@ -24,6 +24,8 @@ export interface UpdateUserDto {
   nationalityId?: number;
   governorateId?: number;
   branchId?: number;
+  teacherIds?: number[];
+  studentIds?: number[];
 }
 
 // Generic API response interfaces

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -105,6 +105,24 @@
               }
             </mat-form-field>
           </div>
+          @if (isManager) {
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Teachers</mat-label>
+                <mat-select formControlName="teacherIds" multiple appOpenSelectOnType>
+                  <mat-option *ngFor="let t of teachers" [value]="t.id">{{ t.fullName }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Students</mat-label>
+                <mat-select formControlName="studentIds" multiple appOpenSelectOnType>
+                  <mat-option *ngFor="let s of students" [value]="s.id">{{ s.fullName }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+          }
           <div class="col-md-12 text-end">
             <button mat-flat-button color="primary" [disabled]="basicInfoForm.invalid">Update</button>
           </div>


### PR DESCRIPTION
## Summary
- support teacher and student assignment when updating managers
- fetch available teachers and students via GetUsersForSelects endpoint

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68bc24de8d3c8322be34cebbf00626e9