### PR TITLE
fix: move dashboard summary metrics to widget charts

### DIFF
--- a/src/app/@theme/services/dashboard.service.ts
+++ b/src/app/@theme/services/dashboard.service.ts
@@ -1,0 +1,98 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { ApiResponse } from './lookup.service';
+
+export type DashboardValueType = string | undefined;
+
+export interface DashboardMetricDto {
+  key: string;
+  name?: string;
+  value?: number;
+  previousValue?: number;
+  percentChange?: number;
+  cumulativeTotal?: number;
+  valueType?: DashboardValueType;
+  currencyCode?: string;
+  trend?: number[];
+}
+
+export interface DashboardSummaryDto {
+  month?: string;
+  metrics?: DashboardMetricDto[] | Record<string, DashboardMetricDto>;
+}
+
+export interface ChartSeriesDto {
+  name: string;
+  data: number[];
+  type?: string;
+}
+
+export interface ChartDto {
+  categories: string[];
+  series: ChartSeriesDto[];
+}
+
+export interface RepeatCustomersDto {
+  currentRate?: number;
+  previousRate?: number;
+  percentChange?: number;
+  chart: ChartDto;
+}
+
+export interface MonthlyRevenueTotalsDto {
+  revenue?: number;
+  payouts?: number;
+  netIncome?: number;
+  currencyCode?: string;
+}
+
+export interface MonthlyRevenueDto {
+  chart: ChartDto;
+  totals?: MonthlyRevenueTotalsDto;
+}
+
+export interface RevenueByCurrencySliceDto {
+  label: string;
+  value: number;
+  percentage: number;
+  currencyCode?: string;
+}
+
+export interface RevenueByCurrencyDto {
+  slices: RevenueByCurrencySliceDto[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class DashboardService {
+  private http = inject(HttpClient);
+
+  getSummary(): Observable<ApiResponse<DashboardSummaryDto>> {
+    return this.http.get<ApiResponse<DashboardSummaryDto>>(`${environment.apiUrl}/api/dashboard/summary`);
+  }
+
+  getRepeatCustomers(months: number): Observable<ApiResponse<RepeatCustomersDto>> {
+    const params = new HttpParams().set('months', months.toString());
+    return this.http.get<ApiResponse<RepeatCustomersDto>>(
+      `${environment.apiUrl}/api/dashboard/repeat-customers`,
+      { params }
+    );
+  }
+
+  getMonthlyRevenue(months: number): Observable<ApiResponse<MonthlyRevenueDto>> {
+    const params = new HttpParams().set('months', months.toString());
+    return this.http.get<ApiResponse<MonthlyRevenueDto>>(
+      `${environment.apiUrl}/api/dashboard/monthly-revenue`,
+      { params }
+    );
+  }
+
+  getRevenueByCurrency(startDate: string, endDate: string): Observable<ApiResponse<RevenueByCurrencyDto>> {
+    const params = new HttpParams().set('startDate', startDate).set('endDate', endDate);
+    return this.http.get<ApiResponse<RevenueByCurrencyDto>>(
+      `${environment.apiUrl}/api/dashboard/revenue-by-currency`,
+      { params }
+    );
+  }
+}

--- a/src/app/demo/pages/apex-chart/earning-chart/earning-chart.component.html
+++ b/src/app/demo/pages/apex-chart/earning-chart/earning-chart.component.html
@@ -34,8 +34,8 @@
       </div>
       <div class="col-5 text-end">
         <div class="m-b-5 f-w-600">{{ earningValue() }}</div>
-         <div class="{{ textColor() }} mat-caption f-w-500">
-          <i class="ti ti-arrow-up-right"></i>
+        <div class="{{ trendColor() ?? textColor() }} mat-caption f-w-500">
+          <i [class]="trendIcon() ?? 'ti ti-arrow-up-right'"></i>
           {{ percentageValue() }}
         </div>
       </div>

--- a/src/app/demo/pages/apex-chart/project-overview-chart/project-overview-chart.component.html
+++ b/src/app/demo/pages/apex-chart/project-overview-chart/project-overview-chart.component.html
@@ -1,6 +1,6 @@
 <app-card [showHeader]="false" [padding]="20">
   <div class="flex align-item-center justify-content-between">
-    <div class="customer-report f-16 f-w-600">Project overview</div>
+    <div class="customer-report f-16 f-w-600">Repeat customer rate</div>
     <a [matMenuTriggerFor]="menu" class="avatar avatar-s hover"><i class="ti ti-dots f-18"></i></a>
     <mat-menu #menu="matMenu">
       <a mat-menu-item>Today</a>
@@ -8,50 +8,26 @@
       <a mat-menu-item>Monthly</a>
     </mat-menu>
   </div>
-  <div class="row align-item-center justify-content-center">
-    <div class="col-md-6 col-xl-4">
-      <div class="m-t-15 row align-item-center">
-        <div class="col-6">
-          <p class="text-muted m-b-5 f-16">Total Tasks</p>
-          <div class="f-16 f-w-600">34,686</div>
-        </div>
-        <div class="col-6" id="chart">
-          <apx-chart
-            [series]="chartOptions.series"
-            [chart]="chartOptions.chart"
-            [colors]="chartOptions.colors"
-            [stroke]="chartOptions.stroke"
-            [fill]="chartOptions.fill"
-            [tooltip]="chartOptions.tooltip"
-          ></apx-chart>
-        </div>
-      </div>
+  <div class="text-end m-t-10">
+    <div class="f-16 f-w-600">
+      {{ currentRateText }}
+      <span [class]="changeBadgeClass">{{ changeText }}</span>
     </div>
-    <div class="col-md-6 col-xl-4">
-      <div class="m-t-15 row align-item-center">
-        <div class="col-6">
-          <p class="text-muted m-b-5 f-16">Pending Tasks</p>
-          <div class="f-16 f-w-600">3,786</div>
-        </div>
-        <div class="col-6" id="chart-1">
-          <apx-chart
-            [series]="chartOptions_1.series"
-            [chart]="chartOptions_1.chart"
-            [colors]="chartOptions_1.colors"
-            [stroke]="chartOptions_1.stroke"
-            [fill]="chartOptions_1.fill"
-            [tooltip]="chartOptions_1.tooltip"
-          ></apx-chart>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-6 col-xl-4">
-      <div class="m-t-15 grid">
-        <button mat-flat-button class="b-rad-20" color="primary">
-          <i class="ti ti-plus"></i>
-          Add project
-        </button>
-      </div>
-    </div>
+    <p class="text-muted mat-caption m-b-0">Previous month: {{ previousRateText }}</p>
+  </div>
+  <div id="repeat-customer-chart" class="m-t-20">
+    <apx-chart
+      [series]="chartOptions.series"
+      [chart]="chartOptions.chart"
+      [colors]="chartOptions.colors"
+      [stroke]="chartOptions.stroke"
+      [dataLabels]="chartOptions.dataLabels"
+      [fill]="chartOptions.fill"
+      [grid]="chartOptions.grid"
+      [xaxis]="chartOptions.xaxis"
+      [yaxis]="chartOptions.yaxis"
+      [tooltip]="chartOptions.tooltip"
+      [theme]="chartOptions.theme"
+    ></apx-chart>
   </div>
 </app-card>

--- a/src/app/demo/pages/apex-chart/project-overview-chart/project-overview-chart.component.ts
+++ b/src/app/demo/pages/apex-chart/project-overview-chart/project-overview-chart.component.ts
@@ -1,15 +1,18 @@
 // angular import
-import { Component, effect, inject } from '@angular/core';
+import { Component, OnInit, effect, inject } from '@angular/core';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { ThemeLayoutService } from 'src/app/@theme/services/theme-layout.service';
 
 // third party
-import { NgApexchartsModule, ApexOptions } from 'ng-apexcharts';
+import { NgApexchartsModule, ApexAxisChartSeries, ApexOptions } from 'ng-apexcharts';
 
 // const
 import { DARK, LIGHT } from 'src/app/@theme/const';
+import { ChartSeriesDto, DashboardService, RepeatCustomersDto } from 'src/app/@theme/services/dashboard.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+import { ApiError } from 'src/app/@theme/services/lookup.service';
 
 @Component({
   selector: 'app-project-overview-chart',
@@ -17,72 +20,164 @@ import { DARK, LIGHT } from 'src/app/@theme/const';
   templateUrl: './project-overview-chart.component.html',
   styleUrl: './project-overview-chart.component.scss'
 })
-export class ProjectOverviewChartComponent {
-  themeService = inject(ThemeLayoutService);
+export class ProjectOverviewChartComponent implements OnInit {
+  private themeService = inject(ThemeLayoutService);
+  private dashboardService = inject(DashboardService);
+  private toast = inject(ToastService);
 
-  // public props
   chartOptions: Partial<ApexOptions>;
-  chartOptions_1: Partial<ApexOptions>;
+  currentRate = 0;
+  previousRate = 0;
+  percentChange = 0;
+  readonly months = 6;
 
-  // constructor
   constructor() {
-    this.chartOptions = {
-      chart: {
-        type: 'area',
-        height: 60,
-        stacked: true,
-        sparkline: { enabled: true }
-      },
-      fill: {
-        type: 'gradient',
-        gradient: {
-          shadeIntensity: 1,
-          type: 'vertical',
-          inverseColors: false,
-          opacityFrom: 0.5,
-          opacityTo: 0
-        }
-      },
-      colors: ['#4680FF'],
-      stroke: { curve: 'smooth', width: 2 },
-      series: [{ data: [5, 25, 3, 10, 4, 50, 0] }],
-      tooltip: {
-        theme: LIGHT
-      }
-    };
-    this.chartOptions_1 = {
-      chart: {
-        type: 'area',
-        height: 60,
-        stacked: true,
-        sparkline: { enabled: true }
-      },
-      colors: ['#DC2626'],
-      fill: {
-        type: 'gradient',
-        gradient: {
-          shadeIntensity: 1,
-          type: 'vertical',
-          inverseColors: false,
-          opacityFrom: 0.5,
-          opacityTo: 0
-        }
-      },
-      stroke: { curve: 'smooth', width: 2 },
-      series: [{ data: [0, 50, 4, 10, 3, 25, 5] }],
-      tooltip: {
-        theme: LIGHT
-      }
-    };
     effect(() => {
-      this.isDarkTheme(this.themeService.isDarkMode());
+      this.applyTheme(this.themeService.isDarkMode());
     });
   }
 
-  private isDarkTheme(isDark: string) {
-    const tooltip = { ...this.chartOptions.tooltip, ...this.chartOptions_1.tooltip };
-    tooltip.theme = isDark === DARK ? DARK : LIGHT;
-    this.chartOptions = { ...this.chartOptions, tooltip };
-    this.chartOptions_1 = { ...this.chartOptions_1, tooltip };
+  ngOnInit(): void {
+    this.chartOptions = this.createBaseOptions();
+    this.loadRepeatCustomers();
+  }
+
+  get changeBadgeClass(): string {
+    return this.percentChange >= 0 ? 'user-status bg-success-500 text-white' : 'user-status bg-warn-500 text-white';
+  }
+
+  get changeText(): string {
+    const formatter = new Intl.NumberFormat(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+    const sign = this.percentChange > 0 ? '+' : this.percentChange < 0 ? '−' : '';
+    return `${sign}${formatter.format(Math.abs(this.percentChange))}%`;
+  }
+
+  get currentRateText(): string {
+    return this.formatPercent(this.currentRate);
+  }
+
+  get previousRateText(): string {
+    return this.formatPercent(this.previousRate);
+  }
+
+  private loadRepeatCustomers(): void {
+    this.dashboardService.getRepeatCustomers(this.months).subscribe({
+      next: (response) => {
+        if (response.isSuccess && response.data) {
+          this.applyRepeatCustomerData(response.data);
+        } else {
+          this.handleError(response.errors, 'Failed to load repeat customer data.');
+        }
+      },
+      error: () => this.handleError(undefined, 'Failed to load repeat customer data.')
+    });
+  }
+
+  private applyRepeatCustomerData(data: RepeatCustomersDto): void {
+    const categories = data.chart?.categories ?? [];
+    const series = this.toApexSeries(data.chart?.series);
+    this.chartOptions = {
+      ...this.chartOptions,
+      series,
+      xaxis: {
+        ...(this.chartOptions.xaxis ?? {}),
+        categories,
+        axisBorder: { show: false },
+        axisTicks: { show: false }
+      }
+    };
+    this.currentRate = data.currentRate ?? 0;
+    this.previousRate = data.previousRate ?? 0;
+    this.percentChange = data.percentChange ?? 0;
+  }
+
+  private toApexSeries(series: ChartSeriesDto[] | undefined): ApexAxisChartSeries {
+    if (!series) {
+      return [];
+    }
+    return series.map((item) => ({
+      name: item.name,
+      type: item.type,
+      data: item.data ?? []
+    }));
+  }
+
+  private createBaseOptions(): Partial<ApexOptions> {
+    return {
+      chart: {
+        type: 'line',
+        height: 320,
+        background: 'transparent',
+        toolbar: { show: false }
+      },
+      stroke: { curve: 'smooth', width: 3 },
+      dataLabels: { enabled: false },
+      fill: {
+        type: 'gradient',
+        gradient: {
+          shadeIntensity: 1,
+          type: 'vertical',
+          opacityFrom: 0.15,
+          opacityTo: 0,
+          inverseColors: false
+        }
+      },
+      series: [],
+      colors: ['var(--primary-500)'],
+      grid: {
+        show: true,
+        borderColor: '#F3F5F7',
+        strokeDashArray: 2
+      },
+      xaxis: {
+        categories: [],
+        axisBorder: { show: false },
+        axisTicks: { show: false }
+      },
+      yaxis: {
+        labels: {
+          formatter(value: number) {
+            return `${value}%`;
+          }
+        }
+      },
+      tooltip: {
+        theme: LIGHT,
+        y: {
+          formatter(value: number) {
+            return `${value}%`;
+          }
+        }
+      },
+      theme: {
+        mode: LIGHT
+      }
+    };
+  }
+
+  private applyTheme(isDark: string) {
+    if (!this.chartOptions) {
+      return;
+    }
+    const theme = { ...this.chartOptions.theme };
+    const tooltip = { ...this.chartOptions.tooltip };
+    const mode = isDark === DARK ? DARK : LIGHT;
+    if (theme) {
+      theme.mode = mode;
+    }
+    if (tooltip) {
+      tooltip.theme = mode;
+    }
+    this.chartOptions = { ...this.chartOptions, theme, tooltip };
+  }
+
+  private formatPercent(value: number): string {
+    const formatter = new Intl.NumberFormat(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+    return `${formatter.format(value)}%`;
+  }
+
+  private handleError(errors: ApiError[] | undefined, fallback: string): void {
+    const message = errors && errors.length > 0 ? errors.map((err) => err.message).join('\n') : fallback;
+    this.toast.error(message);
   }
 }

--- a/src/app/demo/pages/apex-chart/revenue-chart/revenue-chart.component.html
+++ b/src/app/demo/pages/apex-chart/revenue-chart/revenue-chart.component.html
@@ -1,7 +1,7 @@
 <div id="chart">
   <apx-chart
     [chart]="chartOptions.chart"
-    [colors]="monthlyColor"
+    [colors]="chartOptions.colors"
     [fill]="chartOptions.fill"
     [dataLabels]="chartOptions.dataLabels"
     [stroke]="chartOptions.stroke"
@@ -11,4 +11,24 @@
     [xaxis]="chartOptions.xaxis"
     [theme]="chartOptions.theme"
   ></apx-chart>
+</div>
+<div class="row g-3 m-t-20 revenue-summary">
+  <div class="col-md-4 col-sm-6">
+    <div class="summary-item">
+      <p class="text-muted m-b-5 f-w-500">Revenue</p>
+      <div class="f-16 f-w-600">{{ formatTotal(totals.revenue) }}</div>
+    </div>
+  </div>
+  <div class="col-md-4 col-sm-6">
+    <div class="summary-item">
+      <p class="text-muted m-b-5 f-w-500">Teacher &amp; Manager Payouts</p>
+      <div class="f-16 f-w-600">{{ formatTotal(totals.payouts) }}</div>
+    </div>
+  </div>
+  <div class="col-md-4 col-sm-6">
+    <div class="summary-item">
+      <p class="text-muted m-b-5 f-w-500">Net Income</p>
+      <div class="f-16 f-w-600">{{ formatTotal(totals.netIncome) }}</div>
+    </div>
+  </div>
 </div>

--- a/src/app/demo/pages/apex-chart/total-income-chart/total-income-chart.component.html
+++ b/src/app/demo/pages/apex-chart/total-income-chart/total-income-chart.component.html
@@ -11,7 +11,7 @@
   <apx-chart
     [series]="chartOptions.series!"
     [chart]="chartOptions.chart!"
-    [colors]="incomeColors"
+    [colors]="chartOptions.colors!"
     [labels]="chartOptions.labels!"
     [plotOptions]="chartOptions.plotOptions!"
     [fill]="chartOptions.fill!"
@@ -20,26 +20,27 @@
     [dataLabels]="chartOptions.dataLabels!"
   ></apx-chart>
   <div class="row g-3 m-t-15">
-    @for (task of income_card; track task) {
-      <div class="col-sm-6 m-t-15">
-        <div class="income-value">
-          <div class="flex align-item-center m-b-10">
-            <div class="flex-shrink-0">
-              <span class="p-5 block {{ task.background }} border-50"></span>
+    @if (slices.length === 0) {
+      <div class="col-12 text-center text-muted mat-caption">No revenue data available.</div>
+    } @else {
+      @for (slice of slices; track slice.label; let i = $index) {
+        <div class="col-sm-6 m-t-15">
+          <div class="income-value">
+            <div class="flex align-item-center m-b-10">
+              <div class="flex-shrink-0">
+                <span class="p-5 block border-50" [ngStyle]="{ 'background-color': getSliceColor(i) }"></span>
+              </div>
+              <div class="flex-grow-1 m-l-10">
+                <p class="m-b-0 f-w-500">{{ slice.label }}</p>
+              </div>
             </div>
-            <div class="flex-grow-1 m-l-10">
-              <p class="m-b-0">{{ task.item }}</p>
+            <div class="f-16 f-w-600">
+              {{ formatValue(slice) }}
+              <span class="text-muted f-w-500">{{ formatPercentage(slice.percentage) }}</span>
             </div>
-          </div>
-          <div class="f-16 f-w-600">
-            {{ task.value }}
-            <span class="text-muted f-w-500">
-              <i class="ti ti-chevrons-up"></i>
-              {{ task.number }}
-            </span>
           </div>
         </div>
-      </div>
+      }
     }
   </div>
 </app-card>

--- a/src/app/demo/pages/widget/chart/chart.component.html
+++ b/src/app/demo/pages/widget/chart/chart.component.html
@@ -1,52 +1,20 @@
 <div class="row widget-chart p-t-25">
-  <div class="col-md-6 col-xxl-3">
-    <app-earning-chart
-      iconImage="#wallet-2"
-      headerTitle="All Earnings"
-      earningValue="$30200"
-      background="bg-primary-50"
-      textColor="text-primary-500"
-      color="var(--primary-500)"
-      percentageValue="30.6%"
-      [data]="[10, 30, 40, 20, 60, 50, 20, 15, 20, 25, 30, 25]"
-    />
-  </div>
-  <div class="col-md-6 col-xxl-3">
-    <app-earning-chart
-      iconImage="#book"
-      headerTitle="Page Views"
-      earningValue="290+"
-      background="bg-warning-50"
-      textColor="text-warning-500"
-      color="var(--warning-500)"
-      percentageValue="30.6%"
-      [data]="[10, 30, 40, 20, 60, 50, 20, 15, 20, 25, 30, 25]"
-    />
-  </div>
-  <div class="col-md-6 col-xxl-3">
-    <app-earning-chart
-      iconImage="#calendar"
-      headerTitle="Total Task"
-      earningValue="14568"
-      background="bg-success-50"
-      textColor="text-success-500"
-      color="var(--success-500)"
-      percentageValue="30.6%"
-      [data]="[10, 30, 40, 20, 60, 50, 20, 15, 20, 25, 30, 25]"
-    />
-  </div>
-  <div class="col-md-6 col-xxl-3">
-    <app-earning-chart
-      iconImage="#coludChange"
-      headerTitle="Download"
-      earningValue="$30200"
-      background="bg-warn-50"
-      textColor="text-warn-500"
-      color="var(--warn-500)"
-      percentageValue="30.6%"
-      [data]="[10, 30, 40, 20, 60, 50, 20, 15, 20, 25, 30, 25]"
-    />
-  </div>
+  @for (card of summaryCards; track card.key) {
+    <div class="col-md-6 col-xxl-3">
+      <app-earning-chart
+        [iconImage]="card.iconImage"
+        [headerTitle]="card.headerTitle"
+        [earningValue]="card.earningValue"
+        [background]="card.background"
+        [textColor]="card.textColor"
+        [color]="card.color"
+        [percentageValue]="card.percentageValue"
+        [data]="card.data"
+        [trendColor]="card.trendColor ?? card.textColor"
+        [trendIcon]="card.trendIcon ?? 'ti ti-arrow-up-right'"
+      />
+    </div>
+  }
   <div class="col-lg-8 col-xxl-9">
     <app-card [showHeader]="false">
       <div class="flex align-item-center justify-content-between">

--- a/src/app/demo/pages/widget/chart/chart.component.ts
+++ b/src/app/demo/pages/widget/chart/chart.component.ts
@@ -1,11 +1,14 @@
 // angular import
-import { Component, effect, inject } from '@angular/core';
+import { Component, OnInit, effect, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { ChartDB } from 'src/app/fake-data/chartDB';
 import { ThemeLayoutService } from 'src/app/@theme/services/theme-layout.service';
+import { DashboardService, DashboardMetricDto } from 'src/app/@theme/services/dashboard.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+import { ApiError } from 'src/app/@theme/services/lookup.service';
 import { EarningChartComponent } from '../../apex-chart/earning-chart/earning-chart.component';
 import { NewOrderChartComponent } from '../../apex-chart/new-order-chart/new-order-chart.component';
 import { NewUserChartComponent } from '../../apex-chart/new-user-chart/new-user-chart.component';
@@ -23,6 +26,20 @@ import { DARK, LIGHT } from 'src/app/@theme/const';
 
 // third party
 import { NgApexchartsModule, ApexOptions } from 'ng-apexcharts';
+
+interface SummaryCardViewModel {
+  key: string;
+  headerTitle: string;
+  iconImage: string;
+  background: string;
+  textColor: string;
+  color: string;
+  earningValue: string;
+  percentageValue: string;
+  data: number[];
+  trendColor?: string;
+  trendIcon?: string;
+}
 
 @Component({
   selector: 'app-chart',
@@ -45,7 +62,9 @@ import { NgApexchartsModule, ApexOptions } from 'ng-apexcharts';
   templateUrl: './chart.component.html',
   styleUrls: ['./chart.component.scss']
 })
-export class WidgetChartComponent {
+export class WidgetChartComponent implements OnInit {
+  private dashboardService = inject(DashboardService);
+  private toast = inject(ToastService);
   themeService = inject(ThemeLayoutService);
 
   // public props
@@ -53,6 +72,53 @@ export class WidgetChartComponent {
   monthlyReportChart: Partial<ApexOptions>;
   salesReportChart: Partial<ApexOptions>;
   acquisitionChart: Partial<ApexOptions>;
+
+  summaryCards: SummaryCardViewModel[] = [
+    {
+      key: 'earnings',
+      headerTitle: 'All Earnings',
+      iconImage: '#wallet-2',
+      background: 'bg-primary-50',
+      textColor: 'text-primary-500',
+      color: 'var(--primary-500)',
+      earningValue: '—',
+      percentageValue: '—',
+      data: []
+    },
+    {
+      key: 'newStudents',
+      headerTitle: 'New Students',
+      iconImage: '#book',
+      background: 'bg-warning-50',
+      textColor: 'text-warning-500',
+      color: 'var(--warning-500)',
+      earningValue: '—',
+      percentageValue: '—',
+      data: []
+    },
+    {
+      key: 'circleReports',
+      headerTitle: 'Circle Reports',
+      iconImage: '#calendar',
+      background: 'bg-success-50',
+      textColor: 'text-success-500',
+      color: 'var(--success-500)',
+      earningValue: '—',
+      percentageValue: '—',
+      data: []
+    },
+    {
+      key: 'netIncome',
+      headerTitle: 'Net Income',
+      iconImage: '#coludChange',
+      background: 'bg-warn-50',
+      textColor: 'text-warn-500',
+      color: 'var(--warn-500)',
+      earningValue: '—',
+      percentageValue: '—',
+      data: []
+    }
+  ];
 
   preset = ['var(--primary-500)'];
   salesReportColor = ['#E58A00', 'var(--primary-500)'];
@@ -72,6 +138,10 @@ export class WidgetChartComponent {
     });
   }
 
+  ngOnInit(): void {
+    this.loadSummary();
+  }
+
   private isDarkTheme(isDarkMode: string) {
     const tooltip = {
       ...this.customerRateChart.tooltip,
@@ -84,6 +154,104 @@ export class WidgetChartComponent {
     this.monthlyReportChart = { ...this.monthlyReportChart, tooltip };
     this.salesReportChart = { ...this.salesReportChart, tooltip };
     this.acquisitionChart = { ...this.acquisitionChart, tooltip };
+  }
+
+  private loadSummary(): void {
+    this.dashboardService.getSummary().subscribe({
+      next: (response) => {
+        if (response.isSuccess && response.data?.metrics) {
+          const metrics = this.toMetricMap(response.data.metrics);
+          this.summaryCards = this.summaryCards.map((card) => {
+            const metric = metrics.get(card.key);
+            if (!metric) {
+              return {
+                ...card,
+                earningValue: '—',
+                percentageValue: '—',
+                data: [],
+                trendColor: card.textColor,
+                trendIcon: 'ti ti-arrow-up-right'
+              };
+            }
+
+            const percent = this.formatPercent(metric.percentChange);
+            const isPositive = (metric.percentChange ?? 0) >= 0;
+            return {
+              ...card,
+              earningValue: this.formatValue(metric.value, metric.valueType, metric.currencyCode),
+              percentageValue: percent,
+              data: this.resolveTrend(metric),
+              trendColor: isPositive ? 'text-success-500' : 'text-warn-500',
+              trendIcon: isPositive ? 'ti ti-arrow-up-right' : 'ti ti-arrow-down-right'
+            };
+          });
+        } else {
+          this.handleError(response.errors, 'Failed to load dashboard summary.');
+        }
+      },
+      error: () => this.handleError(undefined, 'Failed to load dashboard summary.')
+    });
+  }
+
+  private toMetricMap(
+    metrics: DashboardMetricDto[] | Record<string, DashboardMetricDto>
+  ): Map<string, DashboardMetricDto> {
+    if (Array.isArray(metrics)) {
+      return new Map(metrics.filter((metric) => !!metric?.key).map((metric) => [metric.key, metric]));
+    }
+    return new Map(Object.entries(metrics ?? {}));
+  }
+
+  private resolveTrend(metric: DashboardMetricDto | undefined): number[] {
+    if (!metric) {
+      return [];
+    }
+    if (Array.isArray(metric.trend) && metric.trend.length > 0) {
+      return metric.trend;
+    }
+    const previous = metric.previousValue ?? 0;
+    const current = metric.value ?? 0;
+    return [previous, current];
+  }
+
+  private formatValue(value?: number, valueType?: string, currencyCode?: string): string {
+    if (value === undefined || value === null) {
+      return '—';
+    }
+    if (valueType && valueType.toLowerCase() === 'currency') {
+      const code = currencyCode ?? 'USD';
+      try {
+        return new Intl.NumberFormat(undefined, {
+          style: 'currency',
+          currency: code,
+          maximumFractionDigits: 0
+        }).format(value);
+      } catch {
+        return `${code} ${this.formatNumber(value)}`;
+      }
+    }
+    return this.formatNumber(value);
+  }
+
+  private formatNumber(value: number): string {
+    return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value);
+  }
+
+  private formatPercent(value?: number): string {
+    if (value === undefined || value === null) {
+      return '—';
+    }
+    const formatter = new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2
+    });
+    const sign = value > 0 ? '+' : value < 0 ? '−' : '';
+    return `${sign}${formatter.format(Math.abs(value))}%`;
+  }
+
+  private handleError(errors: ApiError[] | undefined, fallback: string): void {
+    const message = errors && errors.length > 0 ? errors.map((err) => err.message).join('\n') : fallback;
+    this.toast.error(message);
   }
 
   // public method


### PR DESCRIPTION
## Summary
- convert dashboard chart DTO series into ApexAxisChartSeries objects before updating the chart options
- ensure the revenue chart colour logic works with typed Apex series values
- move the dashboard summary API integration to the widget chart page and restore the default dashboard cards to their static placeholders

## Testing
- npm run lint
- npm run build -- --configuration production --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68ca9a88db308322ad6ec21629d287c1