### PR TITLE
feat: add compare month picker to invoice dashboard

### DIFF
--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -99,7 +99,8 @@ export class StudentPaymentService {
   getDashboard(
     studentId?: number,
     currencyId?: number,
-    dataMonth?: Date
+    dataMonth?: Date,
+    compareMonth?: Date
   ): Observable<PaymentDashboardDto> {
     let params = new HttpParams();
     if (studentId !== undefined) {
@@ -110,6 +111,9 @@ export class StudentPaymentService {
     }
     if (dataMonth) {
       params = params.set('dataMonth', dataMonth.toISOString());
+    }
+    if (compareMonth) {
+      params = params.set('compareMonth', compareMonth.toISOString());
     }
     return this.http.get<PaymentDashboardDto>(
       `${environment.apiUrl}/api/StudentPayment/Dashboard`,

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.html
@@ -12,6 +12,17 @@
           panelClass="example-month-picker"
         ></mat-datepicker>
       </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Compare Month</mat-label>
+        <input matInput [matDatepicker]="comparePicker" [formControl]="compareMonth" />
+        <mat-datepicker-toggle matIconSuffix [for]="comparePicker"></mat-datepicker-toggle>
+        <mat-datepicker
+          #comparePicker
+          startView="multi-year"
+          (monthSelected)="setCompareMonthAndYear($event, comparePicker)"
+          panelClass="example-month-picker"
+        ></mat-datepicker>
+      </mat-form-field>
     </div>
   </div>
   <div class="col-xxl-8">

--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
@@ -64,6 +64,7 @@ export class InvoiceListComponent implements OnInit {
   private studentPaymentService = inject(StudentPaymentService);
   private route = inject(ActivatedRoute);
   dataMonth = new FormControl<Moment>(moment());
+  compareMonth = new FormControl<Moment | null>(null);
   widgetCards: WidgetCard[] = [];
   bigCard = {
     currentReceivables: 0,
@@ -96,6 +97,12 @@ export class InvoiceListComponent implements OnInit {
     this.loadDashboard();
   }
 
+  setCompareMonthAndYear(normalizedMonthAndYear: Moment, datepicker: MatDatepicker<Moment>) {
+    this.compareMonth.setValue(normalizedMonthAndYear);
+    datepicker.close();
+    this.loadDashboard();
+  }
+
   onTableCount(tab: 'all' | 'paid' | 'unpaid' | 'overdue' | 'cancelled', count: number): void {
     this.tabCounts[tab] = count;
     if (tab !== 'all') {
@@ -109,8 +116,9 @@ export class InvoiceListComponent implements OnInit {
 
   loadDashboard(): void {
     const dataMonthDate = this.dataMonth.value?.toDate();
+    const compareMonthDate = this.compareMonth.value?.toDate();
     this.studentPaymentService
-      .getDashboard(undefined, undefined, dataMonthDate)
+      .getDashboard(undefined, undefined, dataMonthDate, compareMonthDate)
 
       .subscribe((data: PaymentDashboardDto) => {
         const paidTrend = this.getTrend(data.totalPaidMoMPercentage);


### PR DESCRIPTION
## Summary
- add compare month picker on invoice list page
- propagate compareMonth to student payment dashboard service
- reload dashboard data when compare month changes

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6af83566c8322a0661b853317c0cf