### PR TITLE
feat: toggle student activation icons

### DIFF
--- a/src/app/@theme/services/lookup.service.ts
+++ b/src/app/@theme/services/lookup.service.ts
@@ -16,6 +16,7 @@ export interface LookUpUserDto {
   governorate: string;
   governorateId: number;
   branchId: number;
+  inactive?: boolean;
   managerId?: number;
   managerName?: string;
   circleId?: number;

--- a/src/app/@theme/services/user.service.ts
+++ b/src/app/@theme/services/user.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
@@ -58,5 +58,15 @@ export class UserService {
   updateUser(model: UpdateUserDto): Observable<ApiResponse<boolean>> {
     return this.http.post<ApiResponse<boolean>>(`${environment.apiUrl}/api/User/Update`, model);
 
+  }
+
+  disableUser(id: number, statue: boolean): Observable<ApiResponse<boolean>> {
+    const params = new HttpParams()
+      .set('id', id.toString())
+      .set('statue', statue.toString());
+    return this.http.get<ApiResponse<boolean>>(
+      `${environment.apiUrl}/api/User/DisableUser`,
+      { params }
+    );
   }
 }

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.html
@@ -60,7 +60,7 @@
                 <th mat-header-cell *matHeaderCellDef class="text-center">ACTIONS</th>
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
                   <div class="text-center text-nowrap">
-                    <ul class="list-inline p-l-0">
+                    <ul class="list-inline p-l-0" *ngIf="!element.inactive; else inactiveIcons">
                       <li class="list-inline-item m-r-10" matTooltip="View" (click)="studentDetails(element)">
                         <a href="javascript:" class="avatar avatar-xs text-muted">
                           <i class="ti ti-eye f-18"></i>
@@ -81,6 +81,20 @@
                         </a>
                       </li>
                     </ul>
+                    <ng-template #inactiveIcons>
+                      <ul class="list-inline p-l-0">
+                        <li class="list-inline-item m-r-10" matTooltip="Accept" (click)="changeStatus(element, true)">
+                          <a href="javascript:" class="avatar avatar-xs text-muted">
+                            <i class="ti ti-check f-18"></i>
+                          </a>
+                        </li>
+                        <li class="list-inline-item m-r-10" matTooltip="Reject" (click)="changeStatus(element, false)">
+                          <a href="javascript:" class="avatar avatar-xs text-muted">
+                            <i class="ti ti-x f-18"></i>
+                          </a>
+                        </li>
+                      </ul>
+                    </ng-template>
                   </div>
                 </td>
               </ng-container>

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
@@ -15,6 +15,7 @@ import {
   LookUpUserDto,
   FilteredResultRequestDto,
 } from 'src/app/@theme/services/lookup.service';
+import { UserService } from 'src/app/@theme/services/user.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { StudentDetailsComponent } from '../student-details/student-details.component';
 
@@ -26,6 +27,7 @@ import { StudentDetailsComponent } from '../student-details/student-details.comp
 })
 export class StudentListComponent implements OnInit, AfterViewInit {
   private lookupService = inject(LookupService);
+  private userService = inject(UserService);
   dialog = inject(MatDialog);
 
   // public props
@@ -75,6 +77,19 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
     this.dialog.open(StudentDetailsComponent, {
       width: '800px',
       data: student
+    });
+  }
+
+  changeStatus(student: LookUpUserDto, statue: boolean): void {
+    this.userService.disableUser(student.id, statue).subscribe((res) => {
+      if (res.isSuccess) {
+        if (statue) {
+          student.inactive = false;
+        } else {
+          this.dataSource.data = this.dataSource.data.filter((s) => s.id !== student.id);
+          this.totalCount--;
+        }
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- support inactive user state in lookup model
- add disableUser API call
- toggle action icons in student list to approve or reject inactive students

## Testing
- `npm run lint`
- `npm run build`
- `npx ng test` *(fails: Project target does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c68a7b54dc8322aeb87818e9d2d79f