### PR TITLE
Link manager circles to teacher selection

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.html
@@ -109,7 +109,12 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Teachers</mat-label>
-                <mat-select formControlName="teacherIds" multiple appOpenSelectOnType>
+                <mat-select
+                  formControlName="teacherIds"
+                  multiple
+                  appOpenSelectOnType
+                  (selectionChange)="onTeachersChange($event.value)"
+                >
                   <mat-option *ngFor="let t of teachers" [value]="t.id">{{ t.fullName }}</mat-option>
                 </mat-select>
               </mat-form-field>
@@ -125,7 +130,7 @@
             <div class="col-md-6">
               <mat-form-field appearance="outline" class="w-100 m-b-10">
                 <mat-label>Circles</mat-label>
-                <mat-select formControlName="circleIds" multiple appOpenSelectOnType>
+                <mat-select formControlName="circleIds" multiple appOpenSelectOnType disabled>
                   <mat-option *ngFor="let c of circles" [value]="c.id">{{ c.name }}</mat-option>
                 </mat-select>
               </mat-form-field>

--- a/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/user-edit/user-edit.component.ts
@@ -130,9 +130,11 @@ export class UserEditComponent implements OnInit {
           const teacherList = this.currentUser.teachers ?? this.currentUser.managers ?? [];
           if (teacherList.length) {
             this.teachers = teacherList;
+            const ids = teacherList.map((t) => t.id);
             this.basicInfoForm.patchValue({
-              teacherIds: teacherList.map((t) => t.id)
+              teacherIds: ids
             });
+            this.onTeachersChange(ids);
           }
         } else if (this.isTeacher) {
           if (this.currentUser.managers?.length) {
@@ -247,6 +249,9 @@ export class UserEditComponent implements OnInit {
           }
         }
         this.loadRelatedUsers();
+        if (this.isManager) {
+          this.basicInfoForm.get('circleIds')?.disable();
+        }
         if (this.isTeacher) {
           this.basicInfoForm.get('managerId')?.disable();
           const mId = this.basicInfoForm.get('managerId')?.value;
@@ -343,6 +348,19 @@ export class UserEditComponent implements OnInit {
             this.students = Array.from(existing.values());
           }
         });
+    }
+  }
+
+  onTeachersChange(teacherIds: number[]) {
+    if (this.isManager) {
+      const circleIds = Array.from(
+        new Set(
+          (teacherIds || [])
+            .map((id) => this.teachers.find((t) => t.id === id)?.circleId)
+            .filter((id): id is number => id !== undefined)
+        )
+      );
+      this.basicInfoForm.patchValue({ circleIds });
     }
   }
 


### PR DESCRIPTION
## Summary
- Disable manual circle selection on manager edit page and fill circles from selected teachers
- Auto-map selected teacher IDs to their circle IDs

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beaf27afe48322a2f3177c658e8006