### PR TITLE
feat: add payment detail dialog

### DIFF
--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -1,0 +1,19 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { ApiResponse, PagedResultDto } from './lookup.service';
+import { ViewStudentSubscribeReDto } from './student-subscribe.service';
+
+@Injectable({ providedIn: 'root' })
+export class StudentPaymentService {
+  private http = inject(HttpClient);
+
+  getPayment(paymentId: number): Observable<ApiResponse<PagedResultDto<ViewStudentSubscribeReDto>>> {
+    const params = new HttpParams().set('paymentId', paymentId.toString());
+    return this.http.get<ApiResponse<PagedResultDto<ViewStudentSubscribeReDto>>>(
+      `${environment.apiUrl}/api/StudentPayment/GetPayment`,
+      { params }
+    );
+  }
+}

--- a/src/app/@theme/services/student-subscribe.service.ts
+++ b/src/app/@theme/services/student-subscribe.service.ts
@@ -13,6 +13,7 @@ export interface ViewStudentSubscribeReDto {
   plan?: string | null;
   remainingMinutes?: number | null;
   startDate?: string | null;
+  studentPaymentId?: number | null;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
@@ -48,11 +48,25 @@
                     <div class="text-success-500">
                       <i class="fas fa-circle f-10 m-r-10 text-success"></i>
                       Payed
+                      <i
+                        *ngIf="element.studentPaymentId"
+                        class="ti ti-credit-card m-l-10"
+                        style="cursor: pointer"
+                        matTooltip="Payment details"
+                        (click)="openPaymentDetails(element.studentPaymentId)"
+                      ></i>
                     </div>
                   } @else if (element.payStatus === false) {
                     <div class="text-accent-500">
                       <i class="fas fa-circle f-10 m-r-10 text-accent-500"></i>
                       Not payed
+                      <i
+                        *ngIf="element.studentPaymentId"
+                        class="ti ti-credit-card m-l-10"
+                        style="cursor: pointer"
+                        matTooltip="Payment details"
+                        (click)="openPaymentDetails(element.studentPaymentId)"
+                      ></i>
                     </div>
                   } @else {
                     <div>there is no</div>

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
@@ -6,11 +6,14 @@ import { RouterModule } from '@angular/router';
 // angular material
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
+import { MatDialog } from '@angular/material/dialog';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { StudentSubscribeService, ViewStudentSubscribeReDto } from 'src/app/@theme/services/student-subscribe.service';
 import { FilteredResultRequestDto } from 'src/app/@theme/services/lookup.service';
+import { StudentPaymentService } from 'src/app/@theme/services/student-payment.service';
+import { PaymentDetailsComponent } from '../payment-details/payment-details.component';
 
 @Component({
   selector: 'app-membership-list',
@@ -20,6 +23,8 @@ import { FilteredResultRequestDto } from 'src/app/@theme/services/lookup.service
 })
 export class MembershipListComponent implements AfterViewInit, OnInit {
   private service = inject(StudentSubscribeService);
+  private paymentService = inject(StudentPaymentService);
+  private dialog = inject(MatDialog);
 
   displayedColumns: string[] = ['name', 'mobile', 'date', 'status', 'plan', 'action'];
   dataSource = new MatTableDataSource<ViewStudentSubscribeReDto>();
@@ -60,6 +65,18 @@ export class MembershipListComponent implements AfterViewInit, OnInit {
       this.filter.skipCount = this.paginator().pageIndex * this.paginator().pageSize;
       this.filter.maxResultCount = this.paginator().pageSize;
       this.load();
+    });
+  }
+
+  openPaymentDetails(paymentId?: number) {
+    if (!paymentId) {
+      return;
+    }
+    this.paymentService.getPayment(paymentId).subscribe((res) => {
+      const payment = res.data?.items?.[0];
+      if (payment) {
+        this.dialog.open(PaymentDetailsComponent, { data: payment });
+      }
     });
   }
 }

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
@@ -24,11 +24,25 @@
                     <div class="text-success-500">
                       <i class="fas fa-circle f-10 m-r-10 text-success"></i>
                       Payed
+                      <i
+                        *ngIf="element.studentPaymentId"
+                        class="ti ti-credit-card m-l-10"
+                        style="cursor: pointer"
+                        matTooltip="Payment details"
+                        (click)="openPaymentDetails(element.studentPaymentId)"
+                      ></i>
                     </div>
                   } @else if (element.payStatus === false) {
                     <div class="text-accent-500">
                       <i class="fas fa-circle f-10 m-r-10 text-accent-500"></i>
                       Not payed
+                      <i
+                        *ngIf="element.studentPaymentId"
+                        class="ti ti-credit-card m-l-10"
+                        style="cursor: pointer"
+                        matTooltip="Payment details"
+                        (click)="openPaymentDetails(element.studentPaymentId)"
+                      ></i>
                     </div>
                   } @else {
                     <div>there is no</div>

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
@@ -3,9 +3,12 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, ActivatedRoute } from '@angular/router';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
+import { MatDialog } from '@angular/material/dialog';
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { StudentSubscribeService, ViewStudentSubscribeReDto } from 'src/app/@theme/services/student-subscribe.service';
 import { FilteredResultRequestDto } from 'src/app/@theme/services/lookup.service';
+import { StudentPaymentService } from 'src/app/@theme/services/student-payment.service';
+import { PaymentDetailsComponent } from '../payment-details/payment-details.component';
 
 @Component({
   selector: 'app-membership-view',
@@ -16,6 +19,8 @@ import { FilteredResultRequestDto } from 'src/app/@theme/services/lookup.service
 export class MembershipViewComponent implements OnInit, AfterViewInit {
   private service = inject(StudentSubscribeService);
   private route = inject(ActivatedRoute);
+  private paymentService = inject(StudentPaymentService);
+  private dialog = inject(MatDialog);
 
   displayedColumns: string[] = ['plan', 'remainingMinutes', 'startDate', 'status'];
   dataSource = new MatTableDataSource<ViewStudentSubscribeReDto>();
@@ -47,6 +52,18 @@ export class MembershipViewComponent implements OnInit, AfterViewInit {
       this.filter.skipCount = this.paginator().pageIndex * this.paginator().pageSize;
       this.filter.maxResultCount = this.paginator().pageSize;
       this.load();
+    });
+  }
+
+  openPaymentDetails(paymentId?: number) {
+    if (!paymentId) {
+      return;
+    }
+    this.paymentService.getPayment(paymentId).subscribe((res) => {
+      const payment = res.data?.items?.[0];
+      if (payment) {
+        this.dialog.open(PaymentDetailsComponent, { data: payment });
+      }
     });
   }
 }

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
@@ -1,0 +1,12 @@
+<h2 mat-dialog-title>Payment Details</h2>
+<div mat-dialog-content>
+  <p><strong>Name:</strong> {{ data.studentName }}</p>
+  <p><strong>Mobile:</strong> {{ data.studentMobile }}</p>
+  <p><strong>Plan:</strong> {{ data.plan }}</p>
+  <p><strong>Remaining Minutes:</strong> {{ data.remainingMinutes }}</p>
+  <p><strong>Start Date:</strong> {{ data.startDate | date: 'short' }}</p>
+  <p><strong>Status:</strong> {{ data.payStatus ? 'Payed' : 'Not payed' }}</p>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Close</button>
+</div>

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.ts
@@ -1,0 +1,16 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { ViewStudentSubscribeReDto } from 'src/app/@theme/services/student-subscribe.service';
+
+@Component({
+  selector: 'app-payment-details',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './payment-details.component.html',
+  styleUrl: './payment-details.component.scss'
+})
+export class PaymentDetailsComponent {
+  data = inject<ViewStudentSubscribeReDto>(MAT_DIALOG_DATA);
+}


### PR DESCRIPTION
## Summary
- extend subscription model with student payment identifier
- show payment info popup from membership pages

## Testing
- `npm test` (fails: Cannot determine project or target for command.)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c028d6e6fc83229575440fd410d840