### PR TITLE
Disable membership edit icon when paid or canceled

### DIFF
--- a/src/app/@theme/services/student-subscribe.service.ts
+++ b/src/app/@theme/services/student-subscribe.service.ts
@@ -10,6 +10,7 @@ export interface ViewStudentSubscribeReDto {
   studentName?: string | null;
   studentMobile?: string | null;
   payStatus?: boolean | null;
+  isCancelled?: boolean | null;
   plan?: string | null;
   remainingMinutes?: number | null;
   startDate?: string | null;

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
@@ -90,12 +90,22 @@
                         <a [routerLink]="['/membership/view', element.studentId]" class="avatar avatar-xs text-muted">
                           <i class="ti ti-eye f-20"></i>
                         </a>
-                      </li>
-                      <li class="list-inline-item m-r-10" matTooltip="Edit">
-                        <a href="javascript:" class="avatar avatar-xs text-muted">
-                          <i class="ti ti-edit-circle f-20"></i>
-                        </a>
-                      </li>
+                        </li>
+                        <li
+                          class="list-inline-item m-r-10"
+                          matTooltip="Edit"
+                          [matTooltipDisabled]="element.payStatus === true || element.isCancelled === true"
+                        >
+                          <a
+                            href="javascript:"
+                            class="avatar avatar-xs text-muted"
+                            [ngClass]="{
+                              disabled: element.payStatus === true || element.isCancelled === true
+                            }"
+                          >
+                            <i class="ti ti-edit-circle f-20"></i>
+                          </a>
+                        </li>
                       <li class="list-inline-item m-r-10" matTooltip="Delete">
                         <a href="javascript:" class="avatar avatar-xs text-muted">
                           <i class="ti ti-trash f-20"></i>

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.scss
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.scss
@@ -1,1 +1,7 @@
 // This file is intentionally left empty to allow customers to add custom CSS if needed.
+
+.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+  cursor: default;
+}


### PR DESCRIPTION
## Summary
- expose isCancelled flag in student subscribe DTO
- keep edit icon visible but disabled when payStatus is true or membership is cancelled

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68c56d2312f48322a80c343ac6dc4b0c