### PR TITLE
feat: load student subscriptions with payment details

### DIFF
--- a/src/app/@theme/services/student-subscribe.service.ts
+++ b/src/app/@theme/services/student-subscribe.service.ts
@@ -54,5 +54,38 @@ export class StudentSubscribeService {
       { params }
     );
   }
+
+  getStudentSubscribesWithPayment(
+    filter: FilteredResultRequestDto,
+    studentId: number
+  ): Observable<ApiResponse<PagedResultDto<ViewStudentSubscribeReDto>>> {
+    let params = new HttpParams();
+    if (filter.skipCount !== undefined) {
+      params = params.set('SkipCount', filter.skipCount.toString());
+    }
+    if (filter.maxResultCount !== undefined) {
+      params = params.set('MaxResultCount', filter.maxResultCount.toString());
+    }
+    if (filter.searchTerm) {
+      params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (filter.filter) {
+      params = params.set('Filter', filter.filter);
+    }
+    if (filter.lang) {
+      params = params.set('Lang', filter.lang);
+    }
+    if (filter.sortingDirection) {
+      params = params.set('SortingDirection', filter.sortingDirection);
+    }
+    if (filter.sortBy) {
+      params = params.set('SortBy', filter.sortBy);
+    }
+    params = params.set('studentId', studentId.toString());
+    return this.http.get<ApiResponse<PagedResultDto<ViewStudentSubscribeReDto>>>(
+      `${environment.apiUrl}/api/StudentSubscrib/GetStudentSubscribesWithPayment`,
+      { params }
+    );
+  }
 }
 

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
@@ -39,15 +39,17 @@ export class MembershipViewComponent implements OnInit, AfterViewInit {
   }
 
   private load() {
-    this.service.getStudents(this.filter, this.studentId).subscribe((res) => {
-      if (res.isSuccess && res.data?.items) {
-        this.dataSource.data = res.data.items;
-        this.totalCount = res.data.totalCount;
-      } else {
-        this.dataSource.data = [];
-        this.totalCount = 0;
-      }
-    });
+    this.service
+      .getStudentSubscribesWithPayment(this.filter, this.studentId)
+      .subscribe((res) => {
+        if (res.isSuccess && res.data?.items) {
+          this.dataSource.data = res.data.items;
+          this.totalCount = res.data.totalCount;
+        } else {
+          this.dataSource.data = [];
+          this.totalCount = 0;
+        }
+      });
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
## Summary
- add service method for retrieving student subscriptions with their payment info
- show payment details on membership view using new endpoint

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1581512588322aabb524fc07a6e19