### PR TITLE
feat: expand payment details dialog

### DIFF
--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { ApiResponse } from './lookup.service';
+import { ApiResponse, PagedResultDto } from './lookup.service';
 
 export interface StudentPaymentDto {
   id: number;
@@ -14,17 +14,21 @@ export interface StudentPaymentDto {
   paymentDate?: string | null;
   receiptPath?: string | null;
   payStatue?: boolean | null;
+  createdBy?: number | null;
+  createdAt?: string | null;
+  modefiedBy?: number | null;
+  modefiedAt?: string | null;
 }
-
 
 @Injectable({ providedIn: 'root' })
 export class StudentPaymentService {
   private http = inject(HttpClient);
 
-  getPayment(paymentId: number): Observable<ApiResponse<StudentPaymentDto>> {
+  getPayment(
+    paymentId: number
+  ): Observable<ApiResponse<PagedResultDto<StudentPaymentDto>>> {
     const params = new HttpParams().set('paymentId', paymentId.toString());
-    return this.http.get<ApiResponse<StudentPaymentDto>>(
-
+    return this.http.get<ApiResponse<PagedResultDto<StudentPaymentDto>>>(
       `${environment.apiUrl}/api/StudentPayment/GetPayment`,
       { params }
     );

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
@@ -73,9 +73,9 @@ export class MembershipListComponent implements AfterViewInit, OnInit {
       return;
     }
     this.paymentService.getPayment(paymentId).subscribe((res) => {
-      if (res.isSuccess && res.data) {
-        this.dialog.open(PaymentDetailsComponent, { data: res.data });
-
+      const payment = res.data?.items[0];
+      if (res.isSuccess && payment) {
+        this.dialog.open(PaymentDetailsComponent, { data: payment });
       }
     });
   }

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
@@ -1,10 +1,17 @@
-<div class="row p-t-25">
+<div class="row">
   <div class="col-12">
-    <app-card cardTitle="Student Subscribe" padding="0">
-      <div class="p-b-15">
-        <div class="table-containe table-reponsive">
+    <app-card cardTitle="Student Subscribe" headerClass="p-y-15">
+      <ng-template #headerOptionsTemplate>
+        <a class="avatar avatar-s text-accent-500 hover" href="javascript:">
+          <svg class="pc-icon">
+            <use xlink:href="assets/fonts/custom-icon.svg#copy"></use>
+          </svg>
+        </a>
+      </ng-template>
+      <mat-card class="border m-b-0">
+        <mat-card-content class="p-20">
           <div class="table-responsive">
-            <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+            <table mat-table [dataSource]="dataSource" class="mat-elevation-z8 w-100">
               <ng-container matColumnDef="plan">
                 <th mat-header-cell *matHeaderCellDef>PLAN</th>
                 <td mat-cell *matCellDef="let element" class="text-nowrap">{{ element.plan || 'there is no' }}</td>
@@ -62,8 +69,8 @@
               aria-label="Select page of subscribes"
             ></mat-paginator>
           </div>
-        </div>
-      </div>
+        </mat-card-content>
+      </mat-card>
     </app-card>
   </div>
 </div>

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
@@ -60,9 +60,9 @@ export class MembershipViewComponent implements OnInit, AfterViewInit {
       return;
     }
     this.paymentService.getPayment(paymentId).subscribe((res) => {
-      if (res.isSuccess && res.data) {
-        this.dialog.open(PaymentDetailsComponent, { data: res.data });
-
+      const payment = res.data?.items[0];
+      if (res.isSuccess && payment) {
+        this.dialog.open(PaymentDetailsComponent, { data: payment });
       }
     });
   }

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
@@ -1,13 +1,57 @@
 <h2 mat-dialog-title>Payment Details</h2>
 <div mat-dialog-content>
-  <p><strong>Name:</strong> {{ data.studentName }}</p>
-  <p><strong>Subscription:</strong> {{ data.studentSubscribeName }}</p>
-  <p><strong>Amount:</strong> {{ data.amount }}</p>
-  <p><strong>Currency:</strong> {{ data.currencyId }}</p>
-  <p><strong>Payment Date:</strong> {{ data.paymentDate ? (data.paymentDate | date: 'short') : 'N/A' }}</p>
-  <p><strong>Receipt:</strong> {{ data.receiptPath || 'N/A' }}</p>
-  <p><strong>Status:</strong> {{ data.payStatue ? 'Payed' : 'Not payed' }}</p>
-
+  <p>
+    <strong>ID:</strong>
+    {{ data.id }}
+  </p>
+  <p>
+    <strong>Student ID:</strong>
+    {{ data.studentId }}
+  </p>
+  <p>
+    <strong>Name:</strong>
+    {{ data.studentName }}
+  </p>
+  <p>
+    <strong>Subscription:</strong>
+    {{ data.studentSubscribeName }}
+  </p>
+  <p>
+    <strong>Amount:</strong>
+    {{ data.amount }}
+  </p>
+  <p>
+    <strong>Currency:</strong>
+    {{ data.currencyId }}
+  </p>
+  <p>
+    <strong>Payment Date:</strong>
+    {{ data.paymentDate ? (data.paymentDate | date: 'short') : 'N/A' }}
+  </p>
+  <p>
+    <strong>Receipt:</strong>
+    {{ data.receiptPath || 'N/A' }}
+  </p>
+  <p>
+    <strong>Status:</strong>
+    {{ data.payStatue ? 'Payed' : 'Not payed' }}
+  </p>
+  <p>
+    <strong>Created By:</strong>
+    {{ data.createdBy ?? 'N/A' }}
+  </p>
+  <p>
+    <strong>Created At:</strong>
+    {{ data.createdAt ? (data.createdAt | date: 'short') : 'N/A' }}
+  </p>
+  <p>
+    <strong>Modified By:</strong>
+    {{ data.modefiedBy ?? 'N/A' }}
+  </p>
+  <p>
+    <strong>Modified At:</strong>
+    {{ data.modefiedAt ? (data.modefiedAt | date: 'short') : 'N/A' }}
+  </p>
 </div>
 <div mat-dialog-actions align="end">
   <button mat-button mat-dialog-close>Close</button>


### PR DESCRIPTION
## Summary
- capture creation and modification metadata in `StudentPaymentDto`
- extend payment details dialog to display IDs and audit info
- bind dialog to the first payment record returned by the API
- restyle membership view page to match membership settings layout

## Testing
- `npm test` *(fails: Cannot determine project or target for command.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c12df80bf483228cd119faeaa1ecfe