### PR TITLE
fix: include overdue invoices in all tab

### DIFF
--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.ts
@@ -90,8 +90,9 @@ export class InvoiceListTableComponent implements AfterViewInit, OnInit, OnChang
     if (this.month) {
       monthDate = new Date(this.month + '-01');
     }
+    const tab = this.tab ?? 'all';
     this.studentPaymentService
-      .getInvoices(filter, this.tab, undefined, undefined, undefined, undefined, undefined, monthDate)
+      .getInvoices(filter, tab, undefined, undefined, undefined, undefined, undefined, monthDate)
       .subscribe((resp) => {
         const items: InvoiceTableItem[] = resp.data.items.map((item: StudentInvoiceDto) => ({
           id: item.invoiceId,


### PR DESCRIPTION
## Summary
- ensure invoice list loads all statuses by default by requesting `tab=all`

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2aed0746c83228a8b29d4ccc03a22