### PR TITLE
Show red downward arrow for negative values

### DIFF
--- a/src/app/demo/pages/apex-chart/earning-chart/earning-chart.component.html
+++ b/src/app/demo/pages/apex-chart/earning-chart/earning-chart.component.html
@@ -34,8 +34,8 @@
       </div>
       <div class="col-5 text-end">
         <div class="m-b-5 f-w-600">{{ earningValue() }}</div>
-        <div class="{{ textColor() }} mat-caption f-w-500">
-          <i class="ti ti-arrow-up-right"></i>
+        <div class="mat-caption f-w-500" [ngClass]="isNegative() ? 'text-warn-500' : textColor()">
+          <i class="ti" [ngClass]="isNegative() ? 'ti-arrow-down-right' : 'ti-arrow-up-right'"></i>
           {{ percentageValue() }}
         </div>
       </div>

--- a/src/app/demo/pages/apex-chart/earning-chart/earning-chart.component.ts
+++ b/src/app/demo/pages/apex-chart/earning-chart/earning-chart.component.ts
@@ -76,4 +76,8 @@ export class EarningChartComponent implements OnInit {
     tooltip.theme = isDark === DARK ? DARK : LIGHT;
     this.chartOptions = { ...this.chartOptions, tooltip };
   }
+
+  isNegative(): boolean {
+    return parseFloat(this.percentageValue()) < 0;
+  }
 }


### PR DESCRIPTION
## Summary
- display red downward arrow when percentage is negative
- add helper to detect negative percentage values

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68c6aa16608c8322ac8f3e73ecc1541e