### PR TITLE
feat: add payment view and edit dialogs

### DIFF
--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -4,16 +4,32 @@ import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { ApiResponse, FilteredResultRequestDto, PagedResultDto } from './lookup.service';
 
+export enum CurrencyEnum {
+  LE = 1,
+  SAR = 2,
+  USD = 3
+}
+
 export interface StudentPaymentDto {
   invoiceId: number;
   studentId: number;
   userName?: string | null;
   userEmail?: string | null;
+  subscribe?: string | null;
   createDate?: string | null;
   dueDate?: string | null;
   paymentDate?: string | null;
-  quantity?: number | null;
   statusText?: string | null;
+  amount?: number | null;
+  currency?: CurrencyEnum | null;
+}
+
+export interface UpdatePaymentDto {
+  id: number;
+  amount?: number | null;
+  receiptPath?: string | null;
+  payStatue?: boolean | null;
+  isCancelled?: boolean | null;
 }
 
 export interface PaymentDashboardDto {
@@ -56,6 +72,25 @@ export class StudentPaymentService {
     return this.http.get<ApiResponse<StudentPaymentDto>>(
       `${environment.apiUrl}/api/StudentPayment/GetPayment`,
       { params }
+    );
+  }
+
+  updatePayment(
+    model: UpdatePaymentDto,
+    receipt?: File
+  ): Observable<ApiResponse<boolean>> {
+    const formData = new FormData();
+    Object.entries(model).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        formData.append(key, value.toString());
+      }
+    });
+    if (receipt) {
+      formData.append('ReceiptPath', receipt);
+    }
+    return this.http.post<ApiResponse<boolean>>(
+      `${environment.apiUrl}/api/StudentPayment/UpdatePayment`,
+      formData
     );
   }
 

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.html
@@ -60,12 +60,22 @@
       <td mat-cell *matCellDef="let element" class="text-nowrap">
         <ul class="list-inline m-b-0">
           <li class="list-inline-item">
-            <a href="javascript:" class="avatar avatar-xs bg-accent-100 hover m-r-10" matTooltip="View">
+            <a
+              href="javascript:"
+              class="avatar avatar-xs bg-accent-100 hover m-r-10"
+              matTooltip="View"
+              (click)="openPaymentDetails(element.id)"
+            >
               <i class="f-20 ti ti-eye text-accent-500"></i>
             </a>
           </li>
           <li class="list-inline-item">
-            <a href="javascript:" class="avatar avatar-xs bg-primary-50 hover m-r-10" matTooltip="Edit">
+            <a
+              href="javascript:"
+              class="avatar avatar-xs bg-primary-50 hover m-r-10"
+              matTooltip="Edit"
+              (click)="openPaymentEdit(element.id)"
+            >
               <i class="f-20 ti ti-edit text-primary-500"></i>
             </a>
           </li>

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.ts
@@ -23,6 +23,9 @@ import {
   StudentInvoiceDto,
   StudentPaymentService
 } from 'src/app/@theme/services/student-payment.service';
+import { MatDialog } from '@angular/material/dialog';
+import { PaymentDetailsComponent } from '../../../membership/payment-details/payment-details.component';
+import { PaymentEditComponent } from '../../payment-edit/payment-edit.component';
 import {
   ApiResponse,
   FilteredResultRequestDto,
@@ -50,6 +53,7 @@ export class InvoiceListTableComponent implements AfterViewInit, OnInit, OnChang
   @Input() compareMonth?: string;
   @Output() countChange = new EventEmitter<number>();
   private studentPaymentService = inject(StudentPaymentService);
+  private dialog = inject(MatDialog);
 
   // public props
   displayedColumns: string[] = ['id', 'name', 'create_date', 'due_date', 'qty', 'status', 'action'];
@@ -86,6 +90,22 @@ export class InvoiceListTableComponent implements AfterViewInit, OnInit, OnChang
     this.searchTerm = (event.target as HTMLInputElement).value;
     this.dataSource.filter = this.searchTerm.trim().toLowerCase();
     this.countChange.emit(this.dataSource.filteredData.length);
+  }
+
+  openPaymentDetails(id: number) {
+    this.studentPaymentService.getPayment(id).subscribe((res) => {
+      if (res.isSuccess && res.data) {
+        this.dialog.open(PaymentDetailsComponent, { data: res.data });
+      }
+    });
+  }
+
+  openPaymentEdit(id: number) {
+    this.studentPaymentService.getPayment(id).subscribe((res) => {
+      if (res.isSuccess && res.data) {
+        this.dialog.open(PaymentEditComponent, { data: res.data });
+      }
+    });
   }
 
   loadData(): void {

--- a/src/app/demo/pages/admin-panel/invoice/payment-edit/payment-edit.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/payment-edit/payment-edit.component.html
@@ -1,0 +1,21 @@
+<h2 mat-dialog-title>Edit Payment</h2>
+<div mat-dialog-content [formGroup]="form">
+  <mat-form-field appearance="outline" class="w-100">
+    <mat-label>Subscribe</mat-label>
+    <input matInput formControlName="subscribe" />
+  </mat-form-field>
+  <mat-form-field appearance="outline" class="w-100">
+    <mat-label>Amount</mat-label>
+    <input matInput type="number" formControlName="amount" />
+  </mat-form-field>
+  <mat-form-field appearance="outline" class="w-100">
+    <mat-label>Currency</mat-label>
+    <input matInput formControlName="currency" />
+  </mat-form-field>
+  <input type="file" (change)="onFileChange($event)" />
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button color="primary" (click)="confirm()">Confirm Payment</button>
+  <button mat-button color="warn" (click)="cancel()">Cancel Payment</button>
+  <button mat-button mat-dialog-close>Exit</button>
+</div>

--- a/src/app/demo/pages/admin-panel/invoice/payment-edit/payment-edit.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/payment-edit/payment-edit.component.ts
@@ -1,0 +1,62 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { StudentPaymentDto, CurrencyEnum, UpdatePaymentDto, StudentPaymentService } from 'src/app/@theme/services/student-payment.service';
+
+@Component({
+  selector: 'app-payment-edit',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, MatFormFieldModule, MatInputModule, ReactiveFormsModule],
+  templateUrl: './payment-edit.component.html',
+  styleUrl: './payment-edit.component.scss'
+})
+export class PaymentEditComponent {
+  private fb = inject(FormBuilder);
+  private service = inject(StudentPaymentService);
+  private dialogRef = inject(MatDialogRef<PaymentEditComponent>);
+  data = inject<StudentPaymentDto>(MAT_DIALOG_DATA);
+  currencyEnum = CurrencyEnum;
+  receiptFile?: File;
+
+  form = this.fb.group({
+    subscribe: [{ value: this.data.subscribe, disabled: true }],
+    amount: [this.data.amount, Validators.required],
+    currency: [{ value: this.currencyEnum[this.data.currency ?? 1], disabled: true }]
+  });
+
+  onFileChange(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length) {
+      this.receiptFile = input.files[0];
+    }
+  }
+
+  confirm() {
+    const dto: UpdatePaymentDto = {
+      id: this.data.invoiceId,
+      amount: this.form.get('amount')?.value ?? undefined,
+      payStatue: true,
+      isCancelled: false
+    };
+    this.service.updatePayment(dto, this.receiptFile).subscribe(() => {
+      this.dialogRef.close(true);
+    });
+  }
+
+  cancel() {
+    const dto: UpdatePaymentDto = {
+      id: this.data.invoiceId,
+      amount: this.form.get('amount')?.value ?? undefined,
+      payStatue: false,
+      isCancelled: true
+    };
+    this.service.updatePayment(dto, this.receiptFile).subscribe(() => {
+      this.dialogRef.close(true);
+    });
+  }
+}
+

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
@@ -89,7 +89,11 @@
                   <strong>Payment Date:</strong>
                   {{ paymentDetails.paymentDate ? (paymentDetails.paymentDate | date: 'short') : 'N/A' }}
                 </p>
-                <p><strong>Quantity:</strong> {{ paymentDetails.quantity }}</p>
+                <p><strong>Amount:</strong> {{ paymentDetails.amount }}</p>
+                <p>
+                  <strong>Currency:</strong>
+                  {{ paymentDetails.currency !== undefined ? (currencyEnum[paymentDetails.currency] || '') : '' }}
+                </p>
                 <p><strong>Status:</strong> {{ paymentDetails.statusText }}</p>
               </div>
             </mat-expansion-panel>

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
@@ -7,7 +7,11 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { StudentSubscribeService, ViewStudentSubscribeReDto } from 'src/app/@theme/services/student-subscribe.service';
 import { FilteredResultRequestDto } from 'src/app/@theme/services/lookup.service';
-import { StudentPaymentService, StudentPaymentDto } from 'src/app/@theme/services/student-payment.service';
+import {
+  StudentPaymentService,
+  StudentPaymentDto,
+  CurrencyEnum
+} from 'src/app/@theme/services/student-payment.service';
 
 
 @Component({
@@ -30,6 +34,7 @@ export class MembershipViewComponent implements OnInit, AfterViewInit {
   expandedElement: ViewStudentSubscribeReDto | null = null;
   paymentDetails: StudentPaymentDto | null = null;
   panelOpen = false;
+  currencyEnum = CurrencyEnum;
 
   readonly paginator = viewChild.required(MatPaginator);
 

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
@@ -9,6 +9,10 @@
     <span>{{ data.studentId }}</span>
   </div>
   <div class="payment-item">
+    <strong>Subscribe:</strong>
+    <span>{{ data.subscribe }}</span>
+  </div>
+  <div class="payment-item">
     <strong>Name:</strong>
     <span>{{ data.userName }}</span>
   </div>
@@ -29,8 +33,12 @@
     <span>{{ data.paymentDate ? (data.paymentDate | date: 'short') : 'N/A' }}</span>
   </div>
   <div class="payment-item">
-    <strong>Quantity:</strong>
-    <span>{{ data.quantity }}</span>
+    <strong>Amount:</strong>
+    <span>{{ data.amount }}</span>
+  </div>
+  <div class="payment-item">
+    <strong>Currency:</strong>
+    <span>{{ currencyEnum[data.currency ?? 1] }}</span>
   </div>
   <div class="payment-item">
     <strong>Status:</strong>

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.ts
@@ -2,7 +2,10 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
-import { StudentPaymentDto } from 'src/app/@theme/services/student-payment.service';
+import {
+  StudentPaymentDto,
+  CurrencyEnum
+} from 'src/app/@theme/services/student-payment.service';
 
 
 @Component({
@@ -14,5 +17,6 @@ import { StudentPaymentDto } from 'src/app/@theme/services/student-payment.servi
 })
 export class PaymentDetailsComponent {
   data = inject<StudentPaymentDto>(MAT_DIALOG_DATA);
+  currencyEnum = CurrencyEnum;
 
 }


### PR DESCRIPTION
## Summary
- add currency enum and payment update API
- show full payment info including currency
- enable editing payments with confirm or cancel actions
- refactor payment DTO to use `subscribe` and `amount`

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c55d26f9fc8322925b791d6103b4e0