### PR TITLE
feat: add circle selection to manager edit

### DIFF
--- a/src/app/@theme/services/user.service.ts
+++ b/src/app/@theme/services/user.service.ts
@@ -26,6 +26,7 @@ export interface UpdateUserDto {
   branchId?: number;
   teacherIds?: number[];
   studentIds?: number[];
+  circleIds?: number[];
 }
 
 // Generic API response interfaces

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -122,6 +122,14 @@
                 </mat-select>
               </mat-form-field>
             </div>
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Circles</mat-label>
+                <mat-select formControlName="circleIds" multiple appOpenSelectOnType>
+                  <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
           }
           <div class="col-md-12 text-end">
             <button mat-flat-button color="primary" [disabled]="basicInfoForm.invalid">Update</button>


### PR DESCRIPTION
## Summary
- allow managers to select circles when editing profiles
- fetch available circles from Circle API

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd86ce1d1c83229b939104c25fd558