### PR TITLE
feat: add invoice navigation from payment details

### DIFF
--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.html
@@ -1,7 +1,13 @@
 <div class="table-responsive">
   <div class="table-search p-t-20 p-x-20">
     <mat-form-field appearance="outline" class="w-100">
-      <input matInput (keyup)="applyFilter($event)" placeholder="Search...." #input />
+      <input
+        matInput
+        (keyup)="applyFilter($event)"
+        placeholder="Search...."
+        [value]="searchTerm"
+        #input
+      />
     </mat-form-field>
   </div>
 
@@ -69,7 +75,7 @@
               <i class="f-20 ti ti-eye text-accent-500"></i>
             </a>
           </li>
-          @if (element.status == 'unpaid') {
+          @if (element.status === 'unpaid') {
             <li class="list-inline-item">
               <a
                 href="javascript:"

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list-table/invoice-list-table.component.ts
@@ -53,6 +53,7 @@ export class InvoiceListTableComponent implements AfterViewInit, OnInit, OnChang
   @Input() tab?: string;
   @Input() month?: string;
   @Input() compareMonth?: string;
+  @Input() search = '';
   @Output() countChange = new EventEmitter<number>();
   private studentPaymentService = inject(StudentPaymentService);
   private dialog = inject(MatDialog);
@@ -60,7 +61,7 @@ export class InvoiceListTableComponent implements AfterViewInit, OnInit, OnChang
   // public props
   displayedColumns: string[] = ['id', 'name', 'create_date', 'due_date', 'qty', 'status', 'action'];
   dataSource = new MatTableDataSource<InvoiceTableItem>([]);
-  private searchTerm = '';
+  searchTerm = '';
   // paginator
   readonly paginator = viewChild.required(MatPaginator); // if Angular ≥17
 
@@ -78,12 +79,18 @@ export class InvoiceListTableComponent implements AfterViewInit, OnInit, OnChang
         data.status.toLowerCase().includes(term)
       );
     };
+    this.searchTerm = this.search;
     this.loadData();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['tab'] || changes['month'] || changes['compareMonth']) {
       this.loadData();
+    }
+    if (changes['search'] && !changes['search'].firstChange) {
+      this.searchTerm = this.search;
+      this.dataSource.filter = this.searchTerm.trim().toLowerCase();
+      this.countChange.emit(this.dataSource.filteredData.length);
     }
   }
 

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
@@ -90,7 +90,7 @@
             </div>
           </ng-template>
           <div class="p-y-20">
-            <app-invoice-list-table [month]="dataMonth.value?.format('YYYY-MM')" (countChange)="onTableCount('all', $event)" />
+            <app-invoice-list-table [month]="dataMonth.value?.format('YYYY-MM')" [search]="searchTerm" (countChange)="onTableCount('all', $event)" />
           </div>
         </mat-tab>
         <mat-tab>
@@ -103,7 +103,7 @@
             </div>
           </ng-template>
           <div class="p-y-20">
-            <app-invoice-list-table tab="paid" [month]="dataMonth.value?.format('YYYY-MM')" (countChange)="onTableCount('paid', $event)" />
+            <app-invoice-list-table tab="paid" [month]="dataMonth.value?.format('YYYY-MM')" [search]="searchTerm" (countChange)="onTableCount('paid', $event)" />
 
           </div>
         </mat-tab>
@@ -117,7 +117,7 @@
             </div>
           </ng-template>
           <div class="p-y-20">
-            <app-invoice-list-table tab="unpaid" [month]="dataMonth.value?.format('YYYY-MM')" (countChange)="onTableCount('unpaid', $event)" />
+            <app-invoice-list-table tab="unpaid" [month]="dataMonth.value?.format('YYYY-MM')" [search]="searchTerm" (countChange)="onTableCount('unpaid', $event)" />
 
           </div>
         </mat-tab>
@@ -131,7 +131,7 @@
             </div>
           </ng-template>
           <div class="p-y-20">
-            <app-invoice-list-table tab="overdue" [month]="dataMonth.value?.format('YYYY-MM')" (countChange)="onTableCount('overdue', $event)" />
+            <app-invoice-list-table tab="overdue" [month]="dataMonth.value?.format('YYYY-MM')" [search]="searchTerm" (countChange)="onTableCount('overdue', $event)" />
 
           </div>
         </mat-tab>
@@ -145,7 +145,7 @@
             </div>
           </ng-template>
           <div class="p-y-20">
-            <app-invoice-list-table tab="cancelled" [month]="dataMonth.value?.format('YYYY-MM')" (countChange)="onTableCount('cancelled', $event)" />
+            <app-invoice-list-table tab="cancelled" [month]="dataMonth.value?.format('YYYY-MM')" [search]="searchTerm" (countChange)="onTableCount('cancelled', $event)" />
 
           </div>
         </mat-tab>

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
@@ -7,6 +7,7 @@ import { MomentDateAdapter, MAT_MOMENT_DATE_ADAPTER_OPTIONS } from '@angular/mat
 import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
 import * as _moment from 'moment';
 import { default as _rollupMoment, Moment } from 'moment';
+import { ActivatedRoute } from '@angular/router';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -61,6 +62,7 @@ interface WidgetCard {
 })
 export class InvoiceListComponent implements OnInit {
   private studentPaymentService = inject(StudentPaymentService);
+  private route = inject(ActivatedRoute);
   dataMonth = new FormControl<Moment>(moment());
   widgetCards: WidgetCard[] = [];
   bigCard = {
@@ -76,8 +78,13 @@ export class InvoiceListComponent implements OnInit {
     overdue: 0,
     cancelled: 0
   };
+  searchTerm = '';
 
   ngOnInit(): void {
+    this.searchTerm = this.route.snapshot.queryParamMap.get('search') ?? '';
+    this.route.queryParamMap.subscribe((params) => {
+      this.searchTerm = params.get('search') ?? '';
+    });
     this.loadDashboard();
   }
 

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.html
@@ -95,6 +95,7 @@
                   {{ paymentDetails.currency !== undefined ? (currencyEnum[paymentDetails.currency] || '') : '' }}
                 </p>
                 <p><strong>Status:</strong> {{ paymentDetails.statusText }}</p>
+                <button mat-button color="primary" (click)="goToInvoice(paymentDetails?.invoiceId)">View Invoice</button>
               </div>
             </mat-expansion-panel>
             <mat-paginator

--- a/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/membership-view/membership-view.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, OnInit, inject, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule, ActivatedRoute } from '@angular/router';
+import { RouterModule, ActivatedRoute, Router } from '@angular/router';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -24,6 +24,7 @@ export class MembershipViewComponent implements OnInit, AfterViewInit {
   private service = inject(StudentSubscribeService);
   private route = inject(ActivatedRoute);
   private paymentService = inject(StudentPaymentService);
+  private router = inject(Router);
 
   displayedColumns: string[] = ['expand', 'plan', 'remainingMinutes', 'startDate', 'status'];
   dataSource = new MatTableDataSource<ViewStudentSubscribeReDto>();
@@ -86,6 +87,13 @@ export class MembershipViewComponent implements OnInit, AfterViewInit {
         this.paymentDetails = null;
       }
     });
+  }
+
+  goToInvoice(invoiceId?: number | null) {
+    if (invoiceId == null) {
+      return;
+    }
+    this.router.navigate(['/invoice/list'], { queryParams: { search: invoiceId } });
   }
 }
 

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.html
@@ -46,5 +46,6 @@
   </div>
 </div>
 <div mat-dialog-actions align="end">
+  <button mat-button color="primary" (click)="viewInvoice()">View Invoice</button>
   <button mat-button mat-dialog-close>Close</button>
 </div>

--- a/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.ts
+++ b/src/app/demo/pages/admin-panel/membership/payment-details/payment-details.component.ts
@@ -1,12 +1,16 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef
+} from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
+import { Router } from '@angular/router';
 import {
   StudentPaymentDto,
   CurrencyEnum
 } from 'src/app/@theme/services/student-payment.service';
-
 
 @Component({
   selector: 'app-payment-details',
@@ -19,4 +23,13 @@ export class PaymentDetailsComponent {
   data = inject<StudentPaymentDto>(MAT_DIALOG_DATA);
   currencyEnum = CurrencyEnum;
 
+  private router = inject(Router);
+  private dialogRef = inject(MatDialogRef<PaymentDetailsComponent>);
+
+  viewInvoice(): void {
+    this.dialogRef.close();
+    this.router.navigate(['/invoice/list'], {
+      queryParams: { search: this.data.invoiceId }
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- add invoice search button to payment details dialog and membership view
- support invoice list search via query parameter

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c680eb393c83228f727abecce92397