### PR TITLE
feat: add subscribes menu

### DIFF
--- a/src/app/demo/data/menu.ts
+++ b/src/app/demo/data/menu.ts
@@ -327,6 +327,32 @@ export const menus: Navigation[] = [
             ]
           },
           {
+            id: 'subscribes',
+            title: 'Subscribes',
+            type: 'collapse',
+            role: [
+              UserTypesEnum.Admin.toString(),
+              UserTypesEnum.Manager.toString(),
+              UserTypesEnum.BranchLeader.toString(),
+              UserTypesEnum.Student.toString(),
+              UserTypesEnum.Teacher.toString()
+            ],
+            children: [
+              {
+                id: 'subscribe',
+                title: 'Subscribe',
+                type: 'item',
+                url: '/online-course/setting/subscribe'
+              },
+              {
+                id: 'subscribe-type',
+                title: 'Subscribe Type',
+                type: 'item',
+                url: '/online-course/setting/subscribe-type'
+              }
+            ]
+          },
+          {
             id: 'pricing',
             title: 'Pricing',
             type: 'item',


### PR DESCRIPTION
## Summary
- add Subscribes navigation section with Subscribe and Subscribe Type links

## Testing
- `npx ng test able-pro` *(fails: Project target does not exist)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c685320ba483229e0cc0ed5a2213ae