### PR TITLE
Add subscribe options to settings menu

### DIFF
--- a/src/app/demo/data/menu.ts
+++ b/src/app/demo/data/menu.ts
@@ -367,6 +367,18 @@ export const menus: Navigation[] = [
                 title: 'Notification',
                 type: 'item',
                 url: '/online-course/setting/notification'
+              },
+              {
+                id: 'subscribe',
+                title: 'Subscribe',
+                type: 'item',
+                url: '/online-course/setting/subscribe'
+              },
+              {
+                id: 'subscribe-type',
+                title: 'Subscribe Type',
+                type: 'item',
+                url: '/online-course/setting/subscribe-type'
               }
             ]
           }


### PR DESCRIPTION
## Summary
- include Subscribe and Subscribe Type in Online Courses settings menu

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint` *(fails: 2 lint errors about no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe822d0b88322aaecb5b2fa7d25ec