### PR TITLE
Restrict teacher edit fields based on manager selection

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -135,7 +135,7 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Manager</mat-label>
-                <mat-select formControlName="managerId" appOpenSelectOnType>
+                <mat-select formControlName="managerId" appOpenSelectOnType disabled>
                   <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>
                 </mat-select>
               </mat-form-field>
@@ -143,7 +143,7 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Students</mat-label>
-                <mat-select formControlName="studentIds" multiple appOpenSelectOnType>
+                <mat-select formControlName="studentIds" multiple appOpenSelectOnType [disabled]="!basicInfoForm.get('managerId')?.value">
                   <mat-option *ngFor="let s of students" [value]="s.id">{{ s.fullName }}</mat-option>
                 </mat-select>
               </mat-form-field>
@@ -151,7 +151,7 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Circle</mat-label>
-                <mat-select formControlName="circleId" appOpenSelectOnType>
+                <mat-select formControlName="circleId" appOpenSelectOnType [disabled]="!basicInfoForm.get('managerId')?.value">
                   <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
                 </mat-select>
               </mat-form-field>

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
@@ -247,7 +247,18 @@ export class UserEditComponent implements OnInit {
           }
         }
         this.loadRelatedUsers();
-        this.loadCircles();
+        if (this.isTeacher) {
+          this.basicInfoForm.get('managerId')?.disable();
+          const mId = this.basicInfoForm.get('managerId')?.value;
+          if (mId) {
+            this.loadStudentsAndCircles(mId);
+          } else {
+            this.basicInfoForm.get('studentIds')?.disable();
+            this.basicInfoForm.get('circleId')?.disable();
+          }
+        } else {
+          this.loadCircles();
+        }
       }
     }
 
@@ -320,7 +331,7 @@ export class UserEditComponent implements OnInit {
           }
         });
     }
-    if (this.isManager || this.isTeacher) {
+    if (this.isManager) {
       this.lookupService
         .getUsersForSelects(filter, Number(UserTypesEnum.Student), 0, 0, this.currentUser?.branchId || 0)
         .subscribe((res) => {
@@ -331,6 +342,29 @@ export class UserEditComponent implements OnInit {
           }
         });
     }
+  }
+
+  private loadStudentsAndCircles(managerId: number) {
+    const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
+    this.lookupService
+      .getUsersForSelects(filter, Number(UserTypesEnum.Student), managerId, 0, this.currentUser?.branchId || 0)
+      .subscribe((res) => {
+        if (res.isSuccess) {
+          this.students = res.data.items;
+        }
+      });
+    const circleFilter: FilteredResultRequestDto = {
+      skipCount: 0,
+      maxResultCount: 100,
+      filter: `managerId=${managerId}`
+    };
+    this.circleService.getAll(circleFilter).subscribe((res) => {
+      if (res.isSuccess) {
+        this.circles = res.data.items;
+      }
+    });
+    this.basicInfoForm.get('studentIds')?.enable();
+    this.basicInfoForm.get('circleId')?.enable();
   }
 
   private loadCircles() {


### PR DESCRIPTION
## Summary
- disable manager selection when editing teachers
- load students and circles only for the selected manager and enable lists only when a manager exists

## Testing
- `CI=true npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be8f589914832288585f1a639fee5f