### PR TITLE
Allow all users to access content

### DIFF
--- a/src/app/@theme/helpers/auth.guard.ts
+++ b/src/app/@theme/helpers/auth.guard.ts
@@ -9,31 +9,20 @@ export class AuthGuardChild implements CanActivateChild {
   private authenticationService = inject(AuthenticationService);
 
   /**
-   * Determines whether a child route can be activated based on user authentication and authorization.
+   * Determines whether a child route can be activated based on user authentication.
    *
-   * @param route - The activated route snapshot that contains the route configuration and parameters.
+   * @param _route - The activated route snapshot (unused).
    * @param state - The router state snapshot that contains the current router state.
-   * @returns A boolean indicating whether the route can be activated. Redirects to an appropriate page if not.
-   *
-   * If the user is logged in and their role is authorized for the route, returns true.
-   * If the user is logged in but not authorized, redirects to the unauthorized page and returns false.
-   * If the user is not logged in, redirects to the login page with the return URL and returns false.
+   * @returns True if the user is logged in; otherwise, redirects to the login page.
    */
 
-  canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | UrlTree {
-    const userRole = this.authenticationService.getRole();
-
-    if (userRole && this.authenticationService.isLoggedIn()) {
-      const { roles } = route.data;
-      if (roles && !roles.includes(userRole)) {
-        // User not authorized, redirect to unauthorized page
-        return this.router.parseUrl('/unauthorized');
-      }
-      // User is logged in and authorized for child routes
+  canActivateChild(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | UrlTree {
+    if (this.authenticationService.isLoggedIn()) {
+      // User is logged in; allow access regardless of role
       return true;
     }
 
-    // User not logged in or role unavailable, redirect to login page
+    // User not logged in, redirect to login page
     return this.router.createUrlTree(['/login'], { queryParams: { returnUrl: state.url } });
   }
 }

--- a/src/app/@theme/layouts/menu/compact-menu/menu-collapse/menu-collapse.component.ts
+++ b/src/app/@theme/layouts/menu/compact-menu/menu-collapse/menu-collapse.component.ts
@@ -8,7 +8,6 @@ import { CommonModule, Location } from '@angular/common';
 import { NavigationItem } from 'src/app/@theme/types/navigation';
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { MenuItemCompactComponent } from '../menu-item/menu-item.component';
-import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 
 @Component({
   selector: 'app-menu-collapse-compact',
@@ -27,7 +26,6 @@ import { AuthenticationService } from 'src/app/@theme/services/authentication.se
 })
 export class MenuCollapseCompactComponent implements OnInit {
   private location = inject(Location);
-  private authenticationService = inject(AuthenticationService);
 
   // public props
   current_url: string = ''; // Add current URL property
@@ -65,31 +63,8 @@ export class MenuCollapseCompactComponent implements OnInit {
       });
     }, 0);
 
-    /**
-     * current login user role
-     */
-    const currentUserRole = this.authenticationService.currentUserValue?.user.role;
-
-    /**
-     * items parent role
-     */
-    const parentRoleValue = this.parentRole();
-
-    if (this.item()!.role && this.item()!.role!.length > 0) {
-      if (currentUserRole) {
-        const parentRole = this.parentRole();
-        const allowedFromParent =
-          this.item()!.isMainParent || (parentRole && parentRole.length > 0 && parentRole.includes(currentUserRole));
-        if (allowedFromParent) {
-          this.isEnabled = this.item()!.role!.includes(currentUserRole);
-        }
-      }
-    } else if (parentRoleValue && parentRoleValue.length > 0) {
-      // If item.role is empty, check parentRole
-      if (currentUserRole) {
-        this.isEnabled = parentRoleValue.includes(currentUserRole);
-      }
-    }
+    // Enable all menu items regardless of user role
+    this.isEnabled = true;
   }
 
   // Method to handle the collapse of the navigation menu

--- a/src/app/@theme/layouts/menu/compact-menu/menu-item/menu-item.component.ts
+++ b/src/app/@theme/layouts/menu/compact-menu/menu-item/menu-item.component.ts
@@ -7,7 +7,6 @@ import { CommonModule } from '@angular/common';
 import { NavigationItem } from 'src/app/@theme/types/navigation';
 import { ThemeLayoutService } from 'src/app/@theme/services/theme-layout.service';
 import { SharedModule } from 'src/app/demo/shared/shared.module';
-import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 
 @Component({
   selector: 'app-menu-item-compact',
@@ -17,7 +16,6 @@ import { AuthenticationService } from 'src/app/@theme/services/authentication.se
 })
 export class MenuItemCompactComponent implements OnInit {
   private themeService = inject(ThemeLayoutService);
-  private authenticationService = inject(AuthenticationService);
 
   // public props
   readonly item = input.required<NavigationItem>();
@@ -27,35 +25,8 @@ export class MenuItemCompactComponent implements OnInit {
 
   //life cycle hook
   ngOnInit() {
-    /**
-     * current login user role
-     */
-    const CurrentUserRole = this.authenticationService.currentUserValue?.user.role;
-
-    /**
-     * menu items
-     */
-    const item = this.item();
-
-    /**
-     * items parent role
-     */
-    const parentRoleValue = this.parentRole();
-
-    if (item.role && item.role.length > 0) {
-      if (CurrentUserRole) {
-        const parentRole = this.parentRole();
-        const allowedFromParent = item.isMainParent || (parentRole && parentRole.length > 0 && parentRole.includes(CurrentUserRole));
-        if (allowedFromParent) {
-          this.isEnabled = item.role.includes(CurrentUserRole);
-        }
-      }
-    } else if (parentRoleValue && parentRoleValue.length > 0) {
-      // If item.role is empty, check parentRole
-      if (CurrentUserRole) {
-        this.isEnabled = parentRoleValue.includes(CurrentUserRole);
-      }
-    }
+    // Enable all menu items regardless of user role
+    this.isEnabled = true;
   }
 
   // public method

--- a/src/app/@theme/layouts/menu/vertical-menu/menu-collapse/menu-collapse.component.ts
+++ b/src/app/@theme/layouts/menu/vertical-menu/menu-collapse/menu-collapse.component.ts
@@ -8,8 +8,6 @@ import { animate, style, transition, trigger } from '@angular/animations';
 import { NavigationItem } from 'src/app/@theme/types/navigation';
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { MenuItemVerticalComponent } from '../menu-item/menu-item.component';
-import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
-import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 
 @Component({
   selector: 'app-menu-collapse',
@@ -28,7 +26,6 @@ import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 })
 export class MenuCollapseComponent implements OnInit {
   private location = inject(Location);
-  private authenticationService = inject(AuthenticationService);
 
   // public props
   current_url: string = ''; // Add current URL property
@@ -66,31 +63,8 @@ export class MenuCollapseComponent implements OnInit {
       });
     }, 0);
 
-    /**
-     * current login user role
-     */
-    const currentUserRole = this.authenticationService.currentUserValue?.user.role || UserTypesEnum.Admin;
-
-    /**
-     * items parent role
-     */
-    const parentRoleValue = this.parentRole();
-
-    if (this.item()!.role && this.item()!.role!.length > 0) {
-      if (currentUserRole) {
-        const parentRole = this.parentRole();
-        const allowedFromParent =
-          this.item()!.isMainParent || (parentRole && parentRole.length > 0 && parentRole.includes(currentUserRole));
-        if (allowedFromParent) {
-          this.isEnabled = this.item()!.role!.includes(currentUserRole);
-        }
-      }
-    } else if (parentRoleValue && parentRoleValue.length > 0) {
-      // If item.role is empty, check parentRole
-      if (currentUserRole) {
-        this.isEnabled = parentRoleValue.includes(currentUserRole);
-      }
-    }
+    // Enable all menu items regardless of user role
+    this.isEnabled = true;
   }
 
   // Method to handle the collapse of the navigation menu

--- a/src/app/@theme/layouts/menu/vertical-menu/menu-item/menu-item.component.ts
+++ b/src/app/@theme/layouts/menu/vertical-menu/menu-item/menu-item.component.ts
@@ -7,8 +7,6 @@ import { CommonModule } from '@angular/common';
 import { NavigationItem } from 'src/app/@theme/types/navigation';
 import { ThemeLayoutService } from 'src/app/@theme/services/theme-layout.service';
 import { SharedModule } from 'src/app/demo/shared/shared.module';
-import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
-import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 
 @Component({
   selector: 'app-menu-item',
@@ -18,7 +16,6 @@ import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 })
 export class MenuItemVerticalComponent implements OnInit {
   private themeService = inject(ThemeLayoutService);
-  private authenticationService = inject(AuthenticationService);
 
   // public props
   readonly item = input.required<NavigationItem>();
@@ -28,35 +25,8 @@ export class MenuItemVerticalComponent implements OnInit {
 
   //life cycle hook
   ngOnInit() {
-    /**
-     * current login user role
-     */
-    const CurrentUserRole = this.authenticationService.currentUserValue?.user.role || UserTypesEnum.Admin;
-
-    /**
-     * menu items
-     */
-    const item = this.item();
-
-    /**
-     * items parent role
-     */
-    const parentRoleValue = this.parentRole();
-
-    if (item.role && item.role.length > 0) {
-      if (CurrentUserRole) {
-        const parentRole = this.parentRole();
-        const allowedFromParent = item.isMainParent || (parentRole && parentRole.length > 0 && parentRole.includes(CurrentUserRole));
-        if (allowedFromParent) {
-          this.isEnabled = item.role.includes(CurrentUserRole);
-        }
-      }
-    } else if (parentRoleValue && parentRoleValue.length > 0) {
-      // If item.role is empty, check parentRole
-      if (CurrentUserRole) {
-        this.isEnabled = parentRoleValue.includes(CurrentUserRole);
-      }
-    }
+    // Enable all menu items regardless of user role
+    this.isEnabled = true;
   }
 
   // public method


### PR DESCRIPTION
## Summary
- Relax child route guard to allow any logged-in user regardless of role.
- Remove role-based checks from menu components so every user sees all menu items.

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc31dc33388322b8cbdebb40149d73