### PR TITLE
fix: send selected months in UTC

### DIFF
--- a/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
+++ b/src/app/demo/pages/admin-panel/invoice/invoice-list/invoice-list.component.ts
@@ -63,7 +63,9 @@ interface WidgetCard {
 export class InvoiceListComponent implements OnInit {
   private studentPaymentService = inject(StudentPaymentService);
   private route = inject(ActivatedRoute);
-  dataMonth = new FormControl<Moment>(moment());
+  dataMonth = new FormControl<Moment>(
+    moment().startOf('month').utc(true)
+  );
   compareMonth = new FormControl<Moment | null>(null);
   widgetCards: WidgetCard[] = [];
   bigCard = {
@@ -89,16 +91,28 @@ export class InvoiceListComponent implements OnInit {
     this.loadDashboard();
   }
 
-  setDataMonthAndYear(normalizedMonthAndYear: Moment, datepicker: MatDatepicker<Moment>) {
-    this.dataMonth.setValue(normalizedMonthAndYear);
+  setDataMonthAndYear(
+    normalizedMonthAndYear: Moment,
+    datepicker: MatDatepicker<Moment>
+  ) {
+    // clone and normalize to the first day of the selected month in UTC
+    this.dataMonth.setValue(
+      normalizedMonthAndYear.clone().startOf('month').utc(true)
+    );
     datepicker.close();
     this.tabCounts = { all: 0, paid: 0, unpaid: 0, overdue: 0, cancelled: 0 };
 
     this.loadDashboard();
   }
 
-  setCompareMonthAndYear(normalizedMonthAndYear: Moment, datepicker: MatDatepicker<Moment>) {
-    this.compareMonth.setValue(normalizedMonthAndYear);
+  setCompareMonthAndYear(
+    normalizedMonthAndYear: Moment,
+    datepicker: MatDatepicker<Moment>
+  ) {
+    // clone and normalize to the first day of the selected month in UTC
+    this.compareMonth.setValue(
+      normalizedMonthAndYear.clone().startOf('month').utc(true)
+    );
     datepicker.close();
     this.loadDashboard();
   }


### PR DESCRIPTION
## Summary
- clone selected months for data and comparison inputs so later navigation doesn't mutate the stored value
- normalize selected months to the first day in UTC so the API receives the exact month chosen

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6b3d4d61c8322859f8727fcf11b8d