### PR TITLE
Connect membership list to StudentSubscrib API

### DIFF
--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
@@ -44,16 +44,18 @@
               <ng-container matColumnDef="status">
                 <th mat-header-cell *matHeaderCellDef>STATUS</th>
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
-                  @if (element.status === 'active') {
+                  @if (element.status === 'payed') {
                     <div class="text-success-500">
                       <i class="fas fa-circle f-10 m-r-10 text-success"></i>
-                      Active
+                      Payed
+                    </div>
+                  } @else if (element.status === 'not payed') {
+                    <div class="text-accent-500">
+                      <i class="fas fa-circle f-10 m-r-10 text-accent-500"></i>
+                      Not payed
                     </div>
                   } @else {
-                    <div class="text-accent-500">
-                      <i class="fas fa-circle f-10 m-r-10 text-success"></i>
-                      Inactive
-                    </div>
+                    <div>there is no</div>
                   }
                 </td>
               </ng-container>
@@ -61,15 +63,7 @@
               <!-- STATUS Column -->
               <ng-container matColumnDef="plan">
                 <th mat-header-cell *matHeaderCellDef>PLAN</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">
-                  @if (element.plan === 'casual') {
-                    <div class="user-status bg-success-500 text-white">Casual</div>
-                  } @else if (element.plan === 'addicted') {
-                    <div class="user-status bg-primary-500 text-white">Addicted</div>
-                  } @else if (element.plan === 'diehard') {
-                    <div class="user-status bg-warning-500 text-white">Diehard</div>
-                  }
-                </td>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.plan }}</td>
               </ng-container>
 
               <!-- action Column -->

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
@@ -1,7 +1,8 @@
 // angular import
-import { AfterViewInit, Component, viewChild } from '@angular/core';
+import { AfterViewInit, Component, OnInit, inject, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
 
 // angular material
 import { MatTableDataSource } from '@angular/material/table';
@@ -10,7 +11,6 @@ import { MatSort } from '@angular/material/sort';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
-import { membershipListData } from 'src/app/fake-data/membership-list-data';
 
 export interface membershipList {
   name: string;
@@ -22,7 +22,25 @@ export interface membershipList {
   plan: string;
 }
 
-const ELEMENT_DATA: membershipList[] = membershipListData;
+interface StudentApiItem {
+  id: number;
+  studentId: number;
+  studentName?: string | null;
+  studentMobile?: string | null;
+  payStatus?: boolean | null;
+  plan?: string | null;
+  remainingMinutes?: number | null;
+  startDate?: string | null;
+}
+
+interface StudentApiResponse {
+  isSuccess: boolean;
+  errors: { fieldName: string; code: string; message: string; fieldLang: string }[];
+  data: {
+    items: StudentApiItem[];
+    totalCount: number;
+  };
+}
 
 @Component({
   selector: 'app-membership-list',
@@ -30,15 +48,50 @@ const ELEMENT_DATA: membershipList[] = membershipListData;
   templateUrl: './membership-list.component.html',
   styleUrl: './membership-list.component.scss'
 })
-export class MembershipListComponent implements AfterViewInit {
+export class MembershipListComponent implements AfterViewInit, OnInit {
   // public props
   displayedColumns: string[] = ['name', 'mobile', 'date', 'status', 'plan', 'action'];
-  dataSource = new MatTableDataSource(ELEMENT_DATA);
+  dataSource = new MatTableDataSource<membershipList>([]);
+
+  private http = inject(HttpClient);
 
   // paginator
-readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
+  readonly paginator = viewChild.required(MatPaginator); // if Angular ≥17
 
   readonly sort = viewChild(MatSort);
+
+  ngOnInit() {
+    this.http
+      .get<StudentApiResponse>('https://localhost:7260/api/StudentSubscrib/GetStudents')
+      .subscribe((res) => {
+        const items = res?.data?.items ?? [];
+        const data = items.map((item) => this.mapStudent(item));
+        this.dataSource.data = data;
+      });
+  }
+
+  private mapStudent(item: StudentApiItem): membershipList {
+    const payStatus = item?.payStatus;
+    const start = item?.startDate ? new Date(item.startDate) : null;
+    return {
+      name: this.normalize(item?.studentName),
+      src: 'assets/images/user/avatar-1.png',
+      mobile: this.normalize(item?.studentMobile),
+      date: start ? start.toLocaleDateString() : 'there is no',
+      time: start ? start.toLocaleTimeString() : 'there is no',
+      status:
+        payStatus === true
+          ? 'payed'
+          : payStatus === false
+            ? 'not payed'
+            : 'there is no',
+      plan: this.normalize(item?.plan)
+    };
+  }
+
+  private normalize(value: string | null | undefined): string {
+    return value === null || value === undefined || value === '' ? 'there is no' : value;
+  }
 
   // table search filter
   applyFilter(event: Event) {


### PR DESCRIPTION
## Summary
- Parse `StudentSubscrib/GetStudents` response via its `data.items` array
- Map `payStatus` booleans to friendly text and default missing values to `there is no`
- Format `startDate` into separate date and time fields

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c017e720d48322ab70c95ddb7106a4