### PR TITLE
Improve payment detail layout

### DIFF
--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
@@ -1,57 +1,57 @@
 <h2 mat-dialog-title>Payment Details</h2>
 <div mat-dialog-content>
-  <p>
+  <div class="payment-item">
     <strong>ID:</strong>
-    {{ data.id }}
-  </p>
-  <p>
+    <span>{{ data.id }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Student ID:</strong>
-    {{ data.studentId }}
-  </p>
-  <p>
+    <span>{{ data.studentId }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Name:</strong>
-    {{ data.studentName }}
-  </p>
-  <p>
+    <span>{{ data.studentName }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Subscription:</strong>
-    {{ data.studentSubscribeName }}
-  </p>
-  <p>
+    <span>{{ data.studentSubscribeName }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Amount:</strong>
-    {{ data.amount }}
-  </p>
-  <p>
+    <span>{{ data.amount }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Currency:</strong>
-    {{ data.currencyId }}
-  </p>
-  <p>
+    <span>{{ data.currencyId }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Payment Date:</strong>
-    {{ data.paymentDate ? (data.paymentDate | date: 'short') : 'N/A' }}
-  </p>
-  <p>
+    <span>{{ data.paymentDate ? (data.paymentDate | date: 'short') : 'N/A' }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Receipt:</strong>
-    {{ data.receiptPath || 'N/A' }}
-  </p>
-  <p>
+    <span>{{ data.receiptPath || 'N/A' }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Status:</strong>
-    {{ data.payStatue ? 'Payed' : 'Not payed' }}
-  </p>
-  <p>
+    <span>{{ data.payStatue ? 'Payed' : 'Not payed' }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Created By:</strong>
-    {{ data.createdBy ?? 'N/A' }}
-  </p>
-  <p>
+    <span>{{ data.createdBy ?? 'N/A' }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Created At:</strong>
-    {{ data.createdAt ? (data.createdAt | date: 'short') : 'N/A' }}
-  </p>
-  <p>
+    <span>{{ data.createdAt ? (data.createdAt | date: 'short') : 'N/A' }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Modified By:</strong>
-    {{ data.modefiedBy ?? 'N/A' }}
-  </p>
-  <p>
+    <span>{{ data.modefiedBy ?? 'N/A' }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Modified At:</strong>
-    {{ data.modefiedAt ? (data.modefiedAt | date: 'short') : 'N/A' }}
-  </p>
+    <span>{{ data.modefiedAt ? (data.modefiedAt | date: 'short') : 'N/A' }}</span>
+  </div>
 </div>
 <div mat-dialog-actions align="end">
   <button mat-button mat-dialog-close>Close</button>

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.scss
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.scss
@@ -1,0 +1,17 @@
+.payment-item {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.payment-item:last-child {
+  margin-bottom: 0;
+}
+
+.payment-item strong {
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- display each payment field inside a bordered block
- add styling for payment detail items with padding and border radius

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68c1526879ac8322bc8406dc984ca8db