### PR TITLE
feat: add teacher and student details pages

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/student/student-details/student-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-details/student-details.component.html
@@ -1,0 +1,41 @@
+<div class="manager-details-header" mat-dialog-title>
+  <div class="flex align-item-center justify-content-between">
+    <div class="f-w-700 f-16">Student Details</div>
+    <button mat-icon-button class="avatar avatar-s modal-close" mat-dialog-close>
+      <i class="ti ti-x f-20"></i>
+    </button>
+  </div>
+</div>
+<mat-dialog-content class="p-0">
+  <app-scrollbar [customStyle]="{ height: 'calc(100vh - 155px)', position: 'relative' }">
+    <div class="details-wrapper" *ngIf="student as s">
+      <div class="left-panel">
+        <div class="avatar avatar-xl m-b-10">
+          <i class="ti ti-user f-24"></i>
+        </div>
+        <h5 class="m-b-10">{{ s.fullName }}</h5>
+        <div class="contact-list">
+          <div class="contact-item" *ngFor="let c of contactEntries">
+            <i [class]="c.icon"></i>
+            <span class="contact-value">{{ c.value }}</span>
+          </div>
+        </div>
+      </div>
+      <div class="right-panel">
+        <section class="section" *ngIf="detailEntries.length">
+          <h6 class="section-title">Personal Details</h6>
+          <div class="detail-grid">
+            <div class="detail-item" *ngIf="s.branchId !== undefined">
+              <span class="label">Branch:</span>
+              <span>{{ getBranchLabel(s.branchId) }}</span>
+            </div>
+            <div class="detail-item" *ngFor="let entry of detailEntries">
+              <span class="label">{{ entry[0] | titlecase }}:</span>
+              <span>{{ formatValue(entry[0], entry[1]) }}</span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </app-scrollbar>
+</mat-dialog-content>

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-details/student-details.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-details/student-details.component.scss
@@ -1,0 +1,120 @@
+.details-wrapper {
+  display: flex;
+  gap: 20px;
+}
+
+.left-panel {
+  flex: 0 0 220px;
+  text-align: center;
+  border-right: 1px solid var(--bs-border-color, #eee);
+  padding-right: 20px;
+}
+
+.contact-list {
+  margin-top: 15px;
+}
+
+.contact-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.contact-value {
+  direction: ltr;
+}
+
+.right-panel {
+  flex: 1;
+}
+
+.section {
+  margin-bottom: 20px;
+}
+
+.section-title {
+  font-weight: 700;
+
+  margin-bottom: 10px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 8px;
+}
+
+.detail-item {
+
+  display: flex;
+  gap: 4px;
+}
+
+.detail-item .label {
+  font-weight: 700;
+}
+
+
+.relation-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.relation-name {
+  font-weight: 700;
+}
+
+:host-context([dir='rtl']) {
+  .details-wrapper {
+    flex-direction: row-reverse;
+    text-align: right;
+  }
+
+  .left-panel {
+    border-right: none;
+    border-left: 1px solid var(--bs-border-color, #eee);
+    padding-right: 0;
+    padding-left: 20px;
+  }
+
+  .right-panel {
+    text-align: right;
+  }
+
+  .detail-item,
+  .relation-item,
+  .contact-item {
+    flex-direction: row-reverse;
+    text-align: right;
+  }
+
+  .section-title {
+    text-align: right;
+  }
+
+}
+
+.relation-phone {
+  direction: ltr;
+}
+
+@media (max-width: 768px) {
+  .details-wrapper {
+    flex-direction: column;
+  }
+  .left-panel {
+    border-right: none;
+    border-bottom: 1px solid var(--bs-border-color, #eee);
+    padding-right: 0;
+    padding-bottom: 20px;
+  }
+  :host-context([dir='rtl']) .left-panel {
+    border-left: none;
+    padding-left: 0;
+  }
+}
+

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-details/student-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-details/student-details.component.ts
@@ -1,0 +1,71 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { NgxScrollbar } from 'src/app/@theme/components/ngx-scrollbar/ngx-scrollbar';
+import { BranchesEnum } from 'src/app/@theme/types/branchesEnum';
+
+interface ContactEntry {
+  key: string;
+  value: unknown;
+  icon: string;
+}
+
+@Component({
+  selector: 'app-student-details',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, NgxScrollbar],
+  templateUrl: './student-details.component.html',
+  styleUrl: './student-details.component.scss'
+})
+export class StudentDetailsComponent {
+  student?: Record<string, unknown>;
+  contactEntries: ContactEntry[] = [];
+  detailEntries: [string, unknown][] = [];
+
+  Branch = [
+    { id: BranchesEnum.Mens, label: 'الرجال' },
+    { id: BranchesEnum.Women, label: 'النساء' }
+  ];
+
+  constructor() {
+    const user = inject<Record<string, unknown>>(MAT_DIALOG_DATA);
+    if (user) {
+      this.student = user;
+      const raw = user as Record<string, unknown>;
+
+      const contactKeys = ['email', 'mobile', 'secondMobile'];
+      this.contactEntries = contactKeys
+        .filter((k) => raw[k] !== undefined && raw[k] !== null)
+        .map((k) => ({ key: k, value: raw[k], icon: this.getContactIcon(k) }));
+
+      const exclude = ['fullName', ...contactKeys];
+      this.detailEntries = Object.entries(user).filter(
+        ([key, value]) =>
+          !exclude.includes(key) &&
+          !Array.isArray(value) &&
+          (typeof value !== 'object' || value === null)
+      );
+    }
+  }
+
+  getBranchLabel(id: number | undefined): string {
+    return this.Branch.find((b) => b.id === id)?.label || String(id ?? '');
+  }
+
+  formatValue(key: string, value: unknown): unknown {
+    if (key === 'branchId') {
+      return this.getBranchLabel(typeof value === 'number' ? value : undefined);
+    }
+    return value;
+  }
+
+  private getContactIcon(key: string): string {
+    const icons: Record<string, string> = {
+      email: 'ti ti-mail',
+      mobile: 'ti ti-phone',
+      secondMobile: 'ti ti-phone'
+    };
+    return icons[key] || 'ti ti-circle';
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.html
@@ -61,7 +61,7 @@
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
                   <div class="text-center text-nowrap">
                     <ul class="list-inline p-l-0">
-                      <li class="list-inline-item m-r-10" matTooltip="View">
+                      <li class="list-inline-item m-r-10" matTooltip="View" (click)="studentDetails(element)">
                         <a href="javascript:" class="avatar avatar-xs text-muted">
                           <i class="ti ti-eye f-18"></i>
                         </a>

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
@@ -6,6 +6,7 @@ import { RouterModule } from '@angular/router';
 // angular material
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -15,15 +16,17 @@ import {
   FilteredResultRequestDto,
 } from 'src/app/@theme/services/lookup.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+import { StudentDetailsComponent } from '../student-details/student-details.component';
 
 @Component({
   selector: 'app-student-list',
-  imports: [CommonModule, SharedModule, RouterModule],
+  imports: [CommonModule, SharedModule, RouterModule, MatDialogModule],
   templateUrl: './student-list.component.html',
   styleUrl: './student-list.component.scss'
 })
 export class StudentListComponent implements OnInit, AfterViewInit {
   private lookupService = inject(LookupService);
+  dialog = inject(MatDialog);
 
   // public props
   displayedColumns: string[] = ['fullName', 'email', 'mobile', 'nationality', 'action'];
@@ -66,6 +69,13 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
           this.totalCount = 0;
         }
       });
+  }
+
+  studentDetails(student: LookUpUserDto): void {
+    this.dialog.open(StudentDetailsComponent, {
+      width: '800px',
+      data: student
+    });
   }
 
   // life cycle event

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-routing.module.ts
@@ -31,6 +31,13 @@ const routes: Routes = [
         }
       },
       {
+        path: 'details/:id',
+        loadComponent: () => import('./student-details/student-details.component').then((c) => c.StudentDetailsComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
+      },
+      {
         path: 'apply',
         loadComponent: () => import('./student-apply/student-apply.component').then((c) => c.StudentApplyComponent),
         data: {

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-details/teacher-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-details/teacher-details.component.html
@@ -1,0 +1,49 @@
+<div class="manager-details-header" mat-dialog-title>
+  <div class="flex align-item-center justify-content-between">
+    <div class="f-w-700 f-16">Teacher Details</div>
+    <button mat-icon-button class="avatar avatar-s modal-close" mat-dialog-close>
+      <i class="ti ti-x f-20"></i>
+    </button>
+  </div>
+</div>
+<mat-dialog-content class="p-0">
+  <app-scrollbar [customStyle]="{ height: 'calc(100vh - 155px)', position: 'relative' }">
+    <div class="details-wrapper" *ngIf="teacher as t">
+      <div class="left-panel">
+        <div class="avatar avatar-xl m-b-10">
+          <i class="ti ti-user f-24"></i>
+        </div>
+        <h5 class="m-b-10">{{ t.fullName }}</h5>
+        <div class="contact-list">
+          <div class="contact-item" *ngFor="let c of contactEntries">
+            <i [class]="c.icon"></i>
+            <span class="contact-value">{{ c.value }}</span>
+          </div>
+        </div>
+      </div>
+      <div class="right-panel">
+        <section class="section" *ngIf="detailEntries.length">
+          <h6 class="section-title">Personal Details</h6>
+          <div class="detail-grid">
+            <div class="detail-item" *ngIf="t.branchId !== undefined">
+              <span class="label">Branch:</span>
+              <span>{{ getBranchLabel(t.branchId) }}</span>
+            </div>
+            <div class="detail-item" *ngFor="let entry of detailEntries">
+              <span class="label">{{ entry[0] | titlecase }}:</span>
+              <span>{{ formatValue(entry[0], entry[1]) }}</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="section" *ngIf="students.length">
+          <h6 class="section-title">Students</h6>
+          <div class="relation-item" *ngFor="let s of students">
+            <span class="relation-name">{{ s.fullName }}</span>
+            <span class="relation-phone">{{ s.mobile }}</span>
+          </div>
+        </section>
+      </div>
+    </div>
+  </app-scrollbar>
+</mat-dialog-content>

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-details/teacher-details.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-details/teacher-details.component.scss
@@ -1,0 +1,120 @@
+.details-wrapper {
+  display: flex;
+  gap: 20px;
+}
+
+.left-panel {
+  flex: 0 0 220px;
+  text-align: center;
+  border-right: 1px solid var(--bs-border-color, #eee);
+  padding-right: 20px;
+}
+
+.contact-list {
+  margin-top: 15px;
+}
+
+.contact-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.contact-value {
+  direction: ltr;
+}
+
+.right-panel {
+  flex: 1;
+}
+
+.section {
+  margin-bottom: 20px;
+}
+
+.section-title {
+  font-weight: 700;
+
+  margin-bottom: 10px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 8px;
+}
+
+.detail-item {
+
+  display: flex;
+  gap: 4px;
+}
+
+.detail-item .label {
+  font-weight: 700;
+}
+
+
+.relation-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.relation-name {
+  font-weight: 700;
+}
+
+:host-context([dir='rtl']) {
+  .details-wrapper {
+    flex-direction: row-reverse;
+    text-align: right;
+  }
+
+  .left-panel {
+    border-right: none;
+    border-left: 1px solid var(--bs-border-color, #eee);
+    padding-right: 0;
+    padding-left: 20px;
+  }
+
+  .right-panel {
+    text-align: right;
+  }
+
+  .detail-item,
+  .relation-item,
+  .contact-item {
+    flex-direction: row-reverse;
+    text-align: right;
+  }
+
+  .section-title {
+    text-align: right;
+  }
+
+}
+
+.relation-phone {
+  direction: ltr;
+}
+
+@media (max-width: 768px) {
+  .details-wrapper {
+    flex-direction: column;
+  }
+  .left-panel {
+    border-right: none;
+    border-bottom: 1px solid var(--bs-border-color, #eee);
+    padding-right: 0;
+    padding-bottom: 20px;
+  }
+  :host-context([dir='rtl']) .left-panel {
+    border-left: none;
+    padding-left: 0;
+  }
+}
+

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-details/teacher-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-details/teacher-details.component.ts
@@ -1,0 +1,79 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { NgxScrollbar } from 'src/app/@theme/components/ngx-scrollbar/ngx-scrollbar';
+import { BranchesEnum } from 'src/app/@theme/types/branchesEnum';
+
+interface Person {
+  fullName?: string;
+  mobile?: string;
+  [key: string]: unknown;
+}
+
+interface ContactEntry {
+  key: string;
+  value: unknown;
+  icon: string;
+}
+
+@Component({
+  selector: 'app-teacher-details',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, NgxScrollbar],
+  templateUrl: './teacher-details.component.html',
+  styleUrl: './teacher-details.component.scss'
+})
+export class TeacherDetailsComponent {
+  teacher?: Record<string, unknown>;
+  students: Person[] = [];
+  contactEntries: ContactEntry[] = [];
+  detailEntries: [string, unknown][] = [];
+
+  Branch = [
+    { id: BranchesEnum.Mens, label: 'الرجال' },
+    { id: BranchesEnum.Women, label: 'النساء' }
+  ];
+
+  constructor() {
+    const user = inject<Record<string, unknown>>(MAT_DIALOG_DATA);
+    if (user) {
+      this.teacher = user;
+      const raw = user as Record<string, unknown>;
+      this.students = Array.isArray(raw['students']) ? (raw['students'] as Person[]) : [];
+
+      const contactKeys = ['email', 'mobile', 'secondMobile'];
+      this.contactEntries = contactKeys
+        .filter((k) => raw[k] !== undefined && raw[k] !== null)
+        .map((k) => ({ key: k, value: raw[k], icon: this.getContactIcon(k) }));
+
+      const exclude = ['fullName', 'students', ...contactKeys];
+      this.detailEntries = Object.entries(user).filter(
+        ([key, value]) =>
+          !exclude.includes(key) &&
+          !Array.isArray(value) &&
+          (typeof value !== 'object' || value === null)
+      );
+    }
+  }
+
+  getBranchLabel(id: number | undefined): string {
+    return this.Branch.find((b) => b.id === id)?.label || String(id ?? '');
+  }
+
+  formatValue(key: string, value: unknown): unknown {
+    if (key === 'branchId') {
+      return this.getBranchLabel(typeof value === 'number' ? value : undefined);
+    }
+    return value;
+  }
+
+  private getContactIcon(key: string): string {
+    const icons: Record<string, string> = {
+      email: 'ti ti-mail',
+      mobile: 'ti ti-phone',
+      secondMobile: 'ti ti-phone'
+    };
+    return icons[key] || 'ti ti-circle';
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.html
@@ -53,7 +53,7 @@
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
                   <div class="text-center text-nowrap">
                     <ul class="list-inline p-l-0">
-                      <li class="list-inline-item m-r-10" matTooltip="View">
+                      <li class="list-inline-item m-r-10" matTooltip="View" (click)="teacherDetails(element)">
                         <a href="javascript:" class="avatar avatar-xs text-muted">
                           <i class="ti ti-eye f-18"></i>
                         </a>

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-list/teacher-list.component.ts
@@ -6,6 +6,7 @@ import { RouterModule } from '@angular/router';
 // angular material
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -15,15 +16,17 @@ import {
   FilteredResultRequestDto,
 } from 'src/app/@theme/services/lookup.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+import { TeacherDetailsComponent } from '../teacher-details/teacher-details.component';
 
 @Component({
   selector: 'app-teacher-list',
-  imports: [CommonModule, SharedModule, RouterModule],
+  imports: [CommonModule, SharedModule, RouterModule, MatDialogModule],
   templateUrl: './teacher-list.component.html',
   styleUrl: './teacher-list.component.scss'
 })
 export class TeacherListComponent implements OnInit, AfterViewInit {
   private lookupService = inject(LookupService);
+  dialog = inject(MatDialog);
 
   // public props
   displayedColumns: string[] = ['fullName', 'email', 'mobile', 'nationality', 'action'];
@@ -66,6 +69,13 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
           this.totalCount = 0;
         }
       });
+  }
+
+  teacherDetails(teacher: LookUpUserDto): void {
+    this.dialog.open(TeacherDetailsComponent, {
+      width: '800px',
+      data: teacher
+    });
   }
 
   // life cycle event

--- a/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/teacher/teacher-routing.module.ts
@@ -31,6 +31,13 @@ const routes: Routes = [
         }
       },
       {
+        path: 'details/:id',
+        loadComponent: () => import('./teacher-details/teacher-details.component').then((c) => c.TeacherDetailsComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
+      },
+      {
         path: 'apply',
         loadComponent: () => import('./teacher-apply/teacher-apply.component').then((c) => c.TeacherApplyComponent),
         data: {


### PR DESCRIPTION
## Summary
- add teacher details dialog with student list
- add student details dialog and hook to list
- wire up routes and view actions for teacher and student lists

## Testing
- `npm test` (fails: Cannot determine project or target for command.)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd60a08f1c83229bdc7eebcb0f2868