### PR TITLE
Align subscribe service with new API endpoints

### DIFF
--- a/src/app/@theme/services/subscribe.service.ts
+++ b/src/app/@theme/services/subscribe.service.ts
@@ -56,7 +56,7 @@ export class SubscribeService {
   // subscribe crud
   create(model: CreateSubscribeDto): Observable<ApiResponse<boolean>> {
     return this.http.post<ApiResponse<boolean>>(
-      `${environment.apiUrl}/api/Subscribe/Create`,
+      `${environment.apiUrl}/api/Subscribe/CreateSubscribe`,
       model
     );
   }
@@ -70,17 +70,8 @@ export class SubscribeService {
 
   delete(id: number): Observable<ApiResponse<boolean>> {
     const params = new HttpParams().set('id', id.toString());
-    return this.http.post<ApiResponse<boolean>>(
+    return this.http.get<ApiResponse<boolean>>(
       `${environment.apiUrl}/api/Subscribe/Delete`,
-      null,
-      { params }
-    );
-  }
-
-  get(id: number): Observable<ApiResponse<SubscribeDto>> {
-    const params = new HttpParams().set('id', id.toString());
-    return this.http.get<ApiResponse<SubscribeDto>>(
-      `${environment.apiUrl}/api/Subscribe/Get`,
       { params }
     );
   }
@@ -119,31 +110,22 @@ export class SubscribeService {
   // subscribe type crud
   createType(model: CreateSubscribeTypeDto): Observable<ApiResponse<boolean>> {
     return this.http.post<ApiResponse<boolean>>(
-      `${environment.apiUrl}/api/SubscribeType/Create`,
+      `${environment.apiUrl}/api/Subscribe/CreateSubscribeType`,
       model
     );
   }
 
   updateType(model: UpdateSubscribeTypeDto): Observable<ApiResponse<boolean>> {
     return this.http.post<ApiResponse<boolean>>(
-      `${environment.apiUrl}/api/SubscribeType/Update`,
+      `${environment.apiUrl}/api/Subscribe/UpdateType`,
       model
     );
   }
 
   deleteType(id: number): Observable<ApiResponse<boolean>> {
     const params = new HttpParams().set('id', id.toString());
-    return this.http.post<ApiResponse<boolean>>(
-      `${environment.apiUrl}/api/SubscribeType/Delete`,
-      null,
-      { params }
-    );
-  }
-
-  getType(id: number): Observable<ApiResponse<SubscribeTypeDto>> {
-    const params = new HttpParams().set('id', id.toString());
-    return this.http.get<ApiResponse<SubscribeTypeDto>>(
-      `${environment.apiUrl}/api/SubscribeType/Get`,
+    return this.http.get<ApiResponse<boolean>>(
+      `${environment.apiUrl}/api/Subscribe/DeleteType`,
       { params }
     );
   }
@@ -174,7 +156,7 @@ export class SubscribeService {
       params = params.set('SortBy', filter.sortBy);
     }
     return this.http.get<ApiResponse<PagedResultDto<SubscribeTypeDto>>>(
-      `${environment.apiUrl}/api/SubscribeType/GetResultsByFilter`,
+      `${environment.apiUrl}/api/Subscribe/GetTypeResultsByFilter`,
       { params }
     );
   }

--- a/src/app/demo/pages/admin-panel/online-courses/setting/subscribe-type/subscribe-type-form/subscribe-type-form.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/setting/subscribe-type/subscribe-type-form/subscribe-type-form.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import {
   SubscribeService,
   CreateSubscribeTypeDto,
-  UpdateSubscribeTypeDto
+  UpdateSubscribeTypeDto,
+  SubscribeTypeDto
 } from 'src/app/@theme/services/subscribe.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
 
@@ -20,26 +21,26 @@ export class SubscribeTypeFormComponent implements OnInit {
   private fb = inject(FormBuilder);
   private service = inject(SubscribeService);
   private router = inject(Router);
-  private route = inject(ActivatedRoute);
   private toast = inject(ToastService);
 
   form = this.fb.group({
-    id: [0],
+    id: [0 as number | null],
     name: ['', Validators.required],
-    forignPricePerHour: [],
-    arabPricePerHour: []
+    forignPricePerHour: [null as number | null],
+    arabPricePerHour: [null as number | null]
   });
 
   isEdit = false;
 
   ngOnInit() {
-    const id = Number(this.route.snapshot.paramMap.get('id'));
-    if (id) {
+    const data = history.state?.item as SubscribeTypeDto | undefined;
+    if (data) {
       this.isEdit = true;
-      this.service.getType(id).subscribe((res) => {
-        if (res.isSuccess && res.data) {
-          this.form.patchValue(res.data as any);
-        }
+      this.form.patchValue({
+        id: data.id,
+        name: data.name ?? '',
+        forignPricePerHour: data.forignPricePerHour ?? null,
+        arabPricePerHour: data.arabPricePerHour ?? null,
       });
     }
   }

--- a/src/app/demo/pages/admin-panel/online-courses/setting/subscribe-type/subscribe-type.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/setting/subscribe-type/subscribe-type.component.html
@@ -46,6 +46,7 @@
                       <li class="list-inline-item m-r-10" matTooltip="Edit">
                         <a
                           [routerLink]="['/online-course/setting/subscribe-type/edit', element.id]"
+                          [state]="{ item: element }"
                           class="avatar avatar-xs text-muted"
                         >
                           <i class="ti ti-edit-circle f-18"></i>

--- a/src/app/demo/pages/admin-panel/online-courses/setting/subscribe/subscribe-form/subscribe-form.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/setting/subscribe/subscribe-form/subscribe-form.component.ts
@@ -1,13 +1,14 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import {
   SubscribeService,
   CreateSubscribeDto,
   UpdateSubscribeDto,
-  SubscribeTypeDto
+  SubscribeTypeDto,
+  SubscribeDto
 } from 'src/app/@theme/services/subscribe.service';
 import { FilteredResultRequestDto } from 'src/app/@theme/services/lookup.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
@@ -22,30 +23,33 @@ export class SubscribeFormComponent implements OnInit {
   private fb = inject(FormBuilder);
   private service = inject(SubscribeService);
   private router = inject(Router);
-  private route = inject(ActivatedRoute);
   private toast = inject(ToastService);
 
   form = this.fb.group({
-    id: [0],
+    id: [0 as number | null],
     name: ['', Validators.required],
-    leprice: [],
-    sarprice: [],
-    usdprice: [],
-    minutes: [],
-    subscribeTypeId: []
+    leprice: [null as number | null],
+    sarprice: [null as number | null],
+    usdprice: [null as number | null],
+    minutes: [null as number | null],
+    subscribeTypeId: [null as number | null]
   });
 
   isEdit = false;
   types: SubscribeTypeDto[] = [];
 
   ngOnInit() {
-    const id = Number(this.route.snapshot.paramMap.get('id'));
-    if (id) {
+    const data = history.state?.item as SubscribeDto | undefined;
+    if (data) {
       this.isEdit = true;
-      this.service.get(id).subscribe((res) => {
-        if (res.isSuccess && res.data) {
-          this.form.patchValue(res.data as any);
-        }
+      this.form.patchValue({
+        id: data.id,
+        name: data.name ?? '',
+        leprice: data.leprice ?? null,
+        sarprice: data.sarprice ?? null,
+        usdprice: data.usdprice ?? null,
+        minutes: data.minutes ?? null,
+        subscribeTypeId: data.subscribeTypeId ?? null,
       });
     }
     const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };

--- a/src/app/demo/pages/admin-panel/online-courses/setting/subscribe/subscribe.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/setting/subscribe/subscribe.component.html
@@ -46,6 +46,7 @@
                       <li class="list-inline-item m-r-10" matTooltip="Edit">
                         <a
                           [routerLink]="['/online-course/setting/subscribe/edit', element.id]"
+                          [state]="{ item: element }"
                           class="avatar avatar-xs text-muted"
                         >
                           <i class="ti ti-edit-circle f-18"></i>


### PR DESCRIPTION
## Summary
- use router state to supply subscribe or type data when editing
- drop GetById methods from subscribe service
- coalesce router state data to null-safe values before patching subscribe forms
- type numeric fields in subscribe and subscribe-type forms as `number | null`

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command.)*

------
https://chatgpt.com/codex/tasks/task_e_68bfed8930a483229380c5e54fe0f249