### PR TITLE
Show edit icon only for unpaid active memberships

### DIFF
--- a/src/app/@theme/services/student-subscribe.service.ts
+++ b/src/app/@theme/services/student-subscribe.service.ts
@@ -10,6 +10,7 @@ export interface ViewStudentSubscribeReDto {
   studentName?: string | null;
   studentMobile?: string | null;
   payStatus?: boolean | null;
+  isCancelled?: boolean | null;
   plan?: string | null;
   remainingMinutes?: number | null;
   startDate?: string | null;

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
@@ -91,7 +91,11 @@
                           <i class="ti ti-eye f-20"></i>
                         </a>
                       </li>
-                      <li class="list-inline-item m-r-10" matTooltip="Edit">
+                      <li
+                        class="list-inline-item m-r-10"
+                        matTooltip="Edit"
+                        *ngIf="element.payStatus === false && element.isCancelled === false"
+                      >
                         <a href="javascript:" class="avatar avatar-xs text-muted">
                           <i class="ti ti-edit-circle f-20"></i>
                         </a>


### PR DESCRIPTION
## Summary
- expose isCancelled flag in student subscribe DTO
- show edit icon only when payStatus is false and subscription not cancelled

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68c56d2312f48322a80c343ac6dc4b0c