### PR TITLE
feat: add relationships to student editor

### DIFF
--- a/src/app/@theme/services/user.service.ts
+++ b/src/app/@theme/services/user.service.ts
@@ -25,7 +25,7 @@ export interface UpdateUserDto {
   governorateId?: number;
   branchId?: number;
   managerId?: number;
-
+  teacherId?: number;
   teacherIds?: number[];
   studentIds?: number[];
   circleIds?: number[];

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -136,7 +136,6 @@
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Manager</mat-label>
                 <mat-select formControlName="managerId" appOpenSelectOnType>
-
                   <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>
                 </mat-select>
               </mat-form-field>
@@ -153,7 +152,32 @@
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Circle</mat-label>
                 <mat-select formControlName="circleId" appOpenSelectOnType>
-
+                  <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+          }
+          @if (isStudent) {
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Teacher</mat-label>
+                <mat-select formControlName="teacherId" appOpenSelectOnType>
+                  <mat-option *ngFor="let t of teachers" [value]="t.id">{{ t.fullName }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Manager</mat-label>
+                <mat-select formControlName="managerId" appOpenSelectOnType>
+                  <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div class="col-md-6">
+              <mat-form-field appearance="outline" class="w-100 m-b-10">
+                <mat-label>Circle</mat-label>
+                <mat-select formControlName="circleId" appOpenSelectOnType>
                   <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
                 </mat-select>
               </mat-form-field>


### PR DESCRIPTION
## Summary
- support student editing in shared user editor with teacher, manager, and circle fields
- fetch related users and circles for students
- capture selected teacher in `teacherId` field

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be884773e48322984c1485e2664898