### PR TITLE
feat: support circle filters by manager and teacher

### DIFF
--- a/src/app/@theme/services/circle.service.ts
+++ b/src/app/@theme/services/circle.service.ts
@@ -81,7 +81,9 @@ export class CircleService {
   }
 
   getAll(
-    filter: FilteredResultRequestDto
+    filter: FilteredResultRequestDto,
+    managerId?: number,
+    teacherId?: number
   ): Observable<ApiResponse<PagedResultDto<CircleDto>>> {
     let params = new HttpParams();
     if (filter.skipCount !== undefined) {
@@ -104,6 +106,12 @@ export class CircleService {
     }
     if (filter.sortBy) {
       params = params.set('SortBy', filter.sortBy);
+    }
+    if (managerId !== undefined) {
+      params = params.set('managerId', managerId.toString());
+    }
+    if (teacherId !== undefined) {
+      params = params.set('teacherId', teacherId.toString());
     }
     return this.http.get<ApiResponse<PagedResultDto<CircleDto>>>(
       `${environment.apiUrl}/api/Circle/GetResultsByFilter`,

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
@@ -355,10 +355,9 @@ export class UserEditComponent implements OnInit {
       });
     const circleFilter: FilteredResultRequestDto = {
       skipCount: 0,
-      maxResultCount: 100,
-      filter: `managerId=${managerId}`
+      maxResultCount: 100
     };
-    this.circleService.getAll(circleFilter).subscribe((res) => {
+    this.circleService.getAll(circleFilter, managerId).subscribe((res) => {
       if (res.isSuccess) {
         this.circles = res.data.items;
       }


### PR DESCRIPTION
## Summary
- allow circle retrieval to filter by manager or teacher IDs
- update user editor to supply managerId when loading circles

## Testing
- `npx ng test able-pro` *(fails: Project target does not exist)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68be95c52a588322b412f31aa6efd7d9