### PR TITLE
Disable manager selection for manager users in course edit

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.html
@@ -19,7 +19,7 @@
         <div class="col-md-6">
           <mat-form-field appearance="outline" class="w-100">
             <mat-label>Managers</mat-label>
-            <mat-select formControlName="managers" multiple>
+            <mat-select formControlName="managers" multiple [disabled]="isManager">
               <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>
             </mat-select>
           </mat-form-field>

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
@@ -18,6 +18,7 @@ import {
 } from 'src/app/@theme/services/circle.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 
 @Component({
   selector: 'app-courses-update',
@@ -31,12 +32,14 @@ export class CoursesUpdateComponent implements OnInit {
   private circle = inject(CircleService);
   private toast = inject(ToastService);
   private route = inject(ActivatedRoute);
+  private auth = inject(AuthenticationService);
 
   circleForm!: FormGroup;
   teachers: LookUpUserDto[] = [];
   managers: LookUpUserDto[] = [];
   students: LookUpUserDto[] = [];
   id!: number;
+  isManager = false;
 
   ngOnInit(): void {
     this.circleForm = this.fb.group({
@@ -45,6 +48,7 @@ export class CoursesUpdateComponent implements OnInit {
       managers: [[]],
       studentsIds: [[]]
     });
+    this.isManager = this.auth.getRole() === UserTypesEnum.Manager;
     const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
 
     const course = history.state.course as CircleDto | undefined;


### PR DESCRIPTION
## Summary
- Disable managers multiselect on course edit when logged in user is a manager
- Determine user role using AuthenticationService

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68bec06bb5ec8322897aee00e1ff53e7