### PR TITLE
feat: enhance code verification inputs

### DIFF
--- a/src/app/@theme/services/authentication.service.ts
+++ b/src/app/@theme/services/authentication.service.ts
@@ -49,6 +49,7 @@ export class AuthenticationService {
   private currentUserSignal = signal<User | null>(null);
   isLogin: boolean = false;
   pendingEmail: string | null = null;
+  pendingCode: string | null = null;
 
   constructor() {
     // Initialize the signal with the current user from localStorage
@@ -110,6 +111,7 @@ export class AuthenticationService {
             this.currentUserSignal.set(user);
             this.isLogin = true;
             this.pendingEmail = null;
+            this.pendingCode = null;
           }
         })
       );
@@ -124,6 +126,7 @@ export class AuthenticationService {
     localStorage.removeItem('currentUser');
     this.isLogin = false;
     this.pendingEmail = null;
+    this.pendingCode = null;
     // Update the signal to null
     this.currentUserSignal.set(null);
     this.router.navigate(['/login']);

--- a/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.html
+++ b/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.html
@@ -18,24 +18,18 @@
           <p class="text-muted forgot-logo m-b-25">We send you on mail.</p>
           <p class="text-muted forgot-logo m-b-20">We`ve send you code on jone. ****&#64;company.com</p>
           <div class="row text-center">
-            <div class="col-3 g-0">
+            <div class="col-2 g-0" *ngFor="let digit of codeDigits; let i = index">
               <mat-form-field appearance="fill" class="otp-input wid-80">
-                <input matInput maxlength="1" placeholder="0" [(ngModel)]="codeDigits[0]" />
-              </mat-form-field>
-            </div>
-            <div class="col-3">
-              <mat-form-field appearance="fill" class="otp-input wid-80">
-                <input matInput maxlength="1" placeholder="0" [(ngModel)]="codeDigits[1]" />
-              </mat-form-field>
-            </div>
-            <div class="col-3">
-              <mat-form-field appearance="fill" class="otp-input wid-80">
-                <input matInput maxlength="1" placeholder="0" [(ngModel)]="codeDigits[2]" />
-              </mat-form-field>
-            </div>
-            <div class="col-3">
-              <mat-form-field appearance="fill" class="otp-input wid-80">
-                <input matInput maxlength="1" placeholder="0" [(ngModel)]="codeDigits[3]" />
+                <input
+                  matInput
+                  #codeInput
+                  maxlength="1"
+                  placeholder="0"
+                  [(ngModel)]="codeDigits[i]"
+                  (input)="onInput($event, i)"
+                  (keydown)="onKeyDown($event, i)"
+                  (paste)="onPaste($event)"
+                />
               </mat-form-field>
             </div>
           </div>

--- a/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/code-verification/code-verification.component.ts
@@ -1,5 +1,5 @@
 // angular import
-import { Component, inject } from '@angular/core';
+import { Component, inject, ViewChildren, ElementRef, QueryList, OnInit, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 
@@ -17,12 +17,59 @@ import { DASHBOARD_PATH } from 'src/app/app-config';
   templateUrl: './code-verification.component.html',
   styleUrls: ['./code-verification.component.scss', '../authentication-1.scss', '../../authentication.scss']
 })
-export class CodeVerificationComponent {
+export class CodeVerificationComponent implements OnInit, AfterViewInit {
   private authService = inject(AuthenticationService);
   private router = inject(Router);
   private toast = inject(ToastService);
 
-  codeDigits: string[] = ['', '', '', ''];
+  codeDigits: string[] = Array(6).fill('');
+  @ViewChildren('codeInput') codeInputs!: QueryList<ElementRef<HTMLInputElement>>;
+
+  ngOnInit() {
+    if (this.authService.pendingCode) {
+      const digits = this.authService.pendingCode.split('');
+      this.codeDigits = this.codeDigits.map((_, i) => digits[i] || '');
+    }
+  }
+
+  ngAfterViewInit() {
+    const index = this.codeDigits.findIndex((d) => !d);
+    const focusIndex = index === -1 ? this.codeDigits.length - 1 : index;
+    const input = this.codeInputs.toArray()[focusIndex];
+    if (input) {
+      input.nativeElement.focus();
+    }
+  }
+
+  onInput(event: Event, index: number) {
+    const inputEl = event.target as HTMLInputElement;
+    const value = inputEl.value.replace(/\D/g, '');
+    this.codeDigits[index] = value;
+    inputEl.value = value;
+    if (value && index < this.codeDigits.length - 1) {
+      this.codeInputs.toArray()[index + 1].nativeElement.focus();
+    }
+  }
+
+  onKeyDown(event: KeyboardEvent, index: number) {
+    if (event.key === 'Backspace' && !this.codeDigits[index] && index > 0) {
+      this.codeInputs.toArray()[index - 1].nativeElement.focus();
+    }
+  }
+
+  onPaste(event: ClipboardEvent) {
+    const data = event.clipboardData?.getData('text') ?? '';
+    const digits = data.replace(/\D/g, '').split('');
+    if (digits.length) {
+      event.preventDefault();
+      this.codeDigits = this.codeDigits.map((_, i) => digits[i] || '');
+      const inputs = this.codeInputs.toArray();
+      inputs.forEach((input, i) => (input.nativeElement.value = this.codeDigits[i] || ''));
+      const index = this.codeDigits.findIndex((d) => !d);
+      const focusIndex = index === -1 ? this.codeDigits.length - 1 : index;
+      inputs[focusIndex].nativeElement.focus();
+    }
+  }
 
   verify() {
     const code = this.codeDigits.join('');

--- a/src/app/demo/pages/auth/authentication-1/login/login.component.ts
+++ b/src/app/demo/pages/auth/authentication-1/login/login.component.ts
@@ -78,6 +78,9 @@ export class LoginComponent implements OnInit {
           this.loading = false;
           if (res?.isSuccess && res?.data?.passwordIsCorrect) {
             this.authenticationService.pendingEmail = res.data.email;
+            if (res.data.code) {
+              this.authenticationService.pendingCode = res.data.code;
+            }
             this.toast.success('Login successful');
             this.router.navigateByUrl(this.returnUrl);
           } else if (res?.errors?.length) {


### PR DESCRIPTION
## Summary
- store pending verification codes in the auth service
- auto-populate OTP fields and move focus as user types
- allow pasting codes across inputs

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8153dc6883229590117e90171323