### PR TITLE
feat: add overdue invoice tab

### DIFF
--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.html
@@ -46,6 +46,8 @@
           <span class="user-status bg-success-500 text-white">Paid</span>
         } @else if (element.status === 'unpaid') {
           <span class="user-status bg-cyan-500 text-white">Unpaid</span>
+        } @else if (element.status === 'overdue') {
+          <span class="user-status bg-warn-500 text-white">Overdue</span>
         } @else if (element.status === 'cancelled') {
           <span class="user-status bg-warn-500 text-white">Cancelled</span>
         }

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
@@ -113,6 +113,19 @@
         <mat-tab>
           <ng-template mat-tab-label>
             <div class="flex align-item-center justify-content-between">
+              Overdue
+              <div class="wid-20 hei-20 border-50 flex align-item-center justify-content-center bg-warn-50 text-warn-500 m-l-10">
+                {{ tabCounts.overdue }}
+              </div>
+            </div>
+          </ng-template>
+          <div class="p-y-20">
+            <app-invoice-list-table tab="overdue" [month]="selectedMonth" (countChange)="onTableCount('overdue', $event)" />
+          </div>
+        </mat-tab>
+        <mat-tab>
+          <ng-template mat-tab-label>
+            <div class="flex align-item-center justify-content-between">
               Cancelled
               <div class="wid-20 hei-20 border-50 flex align-item-center justify-content-center bg-warn-50 text-warn-500 m-l-10">
                 {{ tabCounts.cancelled }}

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
@@ -46,6 +46,7 @@ export class InvoiceListComponent implements OnInit {
     all: 0,
     paid: 0,
     unpaid: 0,
+    overdue: 0,
     cancelled: 0
   };
 
@@ -60,11 +61,11 @@ export class InvoiceListComponent implements OnInit {
 
   onMonthChange(value: string): void {
     this.selectedMonth = value;
-    this.tabCounts = { all: 0, paid: 0, unpaid: 0, cancelled: 0 };
+    this.tabCounts = { all: 0, paid: 0, unpaid: 0, overdue: 0, cancelled: 0 };
     this.loadDashboard();
   }
 
-  onTableCount(tab: 'all' | 'paid' | 'unpaid' | 'cancelled', count: number): void {
+  onTableCount(tab: 'all' | 'paid' | 'unpaid' | 'overdue' | 'cancelled', count: number): void {
     this.tabCounts[tab] = count;
   }
 


### PR DESCRIPTION
## Summary
- add overdue invoice filter tab with count and table
- track overdue tab count in invoice list component
- render overdue status in invoice list table

## Testing
- `npx ng test` (fails: Cannot determine project or target for command)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2ab8630dc8322972e9f99c2edada4