### PR TITLE
Add circle report list and detail pages

### DIFF
--- a/src/app/@theme/services/circle-report.service.ts
+++ b/src/app/@theme/services/circle-report.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { ApiResponse } from './lookup.service';
+import { ApiResponse, FilteredResultRequestDto, PagedResultDto } from './lookup.service';
 
 export interface CircleReportAddDto {
   id?: number;
@@ -27,6 +27,20 @@ export interface CircleReportAddDto {
   attendStatueId?: number;
 }
 
+export interface CircleReportListDto {
+  id: number;
+  creationTime?: Date | string;
+  circleId?: number;
+  circleName?: string;
+  studentId?: number;
+  studentName?: string;
+  teacherId?: number;
+  teacherName?: string;
+  attendStatueId?: number;
+  minutes?: number;
+  [key: string]: unknown;
+}
+
 @Injectable({ providedIn: 'root' })
 export class CircleReportService {
   private http = inject(HttpClient);
@@ -49,6 +63,50 @@ export class CircleReportService {
     const params = new HttpParams().set('id', id.toString());
     return this.http.get<ApiResponse<CircleReportAddDto>>(
       `${environment.apiUrl}/api/CircleReport/Get`,
+      { params }
+    );
+  }
+
+  getAll(
+    filter: FilteredResultRequestDto,
+    options?: { circleId?: number | null; studentId?: number | null; teacherId?: number | null }
+  ): Observable<ApiResponse<PagedResultDto<CircleReportListDto>>> {
+    let params = new HttpParams();
+
+    if (filter.skipCount !== undefined) {
+      params = params.set('SkipCount', filter.skipCount.toString());
+    }
+    if (filter.maxResultCount !== undefined) {
+      params = params.set('MaxResultCount', filter.maxResultCount.toString());
+    }
+    if (filter.searchTerm) {
+      params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (filter.filter) {
+      params = params.set('Filter', filter.filter);
+    }
+    if (filter.lang) {
+      params = params.set('Lang', filter.lang);
+    }
+    if (filter.sortingDirection) {
+      params = params.set('SortingDirection', filter.sortingDirection);
+    }
+    if (filter.sortBy) {
+      params = params.set('SortBy', filter.sortBy);
+    }
+
+    if (options?.circleId !== undefined && options?.circleId !== null) {
+      params = params.set('circleId', options.circleId.toString());
+    }
+    if (options?.studentId !== undefined && options?.studentId !== null) {
+      params = params.set('studentId', options.studentId.toString());
+    }
+    if (options?.teacherId !== undefined && options?.teacherId !== null) {
+      params = params.set('teacherId', options.teacherId.toString());
+    }
+
+    return this.http.get<ApiResponse<PagedResultDto<CircleReportListDto>>>(
+      `${environment.apiUrl}/api/CircleReport/GetResultsByFilter`,
       { params }
     );
   }

--- a/src/app/demo/pages/admin-panel/online-courses/online-courses-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/online-courses-routing.module.ts
@@ -70,6 +70,19 @@ const routes: Routes = [
         data: {
           roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Student, UserTypesEnum.Teacher]
         }
+      },
+      {
+        path: 'report',
+        loadChildren: () => import('./report/report-routing.module').then((m) => m.ReportRoutingModule),
+        data: {
+          roles: [
+            UserTypesEnum.Admin,
+            UserTypesEnum.Manager,
+            UserTypesEnum.BranchLeader,
+            UserTypesEnum.Student,
+            UserTypesEnum.Teacher
+          ]
+        }
       }
     ]
   }

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-add/report-add.component.ts
@@ -197,7 +197,10 @@ export class ReportAddComponent implements OnInit {
       return dataMode;
     }
     const path = this.route.snapshot.routeConfig?.path ?? '';
-    return path.includes('update') ? 'update' : 'add';
+    if (path.includes('update') || path.includes('edit')) {
+      return 'update';
+    }
+    return 'add';
   }
 
   onSubmit() {

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-details/report-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-details/report-details.component.html
@@ -1,0 +1,127 @@
+<div class="row p-t-25">
+  <div class="col-12">
+    <app-card cardTitle="Circle Report Details" cardClass="sm-block">
+      <ng-template #headerOptionsTemplate>
+        <div class="header-actions" *ngIf="canEdit && report?.id">
+          <button mat-stroked-button color="primary" (click)="editReport()">
+            <div class="flex align-item-center">
+              <i class="ti ti-edit-circle f-18 m-r-5"></i>
+              Edit Report
+            </div>
+          </button>
+        </div>
+      </ng-template>
+
+      <ng-container *ngIf="!isLoading; else loadingTemplate">
+        <ng-container *ngIf="report; else emptyState">
+          <div class="details-grid">
+            <section class="details-section">
+              <h6>Overview</h6>
+              <div class="detail-item">
+                <span class="label">Circle</span>
+                <span class="value">{{ getCircleName() }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Student</span>
+                <span class="value">{{ getStudentName() }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Teacher</span>
+                <span class="value">{{ getTeacherName() }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Attendance</span>
+                <span class="value">{{ getStatusLabel(report?.attendStatueId) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Minutes</span>
+                <span class="value">{{ displayValue(report?.minutes) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Created On</span>
+                <span class="value">{{ formatDate(report?.creationTime) }}</span>
+              </div>
+            </section>
+
+            <section class="details-section">
+              <h6>New Lesson</h6>
+              <div class="detail-item">
+                <span class="label">Surah</span>
+                <span class="value">{{ displayValue(report?.newId) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">From</span>
+                <span class="value">{{ displayValue(report?.newFrom) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">To</span>
+                <span class="value">{{ displayValue(report?.newTo) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Rate</span>
+                <span class="value">{{ displayValue(report?.newRate) }}</span>
+              </div>
+            </section>
+
+            <section class="details-section">
+              <h6>Recent Reviews</h6>
+              <div class="detail-item">
+                <span class="label">Recent Past</span>
+                <span class="value">{{ displayValue(report?.recentPast) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Recent Past Rate</span>
+                <span class="value">{{ displayValue(report?.recentPastRate) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Distant Past</span>
+                <span class="value">{{ displayValue(report?.distantPast) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Distant Past Rate</span>
+                <span class="value">{{ displayValue(report?.distantPastRate) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Farthest Past</span>
+                <span class="value">{{ displayValue(report?.farthestPast) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Farthest Past Rate</span>
+                <span class="value">{{ displayValue(report?.farthestPastRate) }}</span>
+              </div>
+            </section>
+
+            <section class="details-section">
+              <h6>Additional Notes</h6>
+              <div class="detail-item">
+                <span class="label">The Words of the Quran Stranger</span>
+                <span class="value">{{ displayValue(report?.theWordsQuranStranger) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Intonation</span>
+                <span class="value">{{ displayValue(report?.intonation) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">Other Notes</span>
+                <span class="value">{{ displayValue(report?.other) }}</span>
+              </div>
+            </section>
+          </div>
+        </ng-container>
+      </ng-container>
+
+      <ng-template #loadingTemplate>
+        <div class="loading-container">
+          <mat-progress-spinner diameter="48" mode="indeterminate"></mat-progress-spinner>
+        </div>
+      </ng-template>
+
+      <ng-template #emptyState>
+        <div class="empty-state">
+          <i class="ti ti-notebook f-32 m-b-10"></i>
+          <p>No report details available.</p>
+        </div>
+      </ng-template>
+    </app-card>
+  </div>
+</div>

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-details/report-details.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-details/report-details.component.scss
@@ -1,0 +1,67 @@
+.details-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 992px) {
+  .details-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.details-section {
+  background-color: #f8f9fb;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.02);
+}
+
+.details-section h6 {
+  margin-bottom: 16px;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 13px;
+  letter-spacing: 0.5px;
+}
+
+.detail-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.detail-item:last-of-type {
+  border-bottom: none;
+}
+
+.detail-item .label {
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.detail-item .value {
+  text-align: right;
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.loading-container,
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 0;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.empty-state i {
+  color: rgba(0, 0, 0, 0.38);
+}

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-details/report-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-details/report-details.component.ts
@@ -1,0 +1,163 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, ActivatedRoute, Router } from '@angular/router';
+
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import {
+  CircleReportAddDto,
+  CircleReportListDto,
+  CircleReportService
+} from 'src/app/@theme/services/circle-report.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+import { AttendStatusEnum } from 'src/app/@theme/types/AttendStatusEnum';
+import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+
+type ReportDetails = Omit<CircleReportAddDto, 'creationTime'> &
+  Partial<CircleReportListDto> & {
+    creationTime?: Date | string | null;
+  };
+
+@Component({
+  selector: 'app-report-details',
+  imports: [CommonModule, SharedModule, RouterModule],
+  templateUrl: './report-details.component.html',
+  styleUrl: './report-details.component.scss'
+})
+export class ReportDetailsComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private service = inject(CircleReportService);
+  private toast = inject(ToastService);
+  private auth = inject(AuthenticationService);
+
+  report?: ReportDetails;
+  isLoading = true;
+
+  readonly role = this.auth.getRole();
+  readonly canEdit = this.role !== UserTypesEnum.Student;
+
+  ngOnInit(): void {
+    const stateReport = history.state.report as ReportDetails | undefined;
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+
+    if (!Number.isFinite(id) || !id) {
+      this.toast.error('Invalid report identifier');
+      this.isLoading = false;
+      return;
+    }
+
+    if (stateReport?.id === id) {
+      this.report = stateReport;
+    }
+
+    this.loadReport(id, stateReport);
+  }
+
+  private loadReport(id: number, stateReport?: ReportDetails): void {
+    this.isLoading = true;
+    this.service.get(id).subscribe({
+      next: (res) => {
+        if (res.isSuccess && res.data) {
+          const merged: ReportDetails = {
+            ...stateReport,
+            ...res.data,
+            id
+          };
+          this.report = merged;
+        } else if (stateReport) {
+          this.report = stateReport;
+        } else {
+          this.toast.error('Unable to load report details');
+        }
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+        if (stateReport) {
+          this.report = stateReport;
+        } else {
+          this.toast.error('Error loading report details');
+        }
+      }
+    });
+  }
+
+  getStatusLabel(status?: number | null): string {
+    switch (status) {
+      case AttendStatusEnum.Attended:
+        return 'Attended';
+      case AttendStatusEnum.ExcusedAbsence:
+        return 'Excused absence';
+      case AttendStatusEnum.UnexcusedAbsence:
+        return 'Unexcused absence';
+      default:
+        return '—';
+    }
+  }
+
+  formatDate(value?: string | Date | null): string {
+    if (!value) {
+      return '—';
+    }
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+    return date.toLocaleString();
+  }
+
+  displayValue(value: unknown): string {
+    if (value === null || value === undefined || value === '') {
+      return '—';
+    }
+    return String(value);
+  }
+
+  getStudentName(): string {
+    const report = this.report;
+    if (!report) {
+      return '—';
+    }
+    return (
+      (report.studentName as string | undefined) ||
+      (report['student'] as string | undefined) ||
+      (report['studentFullName'] as string | undefined) ||
+      (typeof report.studentId === 'number' ? `Student #${report.studentId}` : '—')
+    );
+  }
+
+  getCircleName(): string {
+    const report = this.report;
+    if (!report) {
+      return '—';
+    }
+    return (
+      (report.circleName as string | undefined) ||
+      (report['circle'] as string | undefined) ||
+      (report['circleTitle'] as string | undefined) ||
+      (typeof report.circleId === 'number' ? `Circle #${report.circleId}` : '—')
+    );
+  }
+
+  getTeacherName(): string {
+    const report = this.report;
+    if (!report) {
+      return '—';
+    }
+    return (
+      (report.teacherName as string | undefined) ||
+      (report['teacher'] as string | undefined) ||
+      (typeof report.teacherId === 'number' ? `Teacher #${report.teacherId}` : '—')
+    );
+  }
+
+  editReport(): void {
+    if (!this.report?.id) {
+      return;
+    }
+    this.router.navigate(['/online-course/report/edit', this.report.id], {
+      state: { report: this.report }
+    });
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-list/report-list.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-list/report-list.component.html
@@ -1,0 +1,139 @@
+<div class="row p-t-25">
+  <div class="col-12">
+    <app-card cardTitle="Circle Reports" padding="0" cardClass="sm-block">
+      <ng-template #headerOptionsTemplate>
+        <div class="table-options" *ngIf="canManageReports">
+          <button mat-flat-button color="primary" [routerLink]="['/online-course/report/add']">
+            <div class="flex align-item-center">
+              <i class="ti ti-plus f-18 m-r-5"></i>
+              Add Report
+            </div>
+          </button>
+        </div>
+      </ng-template>
+      <div class="p-b-15">
+        <div class="table-containe table-reponsive">
+          <form [formGroup]="filterForm" class="filter-form" (ngSubmit)="onSearch()">
+            <div class="row g-3 p-15">
+              <div class="col-12 col-md-4">
+                <mat-form-field appearance="outline" class="w-100">
+                  <mat-label>Search</mat-label>
+                  <input
+                    matInput
+                    placeholder="Search reports"
+                    formControlName="searchTerm"
+                    (keyup.enter)="onSearch()"
+                  />
+                  <button
+                    mat-icon-button
+                    matSuffix
+                    type="button"
+                    (click)="clearSearch()"
+                    *ngIf="filterForm.value.searchTerm"
+                    aria-label="Clear search"
+                  >
+                    <mat-icon>close</mat-icon>
+                  </button>
+                </mat-form-field>
+              </div>
+              <div class="col-12 col-md-4">
+                <mat-form-field appearance="outline" class="w-100">
+                  <mat-label>Circle</mat-label>
+                  <mat-select formControlName="circleId" [disabled]="isLoadingStudents">
+                    <mat-option [value]="null">All circles</mat-option>
+                    <mat-option *ngFor="let circle of circles" [value]="circle.id">
+                      {{ circle.name }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+              <div class="col-12 col-md-4">
+                <mat-form-field appearance="outline" class="w-100">
+                  <mat-label>Student</mat-label>
+                  <mat-select formControlName="studentId" [disabled]="isLoadingStudents">
+                    <mat-option [value]="null">All students</mat-option>
+                    <mat-option *ngFor="let student of students" [value]="student.id">
+                      {{ student.name }}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+            </div>
+          </form>
+          <mat-progress-bar *ngIf="isLoading" mode="indeterminate"></mat-progress-bar>
+          <div class="table-responsive">
+            <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+              <ng-container matColumnDef="student">
+                <th mat-header-cell *matHeaderCellDef class="p-l-25">STUDENT</th>
+                <td mat-cell *matCellDef="let element" class="p-l-25 text-nowrap">
+                  {{ getStudentDisplay(element) }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="circle">
+                <th mat-header-cell *matHeaderCellDef>CIRCLE</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  {{ getCircleDisplay(element) }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="status">
+                <th mat-header-cell *matHeaderCellDef>STATUS</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  {{ getStatusLabel(element.attendStatueId) }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="creationTime">
+                <th mat-header-cell *matHeaderCellDef>DATE</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  {{ formatDate(element.creationTime) }}
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="actions">
+                <th mat-header-cell *matHeaderCellDef class="text-center">ACTIONS</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  <div class="text-center text-nowrap">
+                    <ul class="list-inline p-l-0">
+                      <li class="list-inline-item m-r-10" matTooltip="View">
+                        <a
+                          [routerLink]="['/online-course/report/details', element.id]"
+                          [state]="{ report: element }"
+                          class="avatar avatar-xs text-muted"
+                        >
+                          <i class="ti ti-eye f-18"></i>
+                        </a>
+                      </li>
+                      <li class="list-inline-item m-r-10" matTooltip="Edit" *ngIf="canManageReports">
+                        <a
+                          [routerLink]="['/online-course/report/edit', element.id]"
+                          [state]="{ report: element }"
+                          class="avatar avatar-xs text-muted"
+                        >
+                          <i class="ti ti-edit-circle f-18"></i>
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+              <tr class="mat-row" *matNoDataRow>
+                <td class="mat-cell" colspan="5">No reports found</td>
+              </tr>
+            </table>
+            <mat-paginator
+              [length]="totalCount"
+              [pageSize]="filter.maxResultCount || 10"
+              [pageSizeOptions]="[5, 10, 25, 100]"
+              aria-label="Select page of reports"
+            ></mat-paginator>
+          </div>
+        </div>
+      </div>
+    </app-card>
+  </div>
+</div>

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-list/report-list.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-list/report-list.component.scss
@@ -1,0 +1,15 @@
+.filter-form {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.filter-form .mat-form-field {
+  margin: 0;
+}
+
+.table-responsive {
+  position: relative;
+}
+
+.mat-progress-bar {
+  margin: 0 15px;
+}

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-list/report-list.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-list/report-list.component.ts
@@ -1,0 +1,310 @@
+import { AfterViewInit, Component, OnDestroy, OnInit, inject, viewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { FormBuilder, FormGroup } from '@angular/forms';
+
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import {
+  CircleReportListDto,
+  CircleReportService
+} from 'src/app/@theme/services/circle-report.service';
+import { CircleDto, CircleService, CircleStudentDto } from 'src/app/@theme/services/circle.service';
+import {
+  FilteredResultRequestDto,
+  LookupService,
+  LookUpUserDto
+} from 'src/app/@theme/services/lookup.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+import { AttendStatusEnum } from 'src/app/@theme/types/AttendStatusEnum';
+
+import { Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+
+interface StudentOption {
+  id: number;
+  name: string;
+}
+
+@Component({
+  selector: 'app-report-list',
+  imports: [CommonModule, SharedModule, RouterModule],
+  templateUrl: './report-list.component.html',
+  styleUrl: './report-list.component.scss'
+})
+export class ReportListComponent implements OnInit, AfterViewInit, OnDestroy {
+  private reportService = inject(CircleReportService);
+  private circleService = inject(CircleService);
+  private lookupService = inject(LookupService);
+  private fb = inject(FormBuilder);
+  private toast = inject(ToastService);
+  private auth = inject(AuthenticationService);
+
+  readonly paginator = viewChild.required(MatPaginator);
+
+  filterForm: FormGroup = this.fb.group({
+    searchTerm: [''],
+    circleId: [null],
+    studentId: [null]
+  });
+
+  displayedColumns: string[] = ['student', 'circle', 'status', 'creationTime', 'actions'];
+  dataSource = new MatTableDataSource<CircleReportListDto>();
+  totalCount = 0;
+  filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 10 };
+
+  circles: CircleDto[] = [];
+  students: StudentOption[] = [];
+  private allStudents: StudentOption[] = [];
+
+  isLoading = false;
+  isLoadingStudents = false;
+
+  private destroy$ = new Subject<void>();
+
+  private selectedCircleId?: number;
+  private selectedStudentId?: number;
+  private readonly teacherId?: number;
+
+  role = this.auth.getRole();
+  canManageReports = this.role !== UserTypesEnum.Student;
+
+  constructor() {
+    const currentUser = this.auth.currentUserValue;
+    if (this.role === UserTypesEnum.Teacher && currentUser?.user?.id) {
+      const parsed = Number(currentUser.user.id);
+      this.teacherId = Number.isNaN(parsed) ? undefined : parsed;
+    }
+  }
+
+  ngOnInit(): void {
+    this.loadCircles();
+    this.loadAllStudents();
+    this.loadReports();
+
+    this.filterForm
+      .get('searchTerm')
+      ?.valueChanges.pipe(debounceTime(300), distinctUntilChanged(), takeUntil(this.destroy$))
+      .subscribe(() => this.onSearch());
+
+    this.filterForm
+      .get('circleId')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((circleId) => this.onCircleChange(circleId));
+
+    this.filterForm
+      .get('studentId')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.applyFilters());
+  }
+
+  ngAfterViewInit(): void {
+    this.paginator().page.subscribe(() => {
+      this.filter.skipCount = this.paginator().pageIndex * this.paginator().pageSize;
+      this.filter.maxResultCount = this.paginator().pageSize;
+      this.loadReports();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private loadCircles(): void {
+    this.circleService
+      .getAll({ skipCount: 0, maxResultCount: 100 })
+      .subscribe((res) => {
+        if (res.isSuccess && res.data?.items) {
+          this.circles = res.data.items;
+        } else {
+          this.circles = [];
+        }
+      });
+  }
+
+  private loadAllStudents(searchTerm?: string): void {
+    this.isLoadingStudents = true;
+    this.lookupService
+      .getUsersForSelects(
+        { skipCount: 0, maxResultCount: 100, searchTerm: searchTerm?.trim() || undefined },
+        Number(UserTypesEnum.Student)
+      )
+      .subscribe({
+        next: (res) => {
+          if (res.isSuccess && res.data?.items) {
+            const mapped = res.data.items.map((s) => this.mapLookupToStudentOption(s));
+            this.allStudents = mapped;
+            if (!this.selectedCircleId) {
+              this.students = [...mapped];
+            }
+          } else {
+            this.allStudents = [];
+            if (!this.selectedCircleId) {
+              this.students = [];
+            }
+          }
+          this.isLoadingStudents = false;
+        },
+        error: () => {
+          this.allStudents = [];
+          if (!this.selectedCircleId) {
+            this.students = [];
+          }
+          this.isLoadingStudents = false;
+        }
+      });
+  }
+
+  private mapLookupToStudentOption(user: LookUpUserDto): StudentOption {
+    const name = user.fullName || user.email || `Student #${user.id}`;
+    return {
+      id: user.id,
+      name
+    };
+  }
+
+  private onCircleChange(circleId: number | null): void {
+    this.selectedCircleId = circleId ?? undefined;
+    this.filterForm.patchValue({ studentId: null }, { emitEvent: false });
+
+    if (circleId) {
+      this.isLoadingStudents = true;
+      this.circleService.get(circleId).subscribe({
+        next: (res) => {
+          if (res.isSuccess && res.data?.students) {
+            const mapped = res.data.students
+              .map((s) => this.mapCircleStudentToOption(s))
+              .filter((s): s is StudentOption => !!s);
+            const unique = new Map(mapped.map((s) => [s.id, s]));
+            this.students = Array.from(unique.values());
+          } else {
+            this.students = [];
+          }
+          this.isLoadingStudents = false;
+          this.applyFilters();
+        },
+        error: () => {
+          this.students = [];
+          this.isLoadingStudents = false;
+          this.applyFilters();
+        }
+      });
+    } else {
+      this.students = [...this.allStudents];
+      this.applyFilters();
+    }
+  }
+
+  private mapCircleStudentToOption(student: CircleStudentDto): StudentOption | undefined {
+    const studentData = student.student as LookUpUserDto | undefined;
+    const id = studentData?.id ?? student.studentId ?? student.id;
+    if (id === undefined || id === null) {
+      return undefined;
+    }
+    const name =
+      studentData?.fullName ||
+      student.fullName ||
+      (typeof id === 'number' ? `Student #${id}` : `Student #${Number(id)}`);
+    return {
+      id: Number(id),
+      name
+    };
+  }
+
+  private applyFilters(): void {
+    const { circleId, studentId } = this.filterForm.value;
+    this.selectedCircleId = circleId ?? undefined;
+    this.selectedStudentId = studentId ?? undefined;
+    this.filter.skipCount = 0;
+    this.paginator()?.firstPage();
+    this.loadReports();
+  }
+
+  onSearch(): void {
+    const term = (this.filterForm.value.searchTerm || '').toString().trim();
+    this.filter.searchTerm = term.length ? term : undefined;
+    this.filter.skipCount = 0;
+    this.paginator()?.firstPage();
+    this.loadReports();
+  }
+
+  clearSearch(): void {
+    this.filterForm.patchValue({ searchTerm: '' }, { emitEvent: false });
+    this.onSearch();
+  }
+
+  private loadReports(): void {
+    this.isLoading = true;
+    this.reportService
+      .getAll(this.filter, {
+        circleId: this.selectedCircleId,
+        studentId: this.selectedStudentId,
+        teacherId: this.teacherId
+      })
+      .subscribe({
+        next: (res) => {
+          if (res.isSuccess && res.data?.items) {
+            this.dataSource.data = res.data.items;
+            this.totalCount = res.data.totalCount;
+          } else {
+            this.dataSource.data = [];
+            this.totalCount = 0;
+          }
+          this.isLoading = false;
+        },
+        error: () => {
+          this.dataSource.data = [];
+          this.totalCount = 0;
+          this.isLoading = false;
+          this.toast.error('Error loading reports');
+        }
+      });
+  }
+
+  getStudentDisplay(report: CircleReportListDto): string {
+    return (
+      (report.studentName as string | undefined) ||
+      (report['student'] as string | undefined) ||
+      (report['studentFullName'] as string | undefined) ||
+      (typeof report.studentId === 'number' ? `Student #${report.studentId}` : '')
+    );
+  }
+
+  getCircleDisplay(report: CircleReportListDto): string {
+    return (
+      (report.circleName as string | undefined) ||
+      (report['circle'] as string | undefined) ||
+      (report['circleTitle'] as string | undefined) ||
+      (typeof report.circleId === 'number' ? `Circle #${report.circleId}` : '')
+    );
+  }
+
+  getStatusLabel(status?: number | null): string {
+    switch (status) {
+      case AttendStatusEnum.Attended:
+        return 'Attended';
+      case AttendStatusEnum.ExcusedAbsence:
+        return 'Excused absence';
+      case AttendStatusEnum.UnexcusedAbsence:
+        return 'Unexcused absence';
+      default:
+        return '—';
+    }
+  }
+
+  formatDate(value?: string | Date | null): string {
+    if (!value) {
+      return '—';
+    }
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+    return date.toLocaleString();
+  }
+}

--- a/src/app/demo/pages/admin-panel/online-courses/report/report-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report-routing.module.ts
@@ -1,0 +1,65 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+
+const routes: Routes = [
+  {
+    path: '',
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        redirectTo: 'list'
+      },
+      {
+        path: 'list',
+        loadComponent: () => import('./report-list/report-list.component').then((c) => c.ReportListComponent),
+        data: {
+          roles: [
+            UserTypesEnum.Admin,
+            UserTypesEnum.Manager,
+            UserTypesEnum.BranchLeader,
+            UserTypesEnum.Student,
+            UserTypesEnum.Teacher
+          ]
+        }
+      },
+      {
+        path: 'details/:id',
+        loadComponent: () => import('./report-details/report-details.component').then((c) => c.ReportDetailsComponent),
+        data: {
+          roles: [
+            UserTypesEnum.Admin,
+            UserTypesEnum.Manager,
+            UserTypesEnum.BranchLeader,
+            UserTypesEnum.Student,
+            UserTypesEnum.Teacher
+          ]
+        }
+      },
+      {
+        path: 'add',
+        loadComponent: () => import('./report-add/report-add.component').then((c) => c.ReportAddComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Teacher],
+          mode: 'add'
+        }
+      },
+      {
+        path: 'edit/:id',
+        loadComponent: () => import('./report-add/report-add.component').then((c) => c.ReportAddComponent),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.BranchLeader, UserTypesEnum.Teacher],
+          mode: 'update'
+        }
+      }
+    ]
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ReportRoutingModule {}

--- a/src/app/demo/pages/admin-panel/online-courses/report/report.module.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/report/report.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ReportRoutingModule } from './report-routing.module';
+
+@NgModule({
+  imports: [CommonModule, ReportRoutingModule]
+})
+export class ReportModule {}


### PR DESCRIPTION
## Summary
- expose a list API on the circle report service for filtered report retrieval
- create a circle report list view with search, circle/student filters, and action links
- add a detailed report page and routing updates so reports can be viewed and edited
- resolve the circle report detail creation time type conflict to unblock builds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9466db53c832292299f1f422548dc