### PR TITLE
feat: persist layout preferences per user

### DIFF
--- a/src/app/@theme/services/user-preference.service.ts
+++ b/src/app/@theme/services/user-preference.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, inject } from '@angular/core';
+
+import { AbleProConfig } from 'src/app/app-config';
+import { AuthenticationService } from './authentication.service';
+
+export interface UserPreferences {
+  layout: string; // vertical, horizontal, compact
+  themeMode: string; // light, dark
+  themeColor: string; // theme class name
+  contrast: boolean;
+  caption: boolean;
+  rtlLayout: boolean;
+  boxLayout: boolean;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserPreferenceService {
+  private authService = inject(AuthenticationService);
+  private readonly storagePrefix = 'user-preferences';
+  private readonly defaultPreferences: UserPreferences = {
+    layout: AbleProConfig.layout,
+    themeMode: AbleProConfig.isDarkMode,
+    themeColor: AbleProConfig.theme_color,
+    contrast: AbleProConfig.theme_contrast,
+    caption: AbleProConfig.menu_caption,
+    rtlLayout: AbleProConfig.isRtlLayout,
+    boxLayout: AbleProConfig.isBox_container
+  };
+
+  getDefaultPreferences(): UserPreferences {
+    return { ...this.defaultPreferences };
+  }
+
+  loadPreferences(): UserPreferences {
+    const preferences = this.readStoredPreferences();
+    this.applyToConfig(preferences);
+    return preferences;
+  }
+
+  updatePreferences(partial: Partial<UserPreferences>): UserPreferences {
+    const updated = { ...this.readStoredPreferences(), ...partial } as UserPreferences;
+    this.writeStoredPreferences(updated);
+    this.applyToConfig(updated);
+    return updated;
+  }
+
+  clearPreferences(): UserPreferences {
+    const defaults = this.getDefaultPreferences();
+    this.removeStoredPreferences();
+    this.applyToConfig(defaults);
+    return defaults;
+  }
+
+  private getStorageKey(): string | null {
+    const currentUser = this.authService.currentUserValue;
+    const identifier = currentUser?.user?.id?.trim() || currentUser?.user?.email?.trim();
+    if (identifier) {
+      return `${this.storagePrefix}:${identifier}`;
+    }
+    return `${this.storagePrefix}:guest`;
+  }
+
+  private readStoredPreferences(): UserPreferences {
+    const defaults = this.getDefaultPreferences();
+    if (typeof localStorage === 'undefined') {
+      return defaults;
+    }
+
+    const key = this.getStorageKey();
+    if (!key) {
+      return defaults;
+    }
+
+    try {
+      const stored = localStorage.getItem(key);
+      if (!stored) {
+        return defaults;
+      }
+      const parsed = JSON.parse(stored) as Partial<UserPreferences>;
+      return { ...defaults, ...parsed } as UserPreferences;
+    } catch (error) {
+      console.warn('Failed to parse stored preferences', error);
+      localStorage.removeItem(key);
+      return defaults;
+    }
+  }
+
+  private writeStoredPreferences(preferences: UserPreferences): void {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    const key = this.getStorageKey();
+    if (!key) {
+      return;
+    }
+    try {
+      localStorage.setItem(key, JSON.stringify(preferences));
+    } catch (error) {
+      console.warn('Failed to store user preferences', error);
+    }
+  }
+
+  private removeStoredPreferences(): void {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    const key = this.getStorageKey();
+    if (!key) {
+      return;
+    }
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.warn('Failed to clear stored preferences', error);
+    }
+  }
+
+  private applyToConfig(preferences: UserPreferences): void {
+    AbleProConfig.layout = preferences.layout;
+    AbleProConfig.isDarkMode = preferences.themeMode;
+    AbleProConfig.theme_color = preferences.themeColor;
+    AbleProConfig.theme_contrast = preferences.contrast;
+    AbleProConfig.menu_caption = preferences.caption;
+    AbleProConfig.isRtlLayout = preferences.rtlLayout;
+    AbleProConfig.isBox_container = preferences.boxLayout;
+  }
+}

--- a/src/app/demo/layout/admin/admin.component.ts
+++ b/src/app/demo/layout/admin/admin.component.ts
@@ -21,6 +21,7 @@ import { FooterComponent } from 'src/app/@theme/layouts/footer/footer.component'
 // service
 import { BuyNowLinkService } from 'src/app/@theme/services/buy-now-link.service';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
+import { UserPreferenceService } from 'src/app/@theme/services/user-preference.service';
 
 // const import
 import { MIN_WIDTH_1025PX, MAX_WIDTH_1024PX, VERTICAL, HORIZONTAL, COMPACT, RTL, LTR } from 'src/app/@theme/const';
@@ -54,6 +55,7 @@ export class AdminComponent implements OnInit, AfterViewInit {
   private themeService = inject(ThemeLayoutService);
   buyNowLinkService = inject(BuyNowLinkService);
   authenticationService = inject(AuthenticationService);
+  private userPreferenceService = inject(UserPreferenceService);
 
   // public props
   readonly sidebar = viewChild<MatDrawer>('sidebar');
@@ -77,6 +79,7 @@ export class AdminComponent implements OnInit, AfterViewInit {
 
   // life cycle event
   ngOnInit() {
+    this.userPreferenceService.loadPreferences();
     this.breakpointObserver.observe([MIN_WIDTH_1025PX, MAX_WIDTH_1024PX]).subscribe((result) => {
       if (result.breakpoints[MAX_WIDTH_1024PX]) {
         this.modeValue = 'over';


### PR DESCRIPTION
## Summary
- add a user preference service that reads and writes layout settings per user in local storage
- update the configuration panel to load stored preferences on init and persist changes
- ensure the admin layout applies saved preferences during its initialization

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca72bb5e1883229d01f9b623ece9d5