### PR TITLE
fix: prevent datepicker from mutating selected months

### DIFF
--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
@@ -90,7 +90,8 @@ export class InvoiceListComponent implements OnInit {
   }
 
   setDataMonthAndYear(normalizedMonthAndYear: Moment, datepicker: MatDatepicker<Moment>) {
-    this.dataMonth.setValue(normalizedMonthAndYear);
+    // clone the selected month to avoid further mutation by the datepicker
+    this.dataMonth.setValue(normalizedMonthAndYear.clone());
     datepicker.close();
     this.tabCounts = { all: 0, paid: 0, unpaid: 0, overdue: 0, cancelled: 0 };
 
@@ -98,7 +99,8 @@ export class InvoiceListComponent implements OnInit {
   }
 
   setCompareMonthAndYear(normalizedMonthAndYear: Moment, datepicker: MatDatepicker<Moment>) {
-    this.compareMonth.setValue(normalizedMonthAndYear);
+    // clone the selected month to avoid the value being mutated when navigating
+    this.compareMonth.setValue(normalizedMonthAndYear.clone());
     datepicker.close();
     this.loadDashboard();
   }


### PR DESCRIPTION
## Summary
- clone selected months for data and comparison inputs so later navigation doesn't mutate the stored value

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6b3d4d61c8322859f8727fcf11b8d