### PR TITLE
Fix report add path under student module

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/online-courses-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/online-courses-routing.module.ts
@@ -65,13 +65,6 @@ const routes: Routes = [
         }
       },
       {
-        path: 'report/add',
-        loadComponent: () => import('./report/report-add/report-add.component').then((c) => c.ReportAddComponent),
-        data: {
-          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
-        }
-      },
-      {
         path: 'setting',
         loadChildren: () => import('./setting/setting.module').then((m) => m.SettingModule),
         data: {

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import {
@@ -23,6 +24,7 @@ export class ReportAddComponent implements OnInit {
   private service = inject(CircleReportService);
   private toast = inject(ToastService);
   private auth = inject(AuthenticationService);
+  private route = inject(ActivatedRoute);
 
   reportForm!: FormGroup;
   teachers: LookUpUserDto[] = [];
@@ -60,6 +62,11 @@ export class ReportAddComponent implements OnInit {
       const teacherId = current ? Number(current.user.id) : 0;
       this.reportForm.get('teacherId')?.setValue(teacherId);
       this.loadStudents(teacherId);
+    }
+
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    if (id) {
+      this.reportForm.get('studentId')?.setValue(id);
     }
   }
 

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-routing.module.ts
@@ -43,6 +43,20 @@ const routes: Routes = [
         data: {
           roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
         }
+      },
+      {
+        path: 'report/add/:id',
+        loadComponent: () => import('../report/report-add/report-add.component').then((c) => c.ReportAddComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
+      },
+      {
+        path: 'report/add',
+        loadComponent: () => import('../report/report-add/report-add.component').then((c) => c.ReportAddComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+        }
       }
     ]
   }


### PR DESCRIPTION
## Summary
- move report add route under student module with optional id
- preload report form's student from route parameter
- remove unused top-level report route

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run build -- --configuration development` *(terminated: long running build)*

------
https://chatgpt.com/codex/tasks/task_e_68bec7a53b608322b8ffaca91d5d3d96