### PR TITLE
feat: add relationships to student editor

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -136,7 +136,6 @@
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Manager</mat-label>
                 <mat-select formControlName="managerId" appOpenSelectOnType>
-
                   <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>
                 </mat-select>
               </mat-form-field>
@@ -153,7 +152,32 @@
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Circle</mat-label>
                 <mat-select formControlName="circleId" appOpenSelectOnType>
-
+                  <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+          }
+          @if (isStudent) {
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Teacher</mat-label>
+                <mat-select formControlName="teacherIds" multiple appOpenSelectOnType>
+                  <mat-option *ngFor="let t of teachers" [value]="t.id">{{ t.fullName }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Manager</mat-label>
+                <mat-select formControlName="managerId" appOpenSelectOnType>
+                  <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Circle</mat-label>
+                <mat-select formControlName="circleId" appOpenSelectOnType>
                   <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
                 </mat-select>
               </mat-form-field>

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
@@ -14,7 +14,7 @@ import {
   NationalityDto,
   GovernorateDto,
   LookUpUserDto,
-  FilteredResultRequestDto,
+  FilteredResultRequestDto
 } from 'src/app/@theme/services/lookup.service';
 import { CircleService, CircleDto } from 'src/app/@theme/services/circle.service';
 import { CountryService, Country } from 'src/app/@theme/services/country.service';
@@ -58,6 +58,7 @@ export class UserEditComponent implements OnInit {
   circles: CircleDto[] = [];
   isManager = false;
   isTeacher = false;
+  isStudent = false;
   Branch = [
     { id: BranchesEnum.Mens, label: 'الرجال' },
     { id: BranchesEnum.Women, label: 'النساء' }
@@ -76,6 +77,7 @@ export class UserEditComponent implements OnInit {
   ngOnInit(): void {
     this.isManager = this.router.url.includes('/manager/');
     this.isTeacher = this.router.url.includes('/teacher/');
+    this.isStudent = this.router.url.includes('/student/');
     this.basicInfoForm = this.fb.group({
       fullName: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
@@ -91,7 +93,7 @@ export class UserEditComponent implements OnInit {
 
       studentIds: [[]],
       circleIds: [[]],
-      circleId: [null],
+      circleId: [null]
     });
 
     this.lookupService.getAllNationalities().subscribe((res) => {
@@ -114,17 +116,15 @@ export class UserEditComponent implements OnInit {
         fullName: this.currentUser.fullName,
         email: this.currentUser.email,
         mobile: clean(this.currentUser.mobile),
-        secondMobile: this.currentUser.secondMobile
-          ? clean(this.currentUser.secondMobile)
-          : '',
+        secondMobile: this.currentUser.secondMobile ? clean(this.currentUser.secondMobile) : '',
         nationalityId: this.currentUser.nationalityId,
         governorateId: this.currentUser.governorateId,
         branchId: this.currentUser.branchId
       });
-      if (this.isManager || this.isTeacher) {
+
+      if (this.isManager || this.isTeacher || this.isStudent) {
         if (this.isManager) {
-          const teacherList =
-            this.currentUser.teachers ?? this.currentUser.managers ?? [];
+          const teacherList = this.currentUser.teachers ?? this.currentUser.managers ?? [];
           if (teacherList.length) {
             this.teachers = teacherList;
             this.basicInfoForm.patchValue({
@@ -136,7 +136,6 @@ export class UserEditComponent implements OnInit {
             this.managers = this.currentUser.managers;
             this.basicInfoForm.patchValue({
               managerId: this.currentUser.managers[0].id
-
             });
           } else if (this.currentUser.managerId && this.currentUser.managerName) {
             const manager: LookUpUserDto = {
@@ -149,15 +148,46 @@ export class UserEditComponent implements OnInit {
               nationalityId: 0,
               governorate: '',
               governorateId: 0,
-              branchId: 0,
+              branchId: 0
             };
             this.managers = [manager];
             this.basicInfoForm.patchValue({
-              managerId: manager.id,
+              managerId: manager.id
+            });
+          }
+        } else if (this.isStudent) {
+          if (this.currentUser.teachers?.length) {
+            this.teachers = this.currentUser.teachers;
+            this.basicInfoForm.patchValue({
+              teacherIds: this.currentUser.teachers.map((t) => t.id)
+            });
+          }
+          if (this.currentUser.managers?.length) {
+            this.managers = this.currentUser.managers;
+            this.basicInfoForm.patchValue({
+              managerId: this.currentUser.managers[0].id
+            });
+          } else if (this.currentUser.managerId && this.currentUser.managerName) {
+            const manager: LookUpUserDto = {
+              id: this.currentUser.managerId,
+              fullName: this.currentUser.managerName,
+              email: '',
+              mobile: '',
+              secondMobile: '',
+              nationality: '',
+              nationalityId: 0,
+              governorate: '',
+              governorateId: 0,
+              branchId: 0
+            };
+            this.managers = [manager];
+            this.basicInfoForm.patchValue({
+              managerId: manager.id
             });
           }
         }
-        if (this.currentUser.students?.length) {
+
+        if ((this.isManager || this.isTeacher) && this.currentUser.students?.length) {
           this.students = this.currentUser.students;
           this.basicInfoForm.patchValue({
             studentIds: this.currentUser.students.map((s) => s.id)
@@ -173,7 +203,7 @@ export class UserEditComponent implements OnInit {
             this.basicInfoForm.patchValue({
               circleIds: this.currentUser.managerCircles.map((c) => c.circleId)
             });
-          } else if (this.isTeacher) {
+          } else {
             this.basicInfoForm.patchValue({
               circleId: this.currentUser.managerCircles[0].circleId
             });
@@ -181,16 +211,16 @@ export class UserEditComponent implements OnInit {
         } else if (this.currentUser.circleId && this.currentUser.circleName) {
           const circle: CircleDto = {
             id: this.currentUser.circleId,
-            name: this.currentUser.circleName,
+            name: this.currentUser.circleName
           };
           this.circles = [circle];
           if (this.isManager) {
             this.basicInfoForm.patchValue({
-              circleIds: [circle.id],
+              circleIds: [circle.id]
             });
-          } else if (this.isTeacher) {
+          } else {
             this.basicInfoForm.patchValue({
-              circleId: circle.id,
+              circleId: circle.id
             });
           }
         }
@@ -202,10 +232,7 @@ export class UserEditComponent implements OnInit {
     this.countryService.getCountries().subscribe((data) => {
       this.countries = data;
       if (this.currentUser) {
-        const detected = this.detectDialCode(
-          this.currentUser.mobile,
-          this.countries
-        );
+        const detected = this.detectDialCode(this.currentUser.mobile, this.countries);
 
         if (detected) {
           this.basicInfoForm.patchValue({
@@ -215,10 +242,7 @@ export class UserEditComponent implements OnInit {
           this.onCountryCodeChange('mobileCountryDialCode');
         }
         if (this.currentUser.secondMobile) {
-          const secondDetected = this.detectDialCode(
-            this.currentUser.secondMobile,
-            this.countries
-          );
+          const secondDetected = this.detectDialCode(this.currentUser.secondMobile, this.countries);
 
           if (secondDetected) {
             this.basicInfoForm.patchValue({
@@ -230,20 +254,13 @@ export class UserEditComponent implements OnInit {
         }
       }
     });
-
   }
 
   private loadRelatedUsers() {
     const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
     if (this.isManager) {
       this.lookupService
-        .getUsersForSelects(
-          filter,
-          Number(UserTypesEnum.Teacher),
-          0,
-          0,
-          this.currentUser?.branchId || 0
-        )
+        .getUsersForSelects(filter, Number(UserTypesEnum.Teacher), 0, 0, this.currentUser?.branchId || 0)
         .subscribe((res) => {
           if (res.isSuccess) {
             const existing = new Map(this.teachers.map((t) => [t.id, t]));
@@ -253,13 +270,26 @@ export class UserEditComponent implements OnInit {
         });
     } else if (this.isTeacher) {
       this.lookupService
-        .getUsersForSelects(
-          filter,
-          Number(UserTypesEnum.Manager),
-          0,
-          0,
-          this.currentUser?.branchId || 0
-        )
+        .getUsersForSelects(filter, Number(UserTypesEnum.Manager), 0, 0, this.currentUser?.branchId || 0)
+        .subscribe((res) => {
+          if (res.isSuccess) {
+            const existing = new Map(this.managers.map((m) => [m.id, m]));
+            res.data.items.forEach((m) => existing.set(m.id, m));
+            this.managers = Array.from(existing.values());
+          }
+        });
+    } else if (this.isStudent) {
+      this.lookupService
+        .getUsersForSelects(filter, Number(UserTypesEnum.Teacher), 0, 0, this.currentUser?.branchId || 0)
+        .subscribe((res) => {
+          if (res.isSuccess) {
+            const existing = new Map(this.teachers.map((t) => [t.id, t]));
+            res.data.items.forEach((t) => existing.set(t.id, t));
+            this.teachers = Array.from(existing.values());
+          }
+        });
+      this.lookupService
+        .getUsersForSelects(filter, Number(UserTypesEnum.Manager), 0, 0, this.currentUser?.branchId || 0)
         .subscribe((res) => {
           if (res.isSuccess) {
             const existing = new Map(this.managers.map((m) => [m.id, m]));
@@ -268,21 +298,17 @@ export class UserEditComponent implements OnInit {
           }
         });
     }
-    this.lookupService
-      .getUsersForSelects(
-        filter,
-        Number(UserTypesEnum.Student),
-        0,
-        0,
-        this.currentUser?.branchId || 0
-      )
-      .subscribe((res) => {
-        if (res.isSuccess) {
-          const existing = new Map(this.students.map((s) => [s.id, s]));
-          res.data.items.forEach((s) => existing.set(s.id, s));
-          this.students = Array.from(existing.values());
-        }
-      });
+    if (this.isManager || this.isTeacher) {
+      this.lookupService
+        .getUsersForSelects(filter, Number(UserTypesEnum.Student), 0, 0, this.currentUser?.branchId || 0)
+        .subscribe((res) => {
+          if (res.isSuccess) {
+            const existing = new Map(this.students.map((s) => [s.id, s]));
+            res.data.items.forEach((s) => existing.set(s.id, s));
+            this.students = Array.from(existing.values());
+          }
+        });
+    }
   }
 
   private loadCircles() {
@@ -308,13 +334,9 @@ export class UserEditComponent implements OnInit {
     }
   }
 
-  private detectDialCode(phone: string, countries: Country[]):
-    | { dialCode: string; number: string }
-    | null {
+  private detectDialCode(phone: string, countries: Country[]): { dialCode: string; number: string } | null {
     const digits = phone.replace(/\D/g, '');
-    const codes = countries
-      .map((c) => c.dialCode.replace('+', ''))
-      .sort((a, b) => b.length - a.length);
+    const codes = countries.map((c) => c.dialCode.replace('+', '')).sort((a, b) => b.length - a.length);
     for (const code of codes) {
       if (digits.startsWith(code)) {
         return { dialCode: `+${code}`, number: digits.slice(code.length) };
@@ -336,13 +358,11 @@ export class UserEditComponent implements OnInit {
         nationalityId: formValue.nationalityId,
         governorateId: formValue.governorateId,
         branchId: formValue.branchId,
-        managerId: this.isTeacher ? formValue.managerId : undefined,
-        teacherIds: this.isManager ? formValue.teacherIds : undefined,
-        studentIds:
-          this.isManager || this.isTeacher ? formValue.studentIds : undefined,
+        managerId: this.isTeacher || this.isStudent ? formValue.managerId : undefined,
+        teacherIds: this.isManager || this.isStudent ? formValue.teacherIds : undefined,
+        studentIds: this.isManager || this.isTeacher ? formValue.studentIds : undefined,
         circleIds: this.isManager ? formValue.circleIds : undefined,
-        circleId: this.isTeacher ? formValue.circleId : undefined,
-
+        circleId: this.isTeacher || this.isStudent ? formValue.circleId : undefined
       };
       this.userService.updateUser(model).subscribe({
         next: (res) => {


### PR DESCRIPTION
## Summary
- support student editing in shared user editor with teacher, manager, and circle fields
- fetch related users and circles for students

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be884773e48322984c1485e2664898