### PR TITLE
feat: add manager details dialog

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.html
@@ -1,0 +1,65 @@
+<div class="manager-details-header" mat-dialog-title>
+  <div class="flex align-item-center justify-content-between">
+    <div class="f-w-700 f-16">Manager Details</div>
+    <button mat-icon-button class="avatar avatar-s modal-close" mat-dialog-close>
+      <i class="ti ti-x f-20"></i>
+    </button>
+  </div>
+</div>
+<mat-dialog-content class="p-0">
+  <app-scrollbar [customStyle]="{ height: 'calc(100vh - 155px)', position: 'relative' }">
+    <div class="details-wrapper" *ngIf="manager as m">
+      <div class="left-panel">
+        <div class="avatar avatar-xl m-b-10">
+          <i class="ti ti-user f-24"></i>
+        </div>
+        <h5 class="m-b-10">{{ m.fullName }}</h5>
+        <div class="contact-list">
+          <div class="contact-item" *ngFor="let c of contactEntries">
+            <i [class]="c.icon"></i>
+            <span class="contact-value">{{ c.value }}</span>
+          </div>
+        </div>
+      </div>
+      <div class="right-panel">
+        <section class="section" *ngIf="detailEntries.length">
+          <h6 class="section-title">Personal Details</h6>
+          <div class="detail-grid">
+            <div class="detail-item" *ngIf="m.branchId !== undefined">
+              <span class="label">Branch:</span>
+              <span>{{ getBranchLabel(m.branchId) }}</span>
+            </div>
+            <div class="detail-item" *ngFor="let entry of detailEntries">
+              <span class="label">{{ entry[0] | titlecase }}:</span>
+              <span>{{ formatValue(entry[0], entry[1]) }}</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="section" *ngIf="teachers.length">
+          <h6 class="section-title">Teachers</h6>
+          <div class="relation-item" *ngFor="let t of teachers">
+            <span class="relation-name">{{ t.fullName }}</span>
+            <span class="relation-phone">{{ t.mobile }}</span>
+          </div>
+        </section>
+
+        <section class="section" *ngIf="students.length">
+          <h6 class="section-title">Students</h6>
+          <div class="relation-item" *ngFor="let s of students">
+            <span class="relation-name">{{ s.fullName }}</span>
+            <span class="relation-phone">{{ s.mobile }}</span>
+          </div>
+        </section>
+
+        <section class="section" *ngIf="managerCircles.length">
+          <h6 class="section-title">Circles</h6>
+          <div class="relation-item" *ngFor="let c of managerCircles">
+            <span class="relation-name">{{ c.circle }}</span>
+            <span class="relation-phone">{{ c.circleId }}</span>
+          </div>
+        </section>
+      </div>
+    </div>
+  </app-scrollbar>
+</mat-dialog-content>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.scss
@@ -1,0 +1,115 @@
+.details-wrapper {
+  display: flex;
+  gap: 20px;
+}
+
+.left-panel {
+  flex: 0 0 220px;
+  text-align: center;
+  border-right: 1px solid var(--bs-border-color, #eee);
+  padding-right: 20px;
+}
+
+.contact-list {
+  margin-top: 15px;
+}
+
+.contact-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.contact-value {
+  direction: ltr;
+}
+
+.right-panel {
+  flex: 1;
+}
+
+.section {
+  margin-bottom: 20px;
+}
+
+.section-title {
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 8px;
+}
+
+.detail-item {
+  display: flex;
+  gap: 4px;
+}
+
+.detail-item .label {
+  font-weight: 700;
+}
+
+.relation-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.relation-name {
+  font-weight: 700;
+}
+
+:host-context([dir='rtl']) {
+  .details-wrapper {
+    flex-direction: row-reverse;
+    text-align: right;
+  }
+
+  .left-panel {
+    border-right: none;
+    border-left: 1px solid var(--bs-border-color, #eee);
+    padding-right: 0;
+    padding-left: 20px;
+  }
+
+  .right-panel {
+    text-align: right;
+  }
+
+  .detail-item,
+  .relation-item,
+  .contact-item {
+    flex-direction: row-reverse;
+    text-align: right;
+  }
+
+  .section-title {
+    text-align: right;
+  }
+}
+
+.relation-phone {
+  direction: ltr;
+}
+
+@media (max-width: 768px) {
+  .details-wrapper {
+    flex-direction: column;
+  }
+  .left-panel {
+    border-right: none;
+    border-bottom: 1px solid var(--bs-border-color, #eee);
+    padding-right: 0;
+    padding-bottom: 20px;
+  }
+  :host-context([dir='rtl']) .left-panel {
+    border-left: none;
+    padding-left: 0;
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-details/manager-details.component.ts
@@ -1,0 +1,93 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { BranchesEnum } from 'src/app/@theme/types/branchesEnum';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { NgxScrollbar } from 'src/app/@theme/components/ngx-scrollbar/ngx-scrollbar';
+
+interface Person {
+  fullName?: string;
+  mobile?: string;
+  [key: string]: unknown;
+}
+
+interface Circle {
+  circleId?: number;
+  circle?: string;
+  [key: string]: unknown;
+}
+
+interface ContactEntry {
+  key: string;
+  value: unknown;
+  icon: string;
+}
+
+@Component({
+  selector: 'app-manager-details',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, NgxScrollbar],
+  templateUrl: './manager-details.component.html',
+  styleUrl: './manager-details.component.scss'
+})
+export class ManagerDetailsComponent {
+  manager?: Record<string, unknown>;
+  teachers: Person[] = [];
+  students: Person[] = [];
+  managerCircles: Circle[] = [];
+  contactEntries: ContactEntry[] = [];
+  detailEntries: [string, unknown][] = [];
+
+  Branch = [
+    { id: BranchesEnum.Mens, label: 'الرجال' },
+    { id: BranchesEnum.Women, label: 'النساء' }
+  ];
+
+  constructor() {
+    const user = inject<Record<string, unknown>>(MAT_DIALOG_DATA);
+    if (user) {
+      this.manager = user;
+      const raw = user as Record<string, unknown>;
+      this.teachers = Array.isArray(raw['teachers']) ? (raw['teachers'] as Person[]) : [];
+      this.students = Array.isArray(raw['students']) ? (raw['students'] as Person[]) : [];
+      this.managerCircles = Array.isArray(raw['managerCircles'])
+        ? (raw['managerCircles'] as Circle[])
+        : [];
+
+      const contactKeys = ['email', 'mobile', 'secondMobile'];
+      this.contactEntries = contactKeys
+        .filter((k) => raw[k] !== undefined && raw[k] !== null)
+        .map((k) => ({ key: k, value: raw[k], icon: this.getContactIcon(k) }));
+
+      const exclude = ['fullName', 'teachers', 'students', 'managerCircles', ...contactKeys];
+      this.detailEntries = Object.entries(user).filter(
+        ([key, value]) =>
+          !exclude.includes(key) &&
+          !Array.isArray(value) &&
+          (typeof value !== 'object' || value === null)
+      );
+    }
+  }
+
+  getBranchLabel(id: number | undefined): string {
+    return this.Branch.find((b) => b.id === id)?.label || String(id ?? '');
+  }
+
+  formatValue(key: string, value: unknown): unknown {
+    if (key === 'branchId') {
+      return this.getBranchLabel(typeof value === 'number' ? value : undefined);
+    }
+    return value;
+  }
+
+  private getContactIcon(key: string): string {
+    const icons: Record<string, string> = {
+      email: 'ti ti-mail',
+      mobile: 'ti ti-phone',
+      secondMobile: 'ti ti-phone'
+    };
+    return icons[key] || 'ti ti-circle';
+  }
+}
+

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.html
@@ -53,7 +53,7 @@
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
                   <div class="text-center text-nowrap">
                     <ul class="list-inline p-l-0">
-                      <li class="list-inline-item m-r-10" matTooltip="View">
+                      <li class="list-inline-item m-r-10" matTooltip="View" (click)="managerDetails(element)">
                         <a href="javascript:" class="avatar avatar-xs text-muted">
                           <i class="ti ti-eye f-18"></i>
                         </a>

--- a/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/manager/manager-list/manager-list.component.ts
@@ -6,6 +6,7 @@ import { RouterModule } from '@angular/router';
 // angular material
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -15,15 +16,17 @@ import {
   FilteredResultRequestDto,
 } from 'src/app/@theme/services/lookup.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+import { ManagerDetailsComponent } from '../manager-details/manager-details.component';
 
 @Component({
   selector: 'app-manager-list',
-  imports: [CommonModule, SharedModule, RouterModule],
+  imports: [CommonModule, SharedModule, RouterModule, MatDialogModule],
   templateUrl: './manager-list.component.html',
   styleUrl: './manager-list.component.scss'
 })
 export class ManagerListComponent implements OnInit, AfterViewInit {
   private lookupService = inject(LookupService);
+  dialog = inject(MatDialog);
 
   // public props
   displayedColumns: string[] = ['fullName', 'email', 'mobile', 'nationality', 'action'];
@@ -66,6 +69,13 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
           this.totalCount = 0;
         }
       });
+  }
+
+  managerDetails(manager: LookUpUserDto): void {
+    this.dialog.open(ManagerDetailsComponent, {
+      width: '800px',
+      data: manager
+    });
   }
 
   // life cycle event


### PR DESCRIPTION
## Summary
- replace dedicated route with dialog-driven manager detail view
- open manager details modal from list and display all related data
- inject MAT_DIALOG_DATA within the dialog constructor to render selected manager information
- show only names and mobile numbers for associated teachers and students
- list each associated circle with its name and id in the manager details dialog
- organize modal content into sections for contact info, personal details, and related teachers, students, and circles
- support right-to-left layouts and bold section titles in the manager details dialog

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd308d0cf883228733ade4358c9d81