### PR TITLE
feat: add month filter for invoice dashboard and list

### DIFF
--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { ApiResponse, PagedResultDto } from './lookup.service';
+import { ApiResponse, FilteredResultRequestDto, PagedResultDto } from './lookup.service';
 
 export interface StudentPaymentDto {
   id: number;
@@ -37,6 +37,17 @@ export interface PaymentDashboardDto {
   collectionRate: number;
 }
 
+export interface StudentInvoiceDto {
+  invoiceId: number;
+  studentId: number;
+  userName?: string | null;
+  userEmail?: string | null;
+  createDate?: string | null;
+  dueDate?: string | null;
+  quantity?: number | null;
+  statusText?: string | null;
+}
+
 @Injectable({ providedIn: 'root' })
 export class StudentPaymentService {
   private http = inject(HttpClient);
@@ -54,7 +65,8 @@ export class StudentPaymentService {
   getDashboard(
     studentId?: number,
     currencyId?: number,
-    month?: Date
+    dataMonth?: Date,
+    compareMonth?: Date
   ): Observable<PaymentDashboardDto> {
     let params = new HttpParams();
     if (studentId !== undefined) {
@@ -63,11 +75,61 @@ export class StudentPaymentService {
     if (currencyId !== undefined) {
       params = params.set('currencyId', currencyId.toString());
     }
-    if (month) {
-      params = params.set('month', month.toISOString());
+    if (dataMonth) {
+      params = params.set('dataMonth', dataMonth.toISOString());
+    }
+    if (compareMonth) {
+      params = params.set('compareMonth', compareMonth.toISOString());
     }
     return this.http.get<PaymentDashboardDto>(
       `${environment.apiUrl}/api/StudentPayment/Dashboard`,
+      { params }
+    );
+  }
+
+  getInvoices(
+    filter: FilteredResultRequestDto,
+    tab?: string,
+    studentId?: number,
+    createdFrom?: Date,
+    createdTo?: Date,
+    dueFrom?: Date,
+    dueTo?: Date,
+    month?: Date
+  ): Observable<ApiResponse<PagedResultDto<StudentInvoiceDto>>> {
+    let params = new HttpParams();
+    if (filter.skipCount !== undefined) {
+      params = params.set('SkipCount', filter.skipCount.toString());
+    }
+    if (filter.maxResultCount !== undefined) {
+      params = params.set('MaxResultCount', filter.maxResultCount.toString());
+    }
+    if (filter.searchTerm) {
+      params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (tab) {
+      params = params.set('tab', tab);
+    }
+    if (studentId) {
+      params = params.set('studentId', studentId.toString());
+    }
+    if (createdFrom) {
+      params = params.set('createdFrom', createdFrom.toISOString());
+    }
+    if (createdTo) {
+      params = params.set('createdTo', createdTo.toISOString());
+    }
+    if (dueFrom) {
+      params = params.set('dueFrom', dueFrom.toISOString());
+    }
+    if (dueTo) {
+      params = params.set('dueTo', dueTo.toISOString());
+    }
+    if (month) {
+      params = params.set('month', month.toISOString());
+    }
+    return this.http.get<ApiResponse<PagedResultDto<StudentInvoiceDto>>>(
+      `${environment.apiUrl}/api/StudentPayment/Invoices`,
       { params }
     );
   }

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.html
@@ -14,27 +14,9 @@
 
     <!-- Name Column -->
     <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header>USER NAME</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>STUDENT</th>
       <td mat-cell *matCellDef="let element" class="text-nowrap">
-        <div class="row align-item-center">
-          <div class="col-auto p-r-0">
-            <img src="{{ element.image }}" alt="user-image" class="wid-40 hei-40 border-50" />
-          </div>
-          <div class="col">
-            <div class="f-w-600 m-b-5">
-              <span class="text-truncate w-100">
-                {{ element.name }}
-              </span>
-            </div>
-            <p class="f-12 mb-0">
-              <a href="javascript:" class="text-muted">
-                <span class="text-truncate w-100">
-                  {{ element.email }}
-                </span>
-              </a>
-            </p>
-          </div>
-        </div>
+        {{ element.name }}
       </td>
     </ng-container>
 

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.ts
@@ -1,25 +1,36 @@
 // angular import
-import { AfterViewInit, Component, viewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  EventEmitter,
+  SimpleChanges,
+  viewChild,
+  inject
+} from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
-import { invoiceListTableData } from 'src/app/fake-data/invoice-list-table-data';
+import {
+  StudentInvoiceDto,
+  StudentPaymentService
+} from 'src/app/@theme/services/student-payment.service';
+import { FilteredResultRequestDto } from 'src/app/@theme/services/lookup.service';
 
-export interface PeriodicElement {
+export interface InvoiceTableItem {
   id: number;
   name: string;
-  image: string;
-  email: string;
   create_date: string;
   due_date: string;
   qty: number;
   status: string;
 }
-
-const ELEMENT_DATA: PeriodicElement[] = invoiceListTableData;
 
 @Component({
   selector: 'app-invoice-list-table',
@@ -27,15 +38,31 @@ const ELEMENT_DATA: PeriodicElement[] = invoiceListTableData;
   templateUrl: './invoice-list-table.component.html',
   styleUrl: './invoice-list-table.component.scss'
 })
-export class InvoiceListTableComponent implements AfterViewInit {
+export class InvoiceListTableComponent implements AfterViewInit, OnInit, OnChanges {
+  @Input() tab?: string;
+  @Input() month?: string;
+  @Output() countChange = new EventEmitter<number>();
+
+  private studentPaymentService = inject(StudentPaymentService);
+
   // public props
   displayedColumns: string[] = ['id', 'name', 'create_date', 'due_date', 'qty', 'status', 'action'];
-  dataSource = new MatTableDataSource(ELEMENT_DATA);
+  dataSource = new MatTableDataSource<InvoiceTableItem>([]);
 
   // paginator
-readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
+  readonly paginator = viewChild.required(MatPaginator); // if Angular ≥17
 
   readonly sort = viewChild(MatSort);
+
+  ngOnInit(): void {
+    this.loadData();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['tab'] || changes['month']) {
+      this.loadData();
+    }
+  }
 
   // table search filter
   applyFilter(event: Event) {
@@ -45,6 +72,28 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
     if (this.dataSource.paginator) {
       this.dataSource.paginator.firstPage();
     }
+  }
+
+  loadData(): void {
+    const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
+    let monthDate: Date | undefined;
+    if (this.month) {
+      monthDate = new Date(this.month + '-01');
+    }
+    this.studentPaymentService
+      .getInvoices(filter, this.tab, undefined, undefined, undefined, undefined, undefined, monthDate)
+      .subscribe((resp) => {
+        const items: InvoiceTableItem[] = resp.data.items.map((item: StudentInvoiceDto) => ({
+          id: item.invoiceId,
+          name: item.userName ?? '',
+          create_date: item.createDate ?? '',
+          due_date: item.dueDate ?? '',
+          qty: item.quantity ?? 0,
+          status: (item.statusText ?? '').toLowerCase()
+        }));
+        this.dataSource.data = items;
+        this.countChange.emit(resp.data.totalCount);
+      });
   }
 
   ngAfterViewInit() {

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
@@ -89,12 +89,12 @@
             <div class="flex align-item-center justify-content-between">
               All
               <div class="wid-20 hei-20 border-50 flex align-item-center justify-content-center bg-primary-50 text-primary-500 m-l-10">
-                4
+                {{ tabCounts.all }}
               </div>
             </div>
           </ng-template>
           <div class="p-y-20">
-            <app-invoice-list-table />
+            <app-invoice-list-table [month]="selectedMonth" (countChange)="onTableCount('all', $event)" />
           </div>
         </mat-tab>
         <mat-tab>
@@ -102,12 +102,12 @@
             <div class="flex align-item-center justify-content-between">
               Paid
               <div class="wid-20 hei-20 border-50 flex align-item-center justify-content-center bg-success-50 text-success-500 m-l-10">
-                2
+                {{ tabCounts.paid }}
               </div>
             </div>
           </ng-template>
           <div class="p-y-20">
-            <app-invoice-list-table />
+            <app-invoice-list-table tab="paid" [month]="selectedMonth" (countChange)="onTableCount('paid', $event)" />
           </div>
         </mat-tab>
         <mat-tab>
@@ -115,23 +115,23 @@
             <div class="flex align-item-center justify-content-between">
               Unpaid
               <div class="wid-20 hei-20 border-50 flex align-item-center justify-content-center bg-warning-50 text-warning-500 m-l-10">
-                2
+                {{ tabCounts.unpaid }}
               </div>
             </div>
           </ng-template>
           <div class="p-y-20">
-            <app-invoice-list-table />
+            <app-invoice-list-table tab="unpaid" [month]="selectedMonth" (countChange)="onTableCount('unpaid', $event)" />
           </div>
         </mat-tab>
         <mat-tab>
           <ng-template mat-tab-label>
             <div class="flex align-item-center justify-content-between">
               Cancelled
-              <div class="wid-20 hei-20 border-50 flex align-item-center justify-content-center bg-warn-50 text-warn-500 m-l-10">1</div>
+              <div class="wid-20 hei-20 border-50 flex align-item-center justify-content-center bg-warn-50 text-warn-500 m-l-10">{{ tabCounts.cancelled }}</div>
             </div>
           </ng-template>
           <div class="p-y-20">
-            <app-invoice-list-table />
+            <app-invoice-list-table tab="cancelled" [month]="selectedMonth" (countChange)="onTableCount('cancelled', $event)" />
           </div>
         </mat-tab>
       </mat-tab-group>

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
@@ -42,6 +42,12 @@ export class InvoiceListComponent implements OnInit {
     totalReceivables: 0,
     collectionRate: 0
   };
+  tabCounts = {
+    all: 0,
+    paid: 0,
+    unpaid: 0,
+    cancelled: 0
+  };
 
   ngOnInit(): void {
     this.loadDashboard();
@@ -54,7 +60,12 @@ export class InvoiceListComponent implements OnInit {
 
   onMonthChange(value: string): void {
     this.selectedMonth = value;
+    this.tabCounts = { all: 0, paid: 0, unpaid: 0, cancelled: 0 };
     this.loadDashboard();
+  }
+
+  onTableCount(tab: 'all' | 'paid' | 'unpaid' | 'cancelled', count: number): void {
+    this.tabCounts[tab] = count;
   }
 
   loadDashboard(): void {


### PR DESCRIPTION
## Summary
- add StudentPaymentService.getInvoices to request invoice lists
- forward month filter to invoice list tables and dashboard
- simplify invoice table column to display student name
- emit invoice counts to update tab labels from API response

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c17c1a64148322857d541ef890d7a5