### PR TITLE
Filter inactive students directly on list page

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.html
@@ -3,8 +3,8 @@
     <app-card cardTitle="Student List" padding="0" cardClass="sm-block">
       <ng-template #headerOptionsTemplate>
         <div class="table-options">
-          <button mat-stroked-button color="accent" class="m-r-10" [routerLink]="['/online-course/student/apply']">
-            Apply Student List
+          <button mat-stroked-button color="accent" class="m-r-10" (click)="toggleInactiveFilter()">
+            {{ showInactive ? 'All Student List' : 'Apply Student List' }}
           </button>
           <button mat-flat-button color="primary" [routerLink]="['/online-course/student/add']">
             <div class="flex align-item-center">

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-list/student-list.component.ts
@@ -35,6 +35,7 @@ export class StudentListComponent implements OnInit, AfterViewInit {
   dataSource = new MatTableDataSource<LookUpUserDto>();
   totalCount = 0;
   filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 10 };
+  showInactive = false;
 
   // paginator
 readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
@@ -44,6 +45,18 @@ readonly paginator = viewChild.required(MatPaginator);  // if Angular ≥17
   applyFilter(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;
     this.filter.searchTerm = filterValue.trim().toLowerCase();
+    this.filter.skipCount = 0;
+    this.paginator().firstPage();
+    this.loadStudents();
+  }
+
+  toggleInactiveFilter(): void {
+    this.showInactive = !this.showInactive;
+    if (this.showInactive) {
+      this.filter.filter = 'inactive=true';
+    } else {
+      delete this.filter.filter;
+    }
     this.filter.skipCount = 0;
     this.paginator().firstPage();
     this.loadStudents();


### PR DESCRIPTION
## Summary
- Toggle inactive students on the main list without routing to apply page
- Restore student apply component to simple placeholder data

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68c68fa060fc83228522d01efd724a61