### PR TITLE
Remove student selection and use circle teacher

### DIFF
--- a/src/app/@theme/services/circle-report.service.ts
+++ b/src/app/@theme/services/circle-report.service.ts
@@ -1,13 +1,8 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import {
-  ApiResponse,
-  FilteredResultRequestDto,
-  LookUpUserDto,
-  PagedResultDto,
-} from './lookup.service';
+import { ApiResponse } from './lookup.service';
 
 export interface CircleReportAddDto {
   id?: number;
@@ -40,43 +35,6 @@ export class CircleReportService {
     return this.http.post<ApiResponse<boolean>>(
       `${environment.apiUrl}/api/CircleReport/Create`,
       model
-    );
-  }
-
-  getUsersForGroup(
-    filter: FilteredResultRequestDto,
-    userTypeId: number,
-    teacherId: number
-  ): Observable<ApiResponse<PagedResultDto<LookUpUserDto>>> {
-    let params = new HttpParams()
-      .set('UserTypeId', userTypeId.toString())
-      .set('teacherId', teacherId.toString());
-
-    if (filter.skipCount !== undefined) {
-      params = params.set('SkipCount', filter.skipCount.toString());
-    }
-    if (filter.maxResultCount !== undefined) {
-      params = params.set('MaxResultCount', filter.maxResultCount.toString());
-    }
-    if (filter.searchTerm) {
-      params = params.set('SearchTerm', filter.searchTerm);
-    }
-    if (filter.filter) {
-      params = params.set('Filter', filter.filter);
-    }
-    if (filter.lang) {
-      params = params.set('Lang', filter.lang);
-    }
-    if (filter.sortingDirection) {
-      params = params.set('SortingDirection', filter.sortingDirection);
-    }
-    if (filter.sortBy) {
-      params = params.set('SortBy', filter.sortBy);
-    }
-
-    return this.http.get<ApiResponse<PagedResultDto<LookUpUserDto>>>(
-      `${environment.apiUrl}/api/UsersForGroups/ManagerRequestTeacherAndStudent`,
-      { params }
     );
   }
 }

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
@@ -22,6 +22,7 @@
                     <li class="list-inline-item" matTooltip="Add Report">
                       <a
                         [routerLink]="['/online-course/student/report/add', element.studentId || element.id]"
+                        [state]="{ circle: course }"
                         class="avatar avatar-xs text-muted"
                       >
                         <i class="ti ti-report f-18"></i>

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.html
@@ -2,24 +2,6 @@
   <div class="col-12">
     <app-card cardTitle="Add Circle Report">
       <form [formGroup]="reportForm" (ngSubmit)="onSubmit()" class="row">
-        <div class="col-md-6" *ngIf="role === UserTypesEnum.Manager">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Teacher</mat-label>
-            <mat-select (selectionChange)="onTeacherChange($event.value)">
-              <mat-option *ngFor="let t of teachers" [value]="t.id">{{ t.fullName }}</mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
-
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Student</mat-label>
-            <mat-select formControlName="studentId">
-              <mat-option *ngFor="let s of students" [value]="s.id">{{ s.fullName }}</mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
-
         <div class="col-md-6">
           <mat-form-field appearance="outline" class="w-100">
             <mat-label>Minutes</mat-label>

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
@@ -8,8 +8,7 @@ import {
   CircleReportService,
   CircleReportAddDto,
 } from 'src/app/@theme/services/circle-report.service';
-import { CircleService } from 'src/app/@theme/services/circle.service';
-import { LookUpUserDto } from 'src/app/@theme/services/lookup.service';
+import { CircleService, CircleDto } from 'src/app/@theme/services/circle.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
@@ -29,8 +28,6 @@ export class ReportAddComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   reportForm!: FormGroup;
-  teachers: LookUpUserDto[] = [];
-  students: LookUpUserDto[] = [];
   role = this.auth.getRole();
   UserTypesEnum = UserTypesEnum;
 
@@ -57,13 +54,17 @@ export class ReportAddComponent implements OnInit {
       attendStatueId: []
     });
 
-    if (this.role === UserTypesEnum.Manager) {
-      this.loadTeachers();
+    const course = history.state.circle as CircleDto | undefined;
+
+    if (course) {
+      this.reportForm.patchValue({
+        teacherId: course.teacherId,
+        circleId: course.id,
+      });
     } else if (this.role === UserTypesEnum.Teacher) {
       const current = this.auth.currentUserValue;
       const teacherId = current ? Number(current.user.id) : 0;
       this.reportForm.get('teacherId')?.setValue(teacherId);
-      this.loadStudents(teacherId);
       this.loadCircle(teacherId);
     }
 
@@ -71,32 +72,6 @@ export class ReportAddComponent implements OnInit {
     if (id) {
       this.reportForm.get('studentId')?.setValue(id);
     }
-  }
-
-  loadTeachers() {
-    this.service
-      .getUsersForGroup({ skipCount: 0, maxResultCount: 100 }, Number(UserTypesEnum.Teacher), 0)
-      .subscribe((res) => {
-        if (res.isSuccess) {
-          this.teachers = res.data.items;
-        }
-      });
-  }
-
-  onTeacherChange(id: number) {
-    this.reportForm.get('teacherId')?.setValue(id);
-    this.loadStudents(id);
-    this.loadCircle(id);
-  }
-
-  loadStudents(teacherId: number) {
-    this.service
-      .getUsersForGroup({ skipCount: 0, maxResultCount: 100 }, Number(UserTypesEnum.Student), teacherId)
-      .subscribe((res) => {
-        if (res.isSuccess) {
-          this.students = res.data.items;
-        }
-      });
   }
 
   loadCircle(teacherId: number) {


### PR DESCRIPTION
## Summary
- Pass circle data when adding a report from course details
- Populate teacher and circle IDs from navigation state
- Drop API for teacher/student lookup and simplify report form

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68becca305f08322ae20becd0cf908ec