### PR TITLE
Load subscribe types from API with error handling

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/setting/subscribe/subscribe-form/subscribe-form.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/setting/subscribe/subscribe-form/subscribe-form.component.ts
@@ -54,10 +54,15 @@ export class SubscribeFormComponent implements OnInit {
 
     }
     const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
-    this.service.getAllTypes(filter).subscribe((res) => {
-      if (res.isSuccess && res.data?.items) {
-        this.types = res.data.items;
-      }
+    this.service.getAllTypes(filter).subscribe({
+      next: (res) => {
+        if (res.isSuccess && res.data?.items) {
+          this.types = res.data.items;
+        } else {
+          this.types = [];
+        }
+      },
+      error: () => this.toast.error('Error loading subscribe types')
     });
   }
 


### PR DESCRIPTION
## Summary
- Ensure subscribe forms retrieve type options from the GetTypeResultsByFilter endpoint
- Handle failures when loading subscribe type options

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68bffadc65548322a402b664fe609108