### PR TITLE
Connect invoice list to payment dashboard API

### DIFF
--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -20,6 +20,23 @@ export interface StudentPaymentDto {
   modefiedAt?: string | null;
 }
 
+export interface PaymentDashboardDto {
+  month: string;
+  totalPaid: number;
+  totalPaidCount: number;
+  totalPaidMoMPercentage: number;
+  totalUnPaid: number;
+  totalUnPaidCount: number;
+  totalUnPaidMoMPercentage: number;
+  totalOverdue: number;
+  totalOverdueCount: number;
+  totalOverdueMoMPercentage: number;
+  currentReceivables: number;
+  overdueReceivables: number;
+  totalReceivables: number;
+  collectionRate: number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class StudentPaymentService {
   private http = inject(HttpClient);
@@ -30,6 +47,27 @@ export class StudentPaymentService {
     const params = new HttpParams().set('paymentId', paymentId.toString());
     return this.http.get<ApiResponse<PagedResultDto<StudentPaymentDto>>>(
       `${environment.apiUrl}/api/StudentPayment/GetPayment`,
+      { params }
+    );
+  }
+
+  getDashboard(
+    studentId?: number,
+    currencyId?: number,
+    month?: Date
+  ): Observable<PaymentDashboardDto> {
+    let params = new HttpParams();
+    if (studentId !== undefined) {
+      params = params.set('studentId', studentId.toString());
+    }
+    if (currencyId !== undefined) {
+      params = params.set('currencyId', currencyId.toString());
+    }
+    if (month) {
+      params = params.set('month', month.toISOString());
+    }
+    return this.http.get<PaymentDashboardDto>(
+      `${environment.apiUrl}/api/StudentPayment/Dashboard`,
       { params }
     );
   }

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
@@ -1,4 +1,15 @@
 <div class="row">
+  <div class="col-12 mb-3 text-end">
+    <mat-form-field appearance="outline">
+      <mat-label>Month</mat-label>
+      <input
+        matInput
+        type="month"
+        [(ngModel)]="selectedMonth"
+        (ngModelChange)="onMonthChange($event)"
+      />
+    </mat-form-field>
+  </div>
   <div class="col-xxl-8">
     <div class="row g-3 mb-3">
       @for (cards of widgetCards; track cards) {
@@ -42,22 +53,30 @@
             </div>
             <div class="flex align-item-center">
               <p class="m-b-0 text-white text-sm">Current</p>
-              <p class="m-b-0 text-white m-l-10">109.1k</p>
+              <p class="m-b-0 text-white m-l-10">{{
+                bigCard.currentReceivables
+              }}</p>
             </div>
           </div>
         </div>
         <div class="flex">
           <p class="m-b-0 text-white text-sm">Overdue</p>
-          <p class="m-b-0 text-white m-l-10">62k</p>
+          <p class="m-b-0 text-white m-l-10">{{ bigCard.overdueReceivables }}</p>
         </div>
       </div>
-      <div class="m-t-15 text-white f-16 f-w-600 m-b-5">$43,078</div>
+      <div class="m-t-15 text-white f-16 f-w-600 m-b-5">
+        ${{ bigCard.totalReceivables }}
+      </div>
       <div class="flex align-item-center">
         <div class="flex-grow-1 m-r-15">
-          <mat-progress-bar color="warn" mode="Determinate" [value]="90"></mat-progress-bar>
+          <mat-progress-bar
+            color="warn"
+            mode="determinate"
+            [value]="bigCard.collectionRate"
+          ></mat-progress-bar>
         </div>
         <div class="flex-shrink-0 text-end wid-30">
-          <p class="text-white m-b-0">90%</p>
+          <p class="text-white m-b-0">{{ bigCard.collectionRate }}%</p>
         </div>
       </div>
     </app-card>


### PR DESCRIPTION
## Summary
- fetch payment dashboard data from backend with optional month parameter
- add month filter to invoice list and populate widgets and totals dynamically

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68c16ba1e2e8832283af0ad51a89b340