### PR TITLE
feat: expand payment details dialog

### DIFF
--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -14,8 +14,11 @@ export interface StudentPaymentDto {
   paymentDate?: string | null;
   receiptPath?: string | null;
   payStatue?: boolean | null;
+  createdBy?: number | null;
+  createdAt?: string | null;
+  modefiedBy?: number | null;
+  modefiedAt?: string | null;
 }
-
 
 @Injectable({ providedIn: 'root' })
 export class StudentPaymentService {
@@ -23,10 +26,6 @@ export class StudentPaymentService {
 
   getPayment(paymentId: number): Observable<ApiResponse<StudentPaymentDto>> {
     const params = new HttpParams().set('paymentId', paymentId.toString());
-    return this.http.get<ApiResponse<StudentPaymentDto>>(
-
-      `${environment.apiUrl}/api/StudentPayment/GetPayment`,
-      { params }
-    );
+    return this.http.get<ApiResponse<StudentPaymentDto>>(`${environment.apiUrl}/api/StudentPayment/GetPayment`, { params });
   }
 }

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
@@ -1,13 +1,57 @@
 <h2 mat-dialog-title>Payment Details</h2>
 <div mat-dialog-content>
-  <p><strong>Name:</strong> {{ data.studentName }}</p>
-  <p><strong>Subscription:</strong> {{ data.studentSubscribeName }}</p>
-  <p><strong>Amount:</strong> {{ data.amount }}</p>
-  <p><strong>Currency:</strong> {{ data.currencyId }}</p>
-  <p><strong>Payment Date:</strong> {{ data.paymentDate ? (data.paymentDate | date: 'short') : 'N/A' }}</p>
-  <p><strong>Receipt:</strong> {{ data.receiptPath || 'N/A' }}</p>
-  <p><strong>Status:</strong> {{ data.payStatue ? 'Payed' : 'Not payed' }}</p>
-
+  <p>
+    <strong>ID:</strong>
+    {{ data.id }}
+  </p>
+  <p>
+    <strong>Student ID:</strong>
+    {{ data.studentId }}
+  </p>
+  <p>
+    <strong>Name:</strong>
+    {{ data.studentName }}
+  </p>
+  <p>
+    <strong>Subscription:</strong>
+    {{ data.studentSubscribeName }}
+  </p>
+  <p>
+    <strong>Amount:</strong>
+    {{ data.amount }}
+  </p>
+  <p>
+    <strong>Currency:</strong>
+    {{ data.currencyId }}
+  </p>
+  <p>
+    <strong>Payment Date:</strong>
+    {{ data.paymentDate ? (data.paymentDate | date: 'short') : 'N/A' }}
+  </p>
+  <p>
+    <strong>Receipt:</strong>
+    {{ data.receiptPath || 'N/A' }}
+  </p>
+  <p>
+    <strong>Status:</strong>
+    {{ data.payStatue ? 'Payed' : 'Not payed' }}
+  </p>
+  <p>
+    <strong>Created By:</strong>
+    {{ data.createdBy ?? 'N/A' }}
+  </p>
+  <p>
+    <strong>Created At:</strong>
+    {{ data.createdAt ? (data.createdAt | date: 'short') : 'N/A' }}
+  </p>
+  <p>
+    <strong>Modified By:</strong>
+    {{ data.modefiedBy ?? 'N/A' }}
+  </p>
+  <p>
+    <strong>Modified At:</strong>
+    {{ data.modefiedAt ? (data.modefiedAt | date: 'short') : 'N/A' }}
+  </p>
 </div>
 <div mat-dialog-actions align="end">
   <button mat-button mat-dialog-close>Close</button>


### PR DESCRIPTION
## Summary
- capture creation and modification metadata in `StudentPaymentDto`
- extend payment details dialog to display IDs and audit info

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c12df80bf483228cd119faeaa1ecfe