### PR TITLE
Add SearchWord support to filtered service requests

### DIFF
--- a/src/app/@theme/services/circle-report.service.ts
+++ b/src/app/@theme/services/circle-report.service.ts
@@ -79,8 +79,13 @@ export class CircleReportService {
     if (filter.maxResultCount !== undefined) {
       params = params.set('MaxResultCount', filter.maxResultCount.toString());
     }
+    const searchWord = filter.searchWord ?? filter.searchTerm;
+
     if (filter.searchTerm) {
       params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (searchWord) {
+      params = params.set('SearchWord', searchWord);
     }
     if (filter.filter) {
       params = params.set('Filter', filter.filter);

--- a/src/app/@theme/services/circle.service.ts
+++ b/src/app/@theme/services/circle.service.ts
@@ -92,8 +92,13 @@ export class CircleService {
     if (filter.maxResultCount !== undefined) {
       params = params.set('MaxResultCount', filter.maxResultCount.toString());
     }
+    const searchWord = filter.searchWord ?? filter.searchTerm;
+
     if (filter.searchTerm) {
       params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (searchWord) {
+      params = params.set('SearchWord', searchWord);
     }
     if (filter.filter) {
       params = params.set('Filter', filter.filter);

--- a/src/app/@theme/services/lookup.service.ts
+++ b/src/app/@theme/services/lookup.service.ts
@@ -39,6 +39,7 @@ export interface ApiResponse<T> {
 export interface FilteredResultRequestDto {
   skipCount?: number;
   searchTerm?: string;
+  searchWord?: string;
   filter?: string;
   lang?: string;
   sortingDirection?: string;
@@ -92,8 +93,13 @@ export class LookupService {
     if (filter.maxResultCount !== undefined) {
       params = params.set('MaxResultCount', filter.maxResultCount.toString());
     }
+    const searchWord = filter.searchWord ?? filter.searchTerm;
+
     if (filter.searchTerm) {
       params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (searchWord) {
+      params = params.set('SearchWord', searchWord);
     }
     if (filter.filter) {
       params = params.set('Filter', filter.filter);

--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -138,8 +138,13 @@ export class StudentPaymentService {
     if (filter.maxResultCount !== undefined) {
       params = params.set('MaxResultCount', filter.maxResultCount.toString());
     }
+    const searchWord = filter.searchWord ?? filter.searchTerm;
+
     if (filter.searchTerm) {
       params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (searchWord) {
+      params = params.set('SearchWord', searchWord);
     }
     if (tab) {
       params = params.set('tab', tab);

--- a/src/app/@theme/services/student-subscribe.service.ts
+++ b/src/app/@theme/services/student-subscribe.service.ts
@@ -37,8 +37,13 @@ export class StudentSubscribeService {
     if (filter.maxResultCount !== undefined) {
       params = params.set('MaxResultCount', filter.maxResultCount.toString());
     }
+    const searchWord = filter.searchWord ?? filter.searchTerm;
+
     if (filter.searchTerm) {
       params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (searchWord) {
+      params = params.set('SearchWord', searchWord);
     }
     if (filter.filter) {
       params = params.set('Filter', filter.filter);
@@ -72,8 +77,13 @@ export class StudentSubscribeService {
     if (filter.maxResultCount !== undefined) {
       params = params.set('MaxResultCount', filter.maxResultCount.toString());
     }
+    const searchWord = filter.searchWord ?? filter.searchTerm;
+
     if (filter.searchTerm) {
       params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (searchWord) {
+      params = params.set('SearchWord', searchWord);
     }
     if (filter.filter) {
       params = params.set('Filter', filter.filter);

--- a/src/app/@theme/services/subscribe.service.ts
+++ b/src/app/@theme/services/subscribe.service.ts
@@ -86,8 +86,13 @@ export class SubscribeService {
     if (filter.maxResultCount !== undefined) {
       params = params.set('MaxResultCount', filter.maxResultCount.toString());
     }
+    const searchWord = filter.searchWord ?? filter.searchTerm;
+
     if (filter.searchTerm) {
       params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (searchWord) {
+      params = params.set('SearchWord', searchWord);
     }
     if (filter.filter) {
       params = params.set('Filter', filter.filter);
@@ -140,8 +145,13 @@ export class SubscribeService {
     if (filter.maxResultCount !== undefined) {
       params = params.set('MaxResultCount', filter.maxResultCount.toString());
     }
+    const searchWord = filter.searchWord ?? filter.searchTerm;
+
     if (filter.searchTerm) {
       params = params.set('SearchTerm', filter.searchTerm);
+    }
+    if (searchWord) {
+      params = params.set('SearchWord', searchWord);
     }
     if (filter.filter) {
       params = params.set('Filter', filter.filter);


### PR DESCRIPTION
## Summary
- extend FilteredResultRequestDto with an optional searchWord field
- send the new SearchWord query parameter alongside existing SearchTerm filtering across list services
- ensure circle report filtering continues to work with the updated backend GetResultsByFilter shape

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c95e7dd87483228c203292464ac79e