### PR TITLE
feat(membership): add subscription dialog

### DIFF
--- a/src/app/@theme/services/lookup.service.ts
+++ b/src/app/@theme/services/lookup.service.ts
@@ -61,6 +61,11 @@ export interface GovernorateDto {
   name: string;
 }
 
+export interface LookupDto {
+  id: number;
+  name: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class LookupService {
   private http = inject(HttpClient);
@@ -113,5 +118,16 @@ export class LookupService {
 
   getAllGovernorates(): Observable<ApiResponse<GovernorateDto[]>> {
     return this.http.get<ApiResponse<GovernorateDto[]>>(`${environment.apiUrl}/api/LookUp/GetAllGovernorate`);
+  }
+
+  getSubscribesByTypeId(id?: number | null): Observable<ApiResponse<LookupDto[]>> {
+    let params = new HttpParams();
+    if (id !== undefined && id !== null) {
+      params = params.set('id', id.toString());
+    }
+    return this.http.get<ApiResponse<LookupDto[]>>(
+      `${environment.apiUrl}/api/LookUp/GetAllSubscribesByTypeId`,
+      { params }
+    );
   }
 }

--- a/src/app/@theme/services/student-subscribe.service.ts
+++ b/src/app/@theme/services/student-subscribe.service.ts
@@ -17,6 +17,11 @@ export interface ViewStudentSubscribeReDto {
   studentPaymentId?: number | null;
 }
 
+export interface AddStudentSubscribeDto {
+  studentId?: number;
+  studentSubscribeId?: number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class StudentSubscribeService {
   private http = inject(HttpClient);
@@ -86,6 +91,13 @@ export class StudentSubscribeService {
     return this.http.get<ApiResponse<PagedResultDto<ViewStudentSubscribeReDto>>>(
       `${environment.apiUrl}/api/StudentSubscrib/GetStudentSubscribesWithPayment`,
       { params }
+    );
+  }
+
+  create(model: AddStudentSubscribeDto): Observable<ApiResponse<boolean>> {
+    return this.http.post<ApiResponse<boolean>>(
+      `${environment.apiUrl}/api/StudentSubscrib/Create`,
+      model
     );
   }
 }

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.html
@@ -102,6 +102,7 @@
                             [ngClass]="{
                               disabled: element.payStatus === true || element.isCancelled === true
                             }"
+                            (click)="openSubscribeDialog(element)"
                           >
                             <i class="ti ti-edit-circle f-20"></i>
                           </a>

--- a/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/membership-list.component.ts
@@ -14,6 +14,7 @@ import { StudentSubscribeService, ViewStudentSubscribeReDto } from 'src/app/@the
 import { FilteredResultRequestDto } from 'src/app/@theme/services/lookup.service';
 import { StudentPaymentService } from 'src/app/@theme/services/student-payment.service';
 import { PaymentDetailsComponent } from '../payment-details/payment-details.component';
+import { StudentSubscribeDialogComponent } from './student-subscribe-dialog/student-subscribe-dialog.component';
 
 @Component({
   selector: 'app-membership-list',
@@ -75,6 +76,20 @@ export class MembershipListComponent implements AfterViewInit, OnInit {
     this.paymentService.getPayment(paymentId).subscribe((res) => {
       if (res.isSuccess && res.data) {
         this.dialog.open(PaymentDetailsComponent, { data: res.data });
+      }
+    });
+  }
+
+  openSubscribeDialog(student: ViewStudentSubscribeReDto) {
+    if (student.payStatus === true || student.isCancelled === true) {
+      return;
+    }
+    const dialogRef = this.dialog.open(StudentSubscribeDialogComponent, {
+      data: { studentId: student.studentId }
+    });
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.load();
       }
     });
   }

--- a/src/app/demo/pages/admin-panel/membership/membership-list/student-subscribe-dialog/student-subscribe-dialog.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/student-subscribe-dialog/student-subscribe-dialog.component.html
@@ -1,0 +1,20 @@
+<h2 mat-dialog-title>Update Subscription</h2>
+<mat-dialog-content [formGroup]="form">
+  <mat-form-field appearance="outline" class="w-100">
+    <mat-label>Subscribe Type</mat-label>
+    <mat-select formControlName="subscribeTypeId">
+      <mat-option [value]="type.id" *ngFor="let type of types">{{ type.name }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="w-100">
+    <mat-label>Subscribe</mat-label>
+    <mat-select formControlName="subscribeId">
+      <mat-option [value]="s.id" *ngFor="let s of subscribes">{{ s.name }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Cancel</button>
+  <button mat-flat-button color="primary" (click)="submit()" [disabled]="form.invalid">Save</button>
+</mat-dialog-actions>

--- a/src/app/demo/pages/admin-panel/membership/membership-list/student-subscribe-dialog/student-subscribe-dialog.component.scss
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/student-subscribe-dialog/student-subscribe-dialog.component.scss
@@ -1,0 +1,1 @@
+/* Empty styles for subscription dialog */

--- a/src/app/demo/pages/admin-panel/membership/membership-list/student-subscribe-dialog/student-subscribe-dialog.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-list/student-subscribe-dialog/student-subscribe-dialog.component.ts
@@ -1,0 +1,91 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { FilteredResultRequestDto, LookupService, LookupDto } from 'src/app/@theme/services/lookup.service';
+import { SubscribeService, SubscribeTypeDto } from 'src/app/@theme/services/subscribe.service';
+import { StudentSubscribeService, AddStudentSubscribeDto } from 'src/app/@theme/services/student-subscribe.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+
+@Component({
+  selector: 'app-student-subscribe-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    ReactiveFormsModule
+  ],
+  templateUrl: './student-subscribe-dialog.component.html',
+  styleUrl: './student-subscribe-dialog.component.scss'
+})
+export class StudentSubscribeDialogComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private subscribeService = inject(SubscribeService);
+  private lookupService = inject(LookupService);
+  private studentSubscribeService = inject(StudentSubscribeService);
+  private toast = inject(ToastService);
+  private dialogRef = inject(MatDialogRef<StudentSubscribeDialogComponent>);
+  private data = inject<{ studentId: number }>(MAT_DIALOG_DATA);
+
+  form = this.fb.group({
+    subscribeTypeId: [null as number | null, Validators.required],
+    subscribeId: [null as number | null, Validators.required]
+  });
+
+  types: SubscribeTypeDto[] = [];
+  subscribes: LookupDto[] = [];
+
+  ngOnInit(): void {
+    const filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 100 };
+    this.subscribeService.getAllTypes(filter).subscribe((res) => {
+      if (res.isSuccess && res.data?.items) {
+        this.types = res.data.items;
+      } else {
+        this.types = [];
+      }
+    });
+
+    this.form.get('subscribeTypeId')?.valueChanges.subscribe((typeId) => {
+      this.form.patchValue({ subscribeId: null }, { emitEvent: false });
+      if (typeId) {
+        this.lookupService.getSubscribesByTypeId(typeId).subscribe((res) => {
+          if (res.isSuccess && res.data) {
+            this.subscribes = res.data;
+          } else {
+            this.subscribes = [];
+          }
+        });
+      } else {
+        this.subscribes = [];
+      }
+    });
+  }
+
+  submit(): void {
+    const subscribeId = this.form.value.subscribeId;
+    if (!subscribeId) {
+      return;
+    }
+    const model: AddStudentSubscribeDto = {
+      studentId: this.data?.studentId,
+      studentSubscribeId: subscribeId
+    };
+    this.studentSubscribeService.create(model).subscribe({
+      next: (res) => {
+        if (res.isSuccess) {
+          this.toast.success('Subscribe updated successfully');
+          this.dialogRef.close(true);
+        } else {
+          this.toast.error('Error updating subscribe');
+        }
+      },
+      error: () => this.toast.error('Error updating subscribe')
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add lookup service to fetch subscribes by type
- create student subscribe dialog for selecting type and subscribe
- hook membership list edit action to open dialog and create subscription

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c66f7a2aa4832294d5ca8b684a640e