### PR TITLE
fix: show payment details expansion

### DIFF
--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
@@ -17,8 +17,8 @@
                 <td mat-cell *matCellDef="let element">
                   <button
                     mat-icon-button
-                    *ngIf="element.studentPaymentId"
-                    (click)="openPaymentDetails(element.studentPaymentId)"
+                    *ngIf="element.studentPaymentId !== null && element.studentPaymentId !== undefined"
+                    (click)="togglePaymentDetails(element)"
                     aria-label="View payment details"
                   >
                     <mat-icon>expand_more</mat-icon>

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
@@ -3,12 +3,11 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, ActivatedRoute } from '@angular/router';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
+import { MatExpansionModule } from '@angular/material/expansion';
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { StudentSubscribeService, ViewStudentSubscribeReDto } from 'src/app/@theme/services/student-subscribe.service';
 import { FilteredResultRequestDto } from 'src/app/@theme/services/lookup.service';
-import { StudentPaymentService } from 'src/app/@theme/services/student-payment.service';
-import { MatDialog } from '@angular/material/dialog';
-import { PaymentDetailsComponent } from '../payment-details/payment-details.component';
+import { StudentPaymentService, StudentPaymentDto } from 'src/app/@theme/services/student-payment.service';
 
 
 @Component({
@@ -69,16 +68,17 @@ export class MembershipViewComponent implements OnInit, AfterViewInit {
     this.expandedElement = element;
     this.panelOpen = true;
     const paymentId = element.studentPaymentId;
-    if (!paymentId) {
+    if (paymentId == null) {
       this.paymentDetails = null;
       return;
     }
     this.paymentService.getPayment(paymentId).subscribe((res) => {
       const payment = res.data?.items[0];
       if (res.isSuccess && payment) {
-        this.dialog.open(PaymentDetailsComponent, { data: payment });
+        this.paymentDetails = payment;
+      } else {
+        this.paymentDetails = null;
       }
-
     });
   }
 }


### PR DESCRIPTION
## Summary
- ensure payment details expansion can be triggered from membership view
- fetch and display payment details inline instead of in dialog
- guard expand button visibility with strict null checks

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c14ee4b1f48322a5ac9d270ee7567f