### PR TITLE
feat: add relations to teacher update

### DIFF
--- a/src/app/@theme/services/user.service.ts
+++ b/src/app/@theme/services/user.service.ts
@@ -24,6 +24,7 @@ export interface UpdateUserDto {
   nationalityId?: number;
   governorateId?: number;
   branchId?: number;
+  managerIds?: number[];
   teacherIds?: number[];
   studentIds?: number[];
   circleIds?: number[];

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -131,6 +131,32 @@
               </mat-form-field>
             </div>
           }
+          @if (isTeacher) {
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Managers</mat-label>
+                <mat-select formControlName="managerIds" multiple appOpenSelectOnType>
+                  <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Students</mat-label>
+                <mat-select formControlName="studentIds" multiple appOpenSelectOnType>
+                  <mat-option *ngFor="let s of students" [value]="s.id">{{ s.fullName }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Circles</mat-label>
+                <mat-select formControlName="circleIds" multiple appOpenSelectOnType>
+                  <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+          }
           <div class="col-md-12 text-end">
             <button mat-flat-button color="primary" [disabled]="basicInfoForm.invalid">Update</button>
           </div>


### PR DESCRIPTION
## Summary
- allow editing teachers with manager, student, and circle selections
- extend UpdateUserDto with `managerIds`
- support loading/managing related entities in user edit component

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd8cb2c8648322b872a419a73faeaa