### PR TITLE
Connect membership list to StudentSubscrib API

### DIFF
--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
@@ -44,16 +44,18 @@
               <ng-container matColumnDef="status">
                 <th mat-header-cell *matHeaderCellDef>STATUS</th>
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
-                  @if (element.status === 'active') {
+                  @if (element.status === 'payed') {
                     <div class="text-success-500">
                       <i class="fas fa-circle f-10 m-r-10 text-success"></i>
-                      Active
+                      Payed
+                    </div>
+                  } @else if (element.status === 'not payed') {
+                    <div class="text-accent-500">
+                      <i class="fas fa-circle f-10 m-r-10 text-accent-500"></i>
+                      Not payed
                     </div>
                   } @else {
-                    <div class="text-accent-500">
-                      <i class="fas fa-circle f-10 m-r-10 text-success"></i>
-                      Inactive
-                    </div>
+                    <div>There is no</div>
                   }
                 </td>
               </ng-container>
@@ -61,15 +63,7 @@
               <!-- STATUS Column -->
               <ng-container matColumnDef="plan">
                 <th mat-header-cell *matHeaderCellDef>PLAN</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">
-                  @if (element.plan === 'casual') {
-                    <div class="user-status bg-success-500 text-white">Casual</div>
-                  } @else if (element.plan === 'addicted') {
-                    <div class="user-status bg-primary-500 text-white">Addicted</div>
-                  } @else if (element.plan === 'diehard') {
-                    <div class="user-status bg-warning-500 text-white">Diehard</div>
-                  }
-                </td>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.plan }}</td>
               </ng-container>
 
               <!-- action Column -->


### PR DESCRIPTION
## Summary
- Load membership data from `https://localhost:7260/api/StudentSubscrib/GetStudents`
- Display "there is no" for missing values and map payment status to "payed"/"not payed"
- Simplify plan column to show value directly

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c017e720d48322ab70c95ddb7106a4