### PR TITLE
Restrict course edits to non-teachers/students

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
@@ -51,7 +51,7 @@
                           <i class="ti ti-eye f-18"></i>
                         </a>
                       </li>
-                      <li class="list-inline-item m-r-10" matTooltip="Edit">
+                      <li class="list-inline-item m-r-10" matTooltip="Edit" *ngIf="!isTeacherOrStudent">
                         <a
                           [routerLink]="['/online-course/courses/edit', element.id]"
                           [state]="{ course: element }"

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
@@ -19,6 +19,8 @@ import {
   FilteredResultRequestDto
 } from 'src/app/@theme/services/lookup.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
+import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 
 @Component({
   selector: 'app-courses-view',
@@ -30,6 +32,7 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
   private circleService = inject(CircleService);
   private dialog = inject(MatDialog);
   private toast = inject(ToastService);
+  private auth = inject(AuthenticationService);
 
 
   displayedColumns: string[] = ['name', 'teacher', 'managers', 'action'];
@@ -38,6 +41,7 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
   filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 10 };
 
   readonly paginator = viewChild.required(MatPaginator);
+  isTeacherOrStudent = [UserTypesEnum.Teacher, UserTypesEnum.Student].includes(this.auth.getRole()!);
 
   ngOnInit() {
     this.loadCircles();


### PR DESCRIPTION
## Summary
- Inject role service into course view and track if user is a teacher or student
- Hide edit button from course view for teachers and students

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68bec599be6c8322bc4dbe96e427355e