### PR TITLE
Refine student editor teacher filtering and circle lock

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -161,8 +161,12 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Teacher</mat-label>
-                <mat-select formControlName="teacherId" appOpenSelectOnType>
-
+                <mat-select
+                  formControlName="teacherId"
+                  appOpenSelectOnType
+                  [disabled]="!basicInfoForm.get('managerId')?.value"
+                  (selectionChange)="onTeacherChange($event.value)"
+                >
                   <mat-option *ngFor="let t of teachers" [value]="t.id">{{ t.fullName }}</mat-option>
                 </mat-select>
               </mat-form-field>
@@ -170,7 +174,11 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Manager</mat-label>
-                <mat-select formControlName="managerId" appOpenSelectOnType>
+                <mat-select
+                  formControlName="managerId"
+                  appOpenSelectOnType
+                  (selectionChange)="onManagerChange($event.value)"
+                >
                   <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>
                 </mat-select>
               </mat-form-field>
@@ -178,7 +186,7 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Circle</mat-label>
-                <mat-select formControlName="circleId" appOpenSelectOnType>
+                <mat-select formControlName="circleId" appOpenSelectOnType disabled>
                   <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
                 </mat-select>
               </mat-form-field>

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
@@ -256,6 +256,17 @@ export class UserEditComponent implements OnInit {
             this.basicInfoForm.get('studentIds')?.disable();
             this.basicInfoForm.get('circleId')?.disable();
           }
+        } else if (this.isStudent) {
+          this.basicInfoForm.get('teacherId')?.disable();
+          this.basicInfoForm.get('circleId')?.disable();
+          const mId = this.basicInfoForm.get('managerId')?.value;
+          if (mId) {
+            this.onManagerChange(mId, true);
+            const tId = this.basicInfoForm.get('teacherId')?.value;
+            if (tId) {
+              this.onTeacherChange(tId);
+            }
+          }
         } else {
           this.loadCircles();
         }
@@ -313,15 +324,6 @@ export class UserEditComponent implements OnInit {
         });
     } else if (this.isStudent) {
       this.lookupService
-        .getUsersForSelects(filter, Number(UserTypesEnum.Teacher), 0, 0, this.currentUser?.branchId || 0)
-        .subscribe((res) => {
-          if (res.isSuccess) {
-            const existing = new Map(this.teachers.map((t) => [t.id, t]));
-            res.data.items.forEach((t) => existing.set(t.id, t));
-            this.teachers = Array.from(existing.values());
-          }
-        });
-      this.lookupService
         .getUsersForSelects(filter, Number(UserTypesEnum.Manager), 0, 0, this.currentUser?.branchId || 0)
         .subscribe((res) => {
           if (res.isSuccess) {
@@ -342,6 +344,54 @@ export class UserEditComponent implements OnInit {
           }
         });
     }
+  }
+
+  onManagerChange(managerId: number, initial = false) {
+    const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
+    if (managerId) {
+      this.lookupService
+        .getUsersForSelects(filter, Number(UserTypesEnum.Teacher), managerId, 0, this.currentUser?.branchId || 0)
+        .subscribe((res) => {
+          if (res.isSuccess) {
+            this.teachers = res.data.items;
+            const current = this.basicInfoForm.get('teacherId')?.value;
+            if (!initial) {
+              this.basicInfoForm.patchValue({ teacherId: null });
+            } else if (current && !this.teachers.some((t) => t.id === current)) {
+              this.basicInfoForm.patchValue({ teacherId: null });
+            }
+          }
+        });
+      this.basicInfoForm.get('teacherId')?.enable();
+      if (!initial) {
+        this.basicInfoForm.patchValue({ circleId: null });
+      }
+      this.circles = [];
+      this.basicInfoForm.get('circleId')?.disable();
+    } else {
+      this.teachers = [];
+      this.basicInfoForm.patchValue({ teacherId: null, circleId: null });
+      this.basicInfoForm.get('teacherId')?.disable();
+      this.circles = [];
+      this.basicInfoForm.get('circleId')?.disable();
+    }
+  }
+
+  onTeacherChange(teacherId: number) {
+    const circleFilter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
+    if (teacherId) {
+      this.circleService.getAll(circleFilter, undefined, teacherId).subscribe((res) => {
+        if (res.isSuccess) {
+          this.circles = res.data.items;
+          const first = this.circles[0];
+          this.basicInfoForm.patchValue({ circleId: first ? first.id : null });
+        }
+      });
+    } else {
+      this.circles = [];
+      this.basicInfoForm.patchValue({ circleId: null });
+    }
+    this.basicInfoForm.get('circleId')?.disable();
   }
 
   private loadStudentsAndCircles(managerId: number) {
@@ -402,7 +452,8 @@ export class UserEditComponent implements OnInit {
 
   onSubmit() {
     if (this.basicInfoForm.valid) {
-      const formValue = this.basicInfoForm.value;
+      // Use getRawValue so disabled controls like circleId are included
+      const formValue = this.basicInfoForm.getRawValue();
       const clean = (v: string) => v.replace(/\D/g, '');
       const model: UpdateUserDto = {
         id: this.userId,


### PR DESCRIPTION
## Summary
- Disable student teacher dropdown until a manager is selected
- Fetch only that manager's teachers and auto-select teacher circle
- Lock circle field to teacher's assigned circle
- Include disabled circle field value when submitting the user form

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*


------
https://chatgpt.com/codex/tasks/task_e_68be9daed14883228ffc3d434275b0f7