### PR TITLE
Refine student editor teacher filtering and circle lock

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -161,8 +161,12 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Teacher</mat-label>
-                <mat-select formControlName="teacherId" appOpenSelectOnType>
-
+                <mat-select
+                  formControlName="teacherId"
+                  appOpenSelectOnType
+                  [disabled]="!basicInfoForm.get('managerId')?.value"
+                  (selectionChange)="onTeacherChange($event.value)"
+                >
                   <mat-option *ngFor="let t of teachers" [value]="t.id">{{ t.fullName }}</mat-option>
                 </mat-select>
               </mat-form-field>
@@ -170,7 +174,11 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Manager</mat-label>
-                <mat-select formControlName="managerId" appOpenSelectOnType>
+                <mat-select
+                  formControlName="managerId"
+                  appOpenSelectOnType
+                  (selectionChange)="onManagerChange($event.value)"
+                >
                   <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>
                 </mat-select>
               </mat-form-field>
@@ -178,7 +186,7 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Circle</mat-label>
-                <mat-select formControlName="circleId" appOpenSelectOnType>
+                <mat-select formControlName="circleId" appOpenSelectOnType disabled>
                   <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
                 </mat-select>
               </mat-form-field>


### PR DESCRIPTION
## Summary
- Disable student teacher dropdown until a manager is selected
- Fetch only that manager's teachers and auto-select teacher circle
- Lock circle field to teacher's assigned circle

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*

------
https://chatgpt.com/codex/tasks/task_e_68be9daed14883228ffc3d434275b0f7