### PR TITLE
Prefill related users when editing managers

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
@@ -37,7 +37,11 @@ export class UserEditComponent implements OnInit {
 
   basicInfoForm!: FormGroup;
   userId!: number;
-  currentUser?: LookUpUserDto;
+  currentUser?: LookUpUserDto & {
+    teachers?: LookUpUserDto[];
+    students?: LookUpUserDto[];
+    managers?: LookUpUserDto[];
+  };
   nationalities: NationalityDto[] = [];
   governorates: GovernorateDto[] = [];
   countries: Country[] = [];
@@ -87,7 +91,7 @@ export class UserEditComponent implements OnInit {
       }
     });
 
-    this.currentUser = history.state['user'] as LookUpUserDto | undefined;
+    this.currentUser = history.state['user'] as typeof this.currentUser;
     if (this.currentUser) {
       this.userId = this.currentUser.id;
       const clean = (phone: string) => phone.replace(/\D/g, '');
@@ -103,6 +107,20 @@ export class UserEditComponent implements OnInit {
         branchId: this.currentUser.branchId
       });
       if (this.isManager) {
+        const teacherList =
+          this.currentUser.teachers ?? this.currentUser.managers ?? [];
+        if (teacherList.length) {
+          this.teachers = teacherList;
+          this.basicInfoForm.patchValue({
+            teacherIds: teacherList.map((t) => t.id)
+          });
+        }
+        if (this.currentUser.students?.length) {
+          this.students = this.currentUser.students;
+          this.basicInfoForm.patchValue({
+            studentIds: this.currentUser.students.map((s) => s.id)
+          });
+        }
         this.loadRelatedUsers();
       }
     }
@@ -147,26 +165,30 @@ export class UserEditComponent implements OnInit {
       .getUsersForSelects(
         filter,
         Number(UserTypesEnum.Teacher),
-        this.userId,
+        0,
         0,
         this.currentUser?.branchId || 0
       )
       .subscribe((res) => {
         if (res.isSuccess) {
-          this.teachers = res.data.items;
+          const existing = new Map(this.teachers.map((t) => [t.id, t]));
+          res.data.items.forEach((t) => existing.set(t.id, t));
+          this.teachers = Array.from(existing.values());
         }
       });
     this.lookupService
       .getUsersForSelects(
         filter,
         Number(UserTypesEnum.Student),
-        this.userId,
+        0,
         0,
         this.currentUser?.branchId || 0
       )
       .subscribe((res) => {
         if (res.isSuccess) {
-          this.students = res.data.items;
+          const existing = new Map(this.students.map((s) => [s.id, s]));
+          res.data.items.forEach((s) => existing.set(s.id, s));
+          this.students = Array.from(existing.values());
         }
       });
   }


### PR DESCRIPTION
## Summary
- preselect manager's teachers and students in edit form
- merge existing relations with fetched users so previous associations are visible
- fetch full branch teacher and student lists without filtering by manager

## Testing
- `npx ng test able-pro` *(fails: Project target does not exist)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc37a2db048322975d7d71f25a554c