### PR TITLE
Add circle report update functionality

### DIFF
--- a/src/app/@theme/services/circle-report.service.ts
+++ b/src/app/@theme/services/circle-report.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
@@ -35,6 +35,21 @@ export class CircleReportService {
     return this.http.post<ApiResponse<boolean>>(
       `${environment.apiUrl}/api/CircleReport/Create`,
       model
+    );
+  }
+
+  update(model: CircleReportAddDto): Observable<ApiResponse<boolean>> {
+    return this.http.post<ApiResponse<boolean>>(
+      `${environment.apiUrl}/api/CircleReport/Update`,
+      model
+    );
+  }
+
+  get(id: number): Observable<ApiResponse<CircleReportAddDto>> {
+    const params = new HttpParams().set('id', id.toString());
+    return this.http.get<ApiResponse<CircleReportAddDto>>(
+      `${environment.apiUrl}/api/CircleReport/Get`,
+      { params }
     );
   }
 }

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-12">
-    <app-card cardTitle="Add Circle Report">
+    <app-card [cardTitle]="cardTitle">
       <form [formGroup]="reportForm" (ngSubmit)="onSubmit()" class="row">
         <div class="col-md-6">
           <mat-form-field appearance="outline" class="w-100">
@@ -118,7 +118,7 @@
         </ng-container>
 
         <div class="col-12">
-          <button mat-flat-button color="primary" type="submit">Create</button>
+          <button mat-flat-button color="primary" type="submit">{{ submitLabel }}</button>
         </div>
       </form>
     </app-card>

--- a/src/app/demo/pages/admin-panel/online-courses/student/student-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/student/student-routing.module.ts
@@ -48,14 +48,24 @@ const routes: Routes = [
         path: 'report/add/:id',
         loadComponent: () => import('../report/report-add/report-add.component').then((c) => c.ReportAddComponent),
         data: {
-          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher],
+          mode: 'add'
+        }
+      },
+      {
+        path: 'report/update/:id',
+        loadComponent: () => import('../report/report-add/report-add.component').then((c) => c.ReportAddComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher],
+          mode: 'update'
         }
       },
       {
         path: 'report/add',
         loadComponent: () => import('../report/report-add/report-add.component').then((c) => c.ReportAddComponent),
         data: {
-          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher],
+          mode: 'add'
         }
       }
     ]


### PR DESCRIPTION
## Summary
- add update and get helpers to the circle report service
- allow the circle report form component to load existing data and call the update endpoint when editing
- expose a student route for updating reports and bind the form card/button labels dynamically

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c92c93541083229559001ab4eed138