### PR TITLE
Refactor getPayment response structure

### DIFF
--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -5,19 +5,15 @@ import { environment } from 'src/environments/environment';
 import { ApiResponse, FilteredResultRequestDto, PagedResultDto } from './lookup.service';
 
 export interface StudentPaymentDto {
-  id: number;
+  invoiceId: number;
   studentId: number;
-  studentName?: string | null;
-  studentSubscribeName?: string | null;
-  amount?: number | null;
-  currencyId?: number | null;
+  userName?: string | null;
+  userEmail?: string | null;
+  createDate?: string | null;
+  dueDate?: string | null;
   paymentDate?: string | null;
-  receiptPath?: string | null;
-  payStatue?: boolean | null;
-  createdBy?: number | null;
-  createdAt?: string | null;
-  modefiedBy?: number | null;
-  modefiedAt?: string | null;
+  quantity?: number | null;
+  statusText?: string | null;
 }
 
 export interface PaymentDashboardDto {
@@ -51,26 +47,13 @@ export interface StudentInvoiceDto {
   statusText?: string | null;
 }
 
-export interface StudentInvoiceDto {
-  invoiceId: number;
-  studentId: number;
-  userName?: string | null;
-  userEmail?: string | null;
-  createDate?: string | null;
-  dueDate?: string | null;
-  quantity?: number | null;
-  statusText?: string | null;
-}
-
 @Injectable({ providedIn: 'root' })
 export class StudentPaymentService {
   private http = inject(HttpClient);
 
-  getPayment(
-    paymentId: number
-  ): Observable<ApiResponse<PagedResultDto<StudentPaymentDto>>> {
+  getPayment(paymentId: number): Observable<ApiResponse<StudentPaymentDto>> {
     const params = new HttpParams().set('paymentId', paymentId.toString());
-    return this.http.get<ApiResponse<PagedResultDto<StudentPaymentDto>>>(
+    return this.http.get<ApiResponse<StudentPaymentDto>>(
       `${environment.apiUrl}/api/StudentPayment/GetPayment`,
       { params }
     );

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
@@ -73,9 +73,8 @@ export class MembershipListComponent implements AfterViewInit, OnInit {
       return;
     }
     this.paymentService.getPayment(paymentId).subscribe((res) => {
-      const payment = res.data?.items[0];
-      if (res.isSuccess && payment) {
-        this.dialog.open(PaymentDetailsComponent, { data: payment });
+      if (res.isSuccess && res.data) {
+        this.dialog.open(PaymentDetailsComponent, { data: res.data });
       }
     });
   }

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
@@ -73,28 +73,24 @@
                 <mat-panel-title>Payment Details</mat-panel-title>
               </mat-expansion-panel-header>
               <div class="p-16">
-                <p><strong>ID:</strong> {{ paymentDetails.id }}</p>
+                <p><strong>Invoice ID:</strong> {{ paymentDetails.invoiceId }}</p>
                 <p><strong>Student ID:</strong> {{ paymentDetails.studentId }}</p>
-                <p><strong>Name:</strong> {{ paymentDetails.studentName }}</p>
-                <p><strong>Subscription:</strong> {{ paymentDetails.studentSubscribeName }}</p>
-                <p><strong>Amount:</strong> {{ paymentDetails.amount }}</p>
-                <p><strong>Currency:</strong> {{ paymentDetails.currencyId }}</p>
+                <p><strong>Name:</strong> {{ paymentDetails.userName }}</p>
+                <p><strong>Email:</strong> {{ paymentDetails.userEmail }}</p>
+                <p>
+                  <strong>Create Date:</strong>
+                  {{ paymentDetails.createDate ? (paymentDetails.createDate | date: 'short') : 'N/A' }}
+                </p>
+                <p>
+                  <strong>Due Date:</strong>
+                  {{ paymentDetails.dueDate ? (paymentDetails.dueDate | date: 'short') : 'N/A' }}
+                </p>
                 <p>
                   <strong>Payment Date:</strong>
                   {{ paymentDetails.paymentDate ? (paymentDetails.paymentDate | date: 'short') : 'N/A' }}
                 </p>
-                <p><strong>Receipt:</strong> {{ paymentDetails.receiptPath || 'N/A' }}</p>
-                <p><strong>Status:</strong> {{ paymentDetails.payStatue ? 'Payed' : 'Not payed' }}</p>
-                <p><strong>Created By:</strong> {{ paymentDetails.createdBy ?? 'N/A' }}</p>
-                <p>
-                  <strong>Created At:</strong>
-                  {{ paymentDetails.createdAt ? (paymentDetails.createdAt | date: 'short') : 'N/A' }}
-                </p>
-                <p><strong>Modified By:</strong> {{ paymentDetails.modefiedBy ?? 'N/A' }}</p>
-                <p>
-                  <strong>Modified At:</strong>
-                  {{ paymentDetails.modefiedAt ? (paymentDetails.modefiedAt | date: 'short') : 'N/A' }}
-                </p>
+                <p><strong>Quantity:</strong> {{ paymentDetails.quantity }}</p>
+                <p><strong>Status:</strong> {{ paymentDetails.statusText }}</p>
               </div>
             </mat-expansion-panel>
             <mat-paginator

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
@@ -75,9 +75,8 @@ export class MembershipViewComponent implements OnInit, AfterViewInit {
       return;
     }
     this.paymentService.getPayment(paymentId).subscribe((res) => {
-      const payment = res.data?.items[0];
-      if (res.isSuccess && payment) {
-        this.paymentDetails = payment;
+      if (res.isSuccess && res.data) {
+        this.paymentDetails = res.data;
       } else {
         this.paymentDetails = null;
       }

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
@@ -1,8 +1,8 @@
 <h2 mat-dialog-title>Payment Details</h2>
 <div mat-dialog-content>
   <div class="payment-item">
-    <strong>ID:</strong>
-    <span>{{ data.id }}</span>
+    <strong>Invoice ID:</strong>
+    <span>{{ data.invoiceId }}</span>
   </div>
   <div class="payment-item">
     <strong>Student ID:</strong>
@@ -10,47 +10,31 @@
   </div>
   <div class="payment-item">
     <strong>Name:</strong>
-    <span>{{ data.studentName }}</span>
+    <span>{{ data.userName }}</span>
   </div>
   <div class="payment-item">
-    <strong>Subscription:</strong>
-    <span>{{ data.studentSubscribeName }}</span>
+    <strong>Email:</strong>
+    <span>{{ data.userEmail }}</span>
   </div>
   <div class="payment-item">
-    <strong>Amount:</strong>
-    <span>{{ data.amount }}</span>
+    <strong>Create Date:</strong>
+    <span>{{ data.createDate ? (data.createDate | date: 'short') : 'N/A' }}</span>
   </div>
   <div class="payment-item">
-    <strong>Currency:</strong>
-    <span>{{ data.currencyId }}</span>
+    <strong>Due Date:</strong>
+    <span>{{ data.dueDate ? (data.dueDate | date: 'short') : 'N/A' }}</span>
   </div>
   <div class="payment-item">
     <strong>Payment Date:</strong>
     <span>{{ data.paymentDate ? (data.paymentDate | date: 'short') : 'N/A' }}</span>
   </div>
   <div class="payment-item">
-    <strong>Receipt:</strong>
-    <span>{{ data.receiptPath || 'N/A' }}</span>
+    <strong>Quantity:</strong>
+    <span>{{ data.quantity }}</span>
   </div>
   <div class="payment-item">
     <strong>Status:</strong>
-    <span>{{ data.payStatue ? 'Payed' : 'Not payed' }}</span>
-  </div>
-  <div class="payment-item">
-    <strong>Created By:</strong>
-    <span>{{ data.createdBy ?? 'N/A' }}</span>
-  </div>
-  <div class="payment-item">
-    <strong>Created At:</strong>
-    <span>{{ data.createdAt ? (data.createdAt | date: 'short') : 'N/A' }}</span>
-  </div>
-  <div class="payment-item">
-    <strong>Modified By:</strong>
-    <span>{{ data.modefiedBy ?? 'N/A' }}</span>
-  </div>
-  <div class="payment-item">
-    <strong>Modified At:</strong>
-    <span>{{ data.modefiedAt ? (data.modefiedAt | date: 'short') : 'N/A' }}</span>
+    <span>{{ data.statusText }}</span>
   </div>
 </div>
 <div mat-dialog-actions align="end">


### PR DESCRIPTION
## Summary
- return single payment details instead of paged list in `getPayment`
- update membership components to use new payment detail fields
- refresh payment details dialogs and views with invoice info

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68c5517694748322ad5de298b4461d48