### PR TITLE
Allow admin to bypass branch filtering

### DIFF
--- a/src/app/@theme/services/lookup.service.ts
+++ b/src/app/@theme/services/lookup.service.ts
@@ -2,6 +2,8 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
+import { AuthenticationService } from './authentication.service';
+import { UserTypesEnum } from '../types/UserTypesEnum';
 
 export interface LookUpUserDto {
   id: number;
@@ -62,6 +64,7 @@ export interface GovernorateDto {
 @Injectable({ providedIn: 'root' })
 export class LookupService {
   private http = inject(HttpClient);
+  private auth = inject(AuthenticationService);
 
   getUsersForSelects(
     filter: FilteredResultRequestDto,
@@ -70,11 +73,13 @@ export class LookupService {
     teacherId = 0,
     branchId = 0
   ): Observable<ApiResponse<PagedResultDto<LookUpUserDto>>> {
+    const role = this.auth.getRole();
+    const effectiveBranchId = role === UserTypesEnum.Admin ? 0 : branchId;
     let params = new HttpParams()
       .set('UserTypeId', userTypeId.toString())
       .set('managerId', managerId.toString())
       .set('teacherId', teacherId.toString())
-      .set('branchId', branchId.toString());
+      .set('branchId', effectiveBranchId.toString());
     if (filter.skipCount !== undefined) {
       params = params.set('SkipCount', filter.skipCount.toString());
     }
@@ -97,21 +102,16 @@ export class LookupService {
       params = params.set('SortBy', filter.sortBy);
     }
 
-    return this.http.get<ApiResponse<PagedResultDto<LookUpUserDto>>>(
-      `${environment.apiUrl}/api/UsersForGroups/GetUsersForSelects`,
-      { params }
-    );
+    return this.http.get<ApiResponse<PagedResultDto<LookUpUserDto>>>(`${environment.apiUrl}/api/UsersForGroups/GetUsersForSelects`, {
+      params
+    });
   }
 
   getAllNationalities(): Observable<ApiResponse<NationalityDto[]>> {
-    return this.http.get<ApiResponse<NationalityDto[]>>(
-      `${environment.apiUrl}/api/LookUp/GetAllNationality`
-    );
+    return this.http.get<ApiResponse<NationalityDto[]>>(`${environment.apiUrl}/api/LookUp/GetAllNationality`);
   }
 
   getAllGovernorates(): Observable<ApiResponse<GovernorateDto[]>> {
-    return this.http.get<ApiResponse<GovernorateDto[]>>(
-      `${environment.apiUrl}/api/LookUp/GetAllGovernorate`
-    );
+    return this.http.get<ApiResponse<GovernorateDto[]>>(`${environment.apiUrl}/api/LookUp/GetAllGovernorate`);
   }
 }


### PR DESCRIPTION
## Summary
- Inject AuthenticationService into LookupService
- Skip branch-based filtering in user lookups when logged-in user is Admin

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be9c011d448322b639c1ccc7212dbe