### PR TITLE
feat: add manager details view

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.html
@@ -1,0 +1,20 @@
+<div class="row p-t-25">
+  <div class="col-12">
+    <app-card cardTitle="Manager Details" padding="0" cardClass="sm-block">
+      <div class="p-15" *ngIf="manager as m">
+        <h5 class="m-b-10">{{ m.fullName }}</h5>
+        <p class="details-item"><strong>Email:</strong> {{ m.email }}</p>
+        <p class="details-item"><strong>Mobile:</strong> {{ m.mobile }}</p>
+        <p class="details-item" *ngIf="m.secondMobile"><strong>Second Mobile:</strong> {{ m.secondMobile }}</p>
+        <p class="details-item"><strong>Nationality:</strong> {{ m.nationality }}</p>
+        <p class="details-item"><strong>Governorate:</strong> {{ m.governorate }}</p>
+        <p class="details-item"><strong>Branch:</strong> {{ getBranchLabel(m.branchId) }}</p>
+      </div>
+      <div class="p-15">
+        <button mat-stroked-button color="primary" [routerLink]="['/online-course/manager/list']">
+          Back to list
+        </button>
+      </div>
+    </app-card>
+  </div>
+</div>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.scss
@@ -1,0 +1,3 @@
+.details-item {
+  margin-bottom: 8px;
+}

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import { LookUpUserDto } from 'src/app/@theme/services/lookup.service';
+import { BranchesEnum } from 'src/app/@theme/types/branchesEnum';
+
+@Component({
+  selector: 'app-manager-details',
+  imports: [CommonModule, SharedModule, RouterModule],
+  templateUrl: './manager-details.component.html',
+  styleUrl: './manager-details.component.scss'
+})
+export class ManagerDetailsComponent implements OnInit {
+  manager?: LookUpUserDto;
+
+  Branch = [
+    { id: BranchesEnum.Mens, label: 'الرجال' },
+    { id: BranchesEnum.Women, label: 'النساء' }
+  ];
+
+  ngOnInit() {
+    const user = history.state['user'] as LookUpUserDto | undefined;
+    if (user) {
+      this.manager = user;
+    }
+  }
+
+  getBranchLabel(id: number | undefined): string {
+    return this.Branch.find((b) => b.id === id)?.label || String(id ?? '');
+  }
+}
+

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.html
@@ -54,7 +54,11 @@
                   <div class="text-center text-nowrap">
                     <ul class="list-inline p-l-0">
                       <li class="list-inline-item m-r-10" matTooltip="View">
-                        <a href="javascript:" class="avatar avatar-xs text-muted">
+                        <a
+                          [routerLink]="['/online-course/manager/details', element.id]"
+                          [state]="{ user: element }"
+                          class="avatar avatar-xs text-muted"
+                        >
                           <i class="ti ti-eye f-18"></i>
                         </a>
                       </li>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-routing.module.ts
@@ -31,6 +31,13 @@ const routes: Routes = [
         }
       },
       {
+        path: 'details/:id',
+        loadComponent: () => import('./manager-details/manager-details.component').then((c) => c.ManagerDetailsComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
+      },
+      {
         path: 'apply',
         loadComponent: () => import('./manager-apply/manager-apply.component').then((c) => c.ManagerApplyComponent),
         data: {


### PR DESCRIPTION
## Summary
- add standalone ManagerDetailsComponent to display manager info
- wire view action in manager list to details page
- register new route for manager detail page

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd308d0cf883228733ade4358c9d81