### PR TITLE
feat: add attendance status handling to report form

### DIFF
--- a/src/app/@theme/types/AttendStatusEnum.ts
+++ b/src/app/@theme/types/AttendStatusEnum.ts
@@ -1,0 +1,5 @@
+export enum AttendStatusEnum {
+  Attended = 1,
+  ExcusedAbsence = 2,
+  UnexcusedAbsence = 3
+}

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.html
@@ -4,101 +4,107 @@
       <form [formGroup]="reportForm" (ngSubmit)="onSubmit()" class="row">
         <div class="col-md-6">
           <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Attend Status</mat-label>
+            <mat-select formControlName="attendStatueId" (selectionChange)="onStatusChange($event.value)">
+              <mat-option [value]="AttendStatusEnum.Attended">حضر</mat-option>
+              <mat-option [value]="AttendStatusEnum.ExcusedAbsence">تغيب بعذر</mat-option>
+              <mat-option [value]="AttendStatusEnum.UnexcusedAbsence">تغيب بدون عذر</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+
+        <div class="col-md-6" *ngIf="selectedStatus === AttendStatusEnum.Attended || selectedStatus === AttendStatusEnum.UnexcusedAbsence">
+          <mat-form-field appearance="outline" class="w-100">
             <mat-label>Minutes</mat-label>
             <input matInput type="number" formControlName="minutes" />
           </mat-form-field>
         </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Attend Statue Id</mat-label>
-            <input matInput type="number" formControlName="attendStatueId" />
-          </mat-form-field>
-        </div>
+        <ng-container *ngIf="selectedStatus === AttendStatusEnum.Attended">
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>New From</mat-label>
+              <input matInput formControlName="newFrom" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>New From</mat-label>
-            <input matInput formControlName="newFrom" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>New To</mat-label>
+              <input matInput formControlName="newTo" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>New To</mat-label>
-            <input matInput formControlName="newTo" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>New Rate</mat-label>
+              <input matInput formControlName="newRate" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>New Rate</mat-label>
-            <input matInput formControlName="newRate" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>Recent Past</mat-label>
+              <input matInput formControlName="recentPast" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Recent Past</mat-label>
-            <input matInput formControlName="recentPast" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>Recent Past Rate</mat-label>
+              <input matInput formControlName="recentPastRate" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Recent Past Rate</mat-label>
-            <input matInput formControlName="recentPastRate" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>Distant Past</mat-label>
+              <input matInput formControlName="distantPast" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Distant Past</mat-label>
-            <input matInput formControlName="distantPast" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>Distant Past Rate</mat-label>
+              <input matInput formControlName="distantPastRate" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Distant Past Rate</mat-label>
-            <input matInput formControlName="distantPastRate" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>Farthest Past</mat-label>
+              <input matInput formControlName="farthestPast" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Farthest Past</mat-label>
-            <input matInput formControlName="farthestPast" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>Farthest Past Rate</mat-label>
+              <input matInput formControlName="farthestPastRate" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Farthest Past Rate</mat-label>
-            <input matInput formControlName="farthestPastRate" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>The Words Quran Stranger</mat-label>
+              <input matInput formControlName="theWordsQuranStranger" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>The Words Quran Stranger</mat-label>
-            <input matInput formControlName="theWordsQuranStranger" />
-          </mat-form-field>
-        </div>
+          <div class="col-md-6">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>Intonation</mat-label>
+              <input matInput formControlName="intonation" />
+            </mat-form-field>
+          </div>
 
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Intonation</mat-label>
-            <input matInput formControlName="intonation" />
-          </mat-form-field>
-        </div>
-
-        <div class="col-md-12">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Other</mat-label>
-            <textarea matInput formControlName="other"></textarea>
-          </mat-form-field>
-        </div>
+          <div class="col-md-12">
+            <mat-form-field appearance="outline" class="w-100">
+              <mat-label>Other</mat-label>
+              <textarea matInput formControlName="other"></textarea>
+            </mat-form-field>
+          </div>
+        </ng-container>
 
         <div class="col-12">
           <button mat-flat-button color="primary" type="submit">Create</button>

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
@@ -4,14 +4,12 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 import { SharedModule } from 'src/app/demo/shared/shared.module';
-import {
-  CircleReportService,
-  CircleReportAddDto,
-} from 'src/app/@theme/services/circle-report.service';
+import { CircleReportService, CircleReportAddDto } from 'src/app/@theme/services/circle-report.service';
 import { CircleService, CircleDto } from 'src/app/@theme/services/circle.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+import { AttendStatusEnum } from 'src/app/@theme/types/AttendStatusEnum';
 
 @Component({
   selector: 'app-report-add',
@@ -30,6 +28,8 @@ export class ReportAddComponent implements OnInit {
   reportForm!: FormGroup;
   role = this.auth.getRole();
   UserTypesEnum = UserTypesEnum;
+  AttendStatusEnum = AttendStatusEnum;
+  selectedStatus?: AttendStatusEnum;
 
   ngOnInit(): void {
     this.reportForm = this.fb.group({
@@ -54,13 +54,15 @@ export class ReportAddComponent implements OnInit {
       attendStatueId: []
     });
 
+    this.toggleFields();
+
     const course = history.state.circle as CircleDto | undefined;
 
     if (course) {
       this.reportForm.patchValue({
         teacherId: course.teacherId ?? course.teacher?.id,
 
-        circleId: course.id,
+        circleId: course.id
       });
     } else if (this.role === UserTypesEnum.Teacher) {
       const current = this.auth.currentUserValue;
@@ -75,14 +77,58 @@ export class ReportAddComponent implements OnInit {
     }
   }
 
+  private allFields(): string[] {
+    return [
+      'minutes',
+      'newId',
+      'newFrom',
+      'newTo',
+      'newRate',
+      'recentPast',
+      'recentPastRate',
+      'distantPast',
+      'distantPastRate',
+      'farthestPast',
+      'farthestPastRate',
+      'theWordsQuranStranger',
+      'intonation',
+      'other'
+    ];
+  }
+
+  private toggleFields() {
+    const controls = this.allFields();
+    controls.forEach((c) => {
+      this.reportForm.get(c)?.disable();
+      this.reportForm.get(c)?.clearValidators();
+      this.reportForm.get(c)?.updateValueAndValidity();
+    });
+  }
+
+  onStatusChange(status: AttendStatusEnum) {
+    this.selectedStatus = status;
+    const controls = this.allFields();
+    controls.forEach((c) => {
+      this.reportForm.get(c)?.disable();
+      this.reportForm.get(c)?.clearValidators();
+      this.reportForm.get(c)?.updateValueAndValidity();
+    });
+
+    if (status === AttendStatusEnum.Attended) {
+      controls.forEach((c) => this.reportForm.get(c)?.enable());
+    } else if (status === AttendStatusEnum.UnexcusedAbsence) {
+      this.reportForm.get('minutes')?.enable();
+      this.reportForm.get('minutes')?.setValidators([Validators.required]);
+      this.reportForm.get('minutes')?.updateValueAndValidity();
+    }
+  }
+
   loadCircle(teacherId: number) {
-    this.circleService
-      .getAll({ skipCount: 0, maxResultCount: 1 }, undefined, teacherId)
-      .subscribe((res) => {
-        if (res.isSuccess && res.data.items.length) {
-          this.reportForm.get('circleId')?.setValue(res.data.items[0].id);
-        }
-      });
+    this.circleService.getAll({ skipCount: 0, maxResultCount: 1 }, undefined, teacherId).subscribe((res) => {
+      if (res.isSuccess && res.data.items.length) {
+        this.reportForm.get('circleId')?.setValue(res.data.items[0].id);
+      }
+    });
   }
 
   onSubmit() {
@@ -104,4 +150,3 @@ export class ReportAddComponent implements OnInit {
     });
   }
 }
-


### PR DESCRIPTION
## Summary
- add AttendStatusEnum
- hide or show report fields based on selected attendance status
- require minutes for unexcused absences

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68bede1e1e688322a9d0e96eb376a4be