### PR TITLE
Enforce role-based menu locking

### DIFF
--- a/src/app/@theme/layouts/menu/compact-menu/menu-collapse/menu-collapse.component.html
+++ b/src/app/@theme/layouts/menu/compact-menu/menu-collapse/menu-collapse.component.html
@@ -19,12 +19,9 @@
     <ul class="coded-submenu" [routerLinkActive]="['active']" [ngClass]="item()!.classes!">
       @for (items of item()!.children; track $index) {
         @if (items.type === 'item') {
-          <app-menu-item-compact [item]="items" [parentRole]="item()!.role && item()!.role!.length > 0 ? item()!.role : parentRole.role" />
+          <app-menu-item-compact [item]="items" />
         } @else if (items.type === 'collapse') {
-          <app-menu-collapse-compact
-            [item]="items"
-            [parentRole]="item()!.role && item()!.role!.length > 0 ? item()!.role : parentRole.role"
-          />
+          <app-menu-collapse-compact [item]="items" />
         }
       }
     </ul>

--- a/src/app/@theme/layouts/menu/compact-menu/menu-collapse/menu-collapse.component.ts
+++ b/src/app/@theme/layouts/menu/compact-menu/menu-collapse/menu-collapse.component.ts
@@ -28,12 +28,11 @@ export class MenuCollapseCompactComponent implements OnInit {
   private location = inject(Location);
 
   // public props
-  current_url: string = ''; // Add current URL property
+  current_url: string = '';
   isEnabled: boolean = false;
 
   // all Version Get Item(Component Name Take)
   readonly item = input<NavigationItem>();
-  readonly parentRole = input<string[]>();
 
   visible = false;
   windowWidth = window.innerWidth;
@@ -63,8 +62,7 @@ export class MenuCollapseCompactComponent implements OnInit {
       });
     }, 0);
 
-    // Enable all menu items regardless of user role
-    this.isEnabled = true;
+    this.isEnabled = !(this.item()?.disabled);
   }
 
   // Method to handle the collapse of the navigation menu

--- a/src/app/@theme/layouts/menu/compact-menu/menu-group/menu-group.component.html
+++ b/src/app/@theme/layouts/menu/compact-menu/menu-group/menu-group.component.html
@@ -4,9 +4,9 @@
   </li>
   @for (items of item().children; track $index) {
     @if (items.type === 'collapse') {
-      <app-menu-collapse-compact [item]="items" [parentRole]="item().role" />
+      <app-menu-collapse-compact [item]="items" />
     } @else if (items.type === 'item') {
-      <app-menu-item-compact [item]="items" [parentRole]="item().role" />
+      <app-menu-item-compact [item]="items" />
     }
   }
 }

--- a/src/app/@theme/layouts/menu/compact-menu/menu-item/menu-item.component.ts
+++ b/src/app/@theme/layouts/menu/compact-menu/menu-item/menu-item.component.ts
@@ -19,14 +19,12 @@ export class MenuItemCompactComponent implements OnInit {
 
   // public props
   readonly item = input.required<NavigationItem>();
-  readonly parentRole = input<string[]>();
 
   isEnabled: boolean = false;
 
   //life cycle hook
   ngOnInit() {
-    // Enable all menu items regardless of user role
-    this.isEnabled = true;
+    this.isEnabled = !(this.item().disabled);
   }
 
   // public method

--- a/src/app/@theme/layouts/menu/horizontal-menu/menu-collapse/menu-collapse.component.html
+++ b/src/app/@theme/layouts/menu/horizontal-menu/menu-collapse/menu-collapse.component.html
@@ -3,7 +3,8 @@
     data-username="able-pro dashboard dashboard"
     class="nav-item coded-hasmenu"
     [routerLinkActive]="['active']"
-    [ngClass]="item().groupClasses"
+    [ngClass]="(item().groupClasses || '') + (!isEnabled ? ' disabled' : '')"
+    matTooltip="{{ !isEnabled ? 'Logout and Login with Admin to view this page ' : '' }}"
   >
     <a [routerLinkActive]="['active']" class="nav-link arrow-edge" (mouseenter)="navCollapse($event)">
       @if (item().icon) {

--- a/src/app/@theme/layouts/menu/horizontal-menu/menu-collapse/menu-collapse.component.ts
+++ b/src/app/@theme/layouts/menu/horizontal-menu/menu-collapse/menu-collapse.component.ts
@@ -33,6 +33,7 @@ export class MenuCollapseComponent implements OnInit {
   readonly item = input<NavigationItem>();
   current_url: string = ''; // Add current URL property
   visible;
+  isEnabled: boolean = false;
 
   // Constructor
   constructor() {
@@ -40,7 +41,8 @@ export class MenuCollapseComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.updateActiveMenu(); // Call updateActiveMenu on init
+    this.isEnabled = !(this.item()?.disabled);
+    this.updateActiveMenu();
   }
 
   // Method to update the active menu item based on URL

--- a/src/app/@theme/layouts/menu/horizontal-menu/menu-item/menu-item.component.html
+++ b/src/app/@theme/layouts/menu/horizontal-menu/menu-item/menu-item.component.html
@@ -1,24 +1,53 @@
 @if (!item()!.hidden) {
   @if (item()!.url && !item()!.external) {
-    <li [ngClass]="item().classes!" [routerLinkActive]="['active']">
-      <a class="nav-link" [target]="item().target ? '_blank' : '_self'" [routerLink]="[item().url]" (click)="closeOtherMenu()">
-        @if (item().icon) {
+    <li
+      [ngClass]="item().classes!"
+      [routerLinkActive]="['active']"
+      matTooltip="{{ !isEnabled ? 'Logout and Login with Admin to view this page ' : '' }}"
+    >
+      <a
+        class="nav-link"
+        [target]="item().target ? '_blank' : '_self'"
+        [ngClass]="{ disabled: !isEnabled }"
+        [routerLink]="[item().url]"
+        (click)="closeOtherMenu()"
+      >
+        @if (!isEnabled) {
           <span class="coded-micon">
             <svg class="pc-icon">
-              <use attr.xlink:href="assets/fonts/custom-icon.svg{{ item().icon }}"></use>
+              <use xlink:href="assets/fonts/custom-icon.svg#custom-lock"></use>
             </svg>
           </span>
+        } @else {
+          @if (item().icon) {
+            <span class="coded-micon">
+              <svg class="pc-icon">
+                <use attr.xlink:href="assets/fonts/custom-icon.svg{{ item().icon }}"></use>
+              </svg>
+            </span>
+          }
         }
         @if (item().icon) {
           <span class="coded-mtext">{{ item()!.title }}</span>
         } @else {
+          @if (!isEnabled) {
+            <span class="coded-micon">
+              <svg class="pc-icon">
+                <use attr.xlink:href="assets/fonts/custom-icon.svg{{ item().icon }}"></use>
+              </svg>
+            </span>
+          }
           {{ item()!.title }}
         }
       </a>
     </li>
   } @else if (item()!.url && item()!.external) {
-    <li [ngClass]="item()!.classes!">
-      <a [target]="item()!.target ? '_blank' : '_self'" [href]="item()!.url">
+    <li [ngClass]="item()!.classes!" matTooltip="{{ !isEnabled ? 'Logout and Login with Admin to view this page ' : '' }}">
+      <a
+        [target]="item()!.target ? '_blank' : '_self'"
+        [href]="item()!.url"
+        [ngClass]="{ disabled: !isEnabled }"
+      >
         @if (item()!.icon) {
           <span class="coded-micon">
             <svg class="pc-icon">

--- a/src/app/@theme/layouts/menu/horizontal-menu/menu-item/menu-item.component.ts
+++ b/src/app/@theme/layouts/menu/horizontal-menu/menu-item/menu-item.component.ts
@@ -1,5 +1,5 @@
 // Angular import
-import { Component, inject, input } from '@angular/core';
+import { Component, OnInit, inject, input } from '@angular/core';
 import { CommonModule, Location, LocationStrategy } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
@@ -13,12 +13,17 @@ import { SharedModule } from 'src/app/demo/shared/shared.module';
   templateUrl: './menu-item.component.html',
   styleUrls: ['./menu-item.component.scss']
 })
-export class MenuItemHorizontalComponent {
+export class MenuItemHorizontalComponent implements OnInit {
   private location = inject(Location);
   private locationStrategy = inject(LocationStrategy);
 
   // public props
   readonly item = input<NavigationItem>();
+  isEnabled: boolean = false;
+
+  ngOnInit() {
+    this.isEnabled = !(this.item()?.disabled);
+  }
 
   // public method
   closeOtherMenu() {

--- a/src/app/@theme/layouts/menu/vertical-menu/menu-collapse/menu-collapse.component.html
+++ b/src/app/@theme/layouts/menu/vertical-menu/menu-collapse/menu-collapse.component.html
@@ -19,9 +19,9 @@
     <ul class="coded-submenu" [routerLinkActive]="['active']" [ngClass]="item()!.classes!">
       @for (items of item()!.children; track $index) {
         @if (items.type === 'item') {
-          <app-menu-item [item]="items" [parentRole]="item()!.role && item()!.role!.length > 0 ? item()!.role : parentRole.role" />
+          <app-menu-item [item]="items" />
         } @else if (items.type === 'collapse') {
-          <app-menu-collapse [item]="items" [parentRole]="item()!.role && item()!.role!.length > 0 ? item()!.role : parentRole.role" />
+          <app-menu-collapse [item]="items" />
         }
       }
     </ul>

--- a/src/app/@theme/layouts/menu/vertical-menu/menu-collapse/menu-collapse.component.ts
+++ b/src/app/@theme/layouts/menu/vertical-menu/menu-collapse/menu-collapse.component.ts
@@ -28,12 +28,11 @@ export class MenuCollapseComponent implements OnInit {
   private location = inject(Location);
 
   // public props
-  current_url: string = ''; // Add current URL property
+  current_url: string = '';
   isEnabled: boolean = false;
 
   // all Version Get Item(Component Name Take)
   readonly item = input<NavigationItem>();
-  readonly parentRole = input<string[]>();
 
   visible = false;
   windowWidth = window.innerWidth;
@@ -63,8 +62,7 @@ export class MenuCollapseComponent implements OnInit {
       });
     }, 0);
 
-    // Enable all menu items regardless of user role
-    this.isEnabled = true;
+    this.isEnabled = !(this.item()?.disabled);
   }
 
   // Method to handle the collapse of the navigation menu

--- a/src/app/@theme/layouts/menu/vertical-menu/menu-group/menu-group.component.html
+++ b/src/app/@theme/layouts/menu/vertical-menu/menu-group/menu-group.component.html
@@ -4,9 +4,9 @@
   </li>
   @for (items of item().children; track $index) {
     @if (items.type === 'collapse') {
-      <app-menu-collapse [item]="items" [parentRole]="item().role" />
+      <app-menu-collapse [item]="items" />
     } @else if (items.type === 'item') {
-      <app-menu-item [item]="items" [parentRole]="item().role" />
+      <app-menu-item [item]="items" />
     }
   }
 }

--- a/src/app/@theme/layouts/menu/vertical-menu/menu-item/menu-item.component.ts
+++ b/src/app/@theme/layouts/menu/vertical-menu/menu-item/menu-item.component.ts
@@ -19,14 +19,12 @@ export class MenuItemVerticalComponent implements OnInit {
 
   // public props
   readonly item = input.required<NavigationItem>();
-  readonly parentRole = input<string[]>();
 
   isEnabled: boolean = false;
 
   //life cycle hook
   ngOnInit() {
-    // Enable all menu items regardless of user role
-    this.isEnabled = true;
+    this.isEnabled = !(this.item().disabled);
   }
 
   // public method

--- a/src/app/demo/data/menu.ts
+++ b/src/app/demo/data/menu.ts
@@ -21,13 +21,7 @@ export const menus: Navigation[] = [
         title: 'Dashboard',
         type: 'collapse',
         icon: '#custom-status-up',
-        role: [
-          UserTypesEnum.Admin.toString(),
-          UserTypesEnum.Manager.toString(),
-          UserTypesEnum.BranchLeader.toString(),
-          UserTypesEnum.Student.toString(),
-          UserTypesEnum.Teacher.toString()
-        ],
+        role: [UserTypesEnum.Admin.toString()],
         children: [
           {
             id: 'default',
@@ -41,26 +35,14 @@ export const menus: Navigation[] = [
             title: 'Analytics',
             type: 'item',
             url: '/dashboard/analytics',
-            role: [
-              UserTypesEnum.Admin.toString(),
-              UserTypesEnum.Manager.toString(),
-              UserTypesEnum.BranchLeader.toString(),
-              UserTypesEnum.Student.toString(),
-              UserTypesEnum.Teacher.toString()
-            ]
+            role: [UserTypesEnum.Admin.toString()]
           },
           {
             id: 'finance',
             title: 'Finance',
             type: 'item',
             url: '/dashboard/finance',
-            role: [
-              UserTypesEnum.Admin.toString(),
-              UserTypesEnum.Manager.toString(),
-              UserTypesEnum.BranchLeader.toString(),
-              UserTypesEnum.Student.toString(),
-              UserTypesEnum.Teacher.toString()
-            ]
+            role: [UserTypesEnum.Admin.toString()]
           }
         ]
       },

--- a/src/app/demo/layout/admin/admin.component.ts
+++ b/src/app/demo/layout/admin/admin.component.ts
@@ -96,7 +96,10 @@ export class AdminComponent implements OnInit, AfterViewInit {
      * current login user role
      */
     const currentUser = this.authenticationService.currentUserValue;
-    const userRoles = currentUser?.user.role ? [currentUser.user.role] : [UserTypesEnum.Admin.toString()];
+    const userRoles =
+      currentUser?.user.role !== undefined && currentUser?.user.role !== null
+        ? [currentUser.user.role.toString()]
+        : [UserTypesEnum.Admin.toString()];
 
     /**
      * Role base menu filtering
@@ -115,17 +118,27 @@ export class AdminComponent implements OnInit, AfterViewInit {
   /**
    * Role base menu filtering
    */
-  RoleBaseFilterMenu(menus: Navigation[], userRoles: string[], parentRoles: string[] = [UserTypesEnum.Admin.toString(),UserTypesEnum.Manager.toString()]): Navigation[] {
+  RoleBaseFilterMenu(
+    menus: Navigation[],
+    userRoles: string[],
+    parentRoles: string[] = [
+      UserTypesEnum.Admin.toString(),
+      UserTypesEnum.Manager.toString(),
+      UserTypesEnum.BranchLeader.toString(),
+      UserTypesEnum.Teacher.toString(),
+      UserTypesEnum.Student.toString()
+    ]
+  ): Navigation[] {
     return menus.map((item) => {
-      // If item doesn't have a specific role, inherit roles from parent
-      const itemRoles = item.role ? item.role : parentRoles;
+      const itemRoles = item.role && item.role.length ? item.role : parentRoles;
+      item.role = itemRoles;
+      item.disabled = !userRoles.some((role) => itemRoles.includes(role));
 
-      // If item has children, recursively filter them, passing current item's roles as parentRoles
       if (item.children) {
         item.children = this.RoleBaseFilterMenu(item.children, userRoles, itemRoles);
       }
 
-      return item; // Return the item whether it is visible or disabled
+      return item;
     });
   }
 


### PR DESCRIPTION
## Summary
- Restrict dashboard menu entries to administrators and expose roles for filtering
- Derive menu item disabled state from user role and apply across vertical, compact, and horizontal menus
- Lock menu links with tooltips when user lacks permission
- Fix role comparison to prevent valid roles (e.g., BranchLeader) from being treated as unauthorized

## Testing
- ❌ `npm test` (Cannot determine project or target for command)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd743ec1588322b52a3c536bc046f9