### PR TITLE
feat: integrate dashboard subscriber analytics with apex charts

### DIFF
--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -1,0 +1,80 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface SubscriberTypeSeriesDto {
+  name: string;
+  data: number[];
+  type?: string;
+}
+
+export interface SubscriberByTypeChartDto {
+  chart?: Record<string, unknown>;
+  xaxis?: Record<string, unknown>;
+  series?: SubscriberTypeSeriesDto[] | number[];
+}
+
+export interface SubscriberDistributionSliceDto {
+  label: string;
+  value: number;
+  percentage?: number;
+  color?: string;
+}
+
+export interface SubscriberDistributionDto {
+  slices: SubscriberDistributionSliceDto[];
+}
+
+export interface SubscriberTypeBreakdownDto {
+  label?: string;
+  type?: string;
+  name?: string;
+  totalSubscribers?: number;
+  uniqueSubscribers?: number;
+  newSubscribers?: number;
+  returningSubscribers?: number;
+  percentage?: number;
+  [key: string]: string | number | undefined;
+}
+
+export interface SubscriberTypeAnalyticsDto {
+  subscribersByType: SubscriberByTypeChartDto;
+  distribution: SubscriberDistributionDto;
+  breakdown?: SubscriberTypeBreakdownDto[];
+  totalSubscribers?: number;
+  uniqueSubscribers?: number;
+  newSubscribers?: number;
+  returningSubscribers?: number;
+  activeSubscribers?: number;
+  inactiveSubscribers?: number;
+  churnedSubscribers?: number;
+  totals?: Record<string, number>;
+  startDate?: string;
+  endDate?: string;
+  [key: string]: unknown;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DashboardService {
+  private http = inject(HttpClient);
+
+  getSubscribersByType(startDate?: string, endDate?: string): Observable<SubscriberTypeAnalyticsDto> {
+    let params = new HttpParams();
+
+    if (startDate) {
+      params = params.set('startDate', startDate);
+    }
+
+    if (endDate) {
+      params = params.set('endDate', endDate);
+    }
+
+    const options = params.keys().length ? { params } : {};
+
+    return this.http.get<SubscriberTypeAnalyticsDto>(
+      `${environment.apiUrl}/api/dashboard/subscribers/by-type`,
+      options
+    );
+  }
+}

--- a/src/app/demo/pages/chart/apex-charts/apex-charts.component.html
+++ b/src/app/demo/pages/chart/apex-charts/apex-charts.component.html
@@ -1,312 +1,107 @@
-<div class="row p-t-25">
-  <div class="col-md-6">
-    <app-card cardTitle="Bar Chart">
+<div class="row p-t-25 g-3">
+  <div class="col-12">
+    <div class="row g-3">
+      <div class="col-sm-6 col-xl-3" *ngFor="let metric of totalsList; trackBy: trackByKey">
+        <app-card>
+          <div class="d-flex flex-column gap-1">
+            <span class="text-muted text-uppercase f-12">{{ metric.label }}</span>
+            <h5 class="mb-0">{{ metric.value | number }}</h5>
+          </div>
+        </app-card>
+      </div>
+      <div class="col-12" *ngIf="!totalsList.length">
+        <app-card>
+          <p class="mb-0 text-center text-muted">لا توجد بيانات إجمالية للمشتركين.</p>
+        </app-card>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-xl-8 col-lg-7">
+    <app-card cardTitle="المشتركين حسب النوع">
       <apx-chart
         [series]="barChart.series"
         [chart]="barChart.chart"
         [dataLabels]="barChart.dataLabels"
         [plotOptions]="barChart.plotOptions"
-        [stroke]="barChart.stroke"
-        [responsive]="barChart.responsive"
         [xaxis]="barChart.xaxis"
-        [yaxis]="barChart.yaxis"
+        [grid]="barChart.grid"
         [colors]="preset"
-        [fill]="barChart.fill"
         [tooltip]="barChart.tooltip"
       ></apx-chart>
     </app-card>
   </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Bar Chart Stacked">
-      <apx-chart
-        [series]="barStackedChart.series"
-        [chart]="barStackedChart.chart"
-        [dataLabels]="barStackedChart.dataLabels"
-        [plotOptions]="barStackedChart.plotOptions"
-        [stroke]="barStackedChart.stroke"
-        [responsive]="barStackedChart.responsive"
-        [xaxis]="barStackedChart.xaxis"
-        [colors]="barChartColor"
-        [fill]="barStackedChart.fill"
-        [tooltip]="barStackedChart.tooltip"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Bar chart horizontal">
-      <apx-chart
-        [series]="barHorizontalChart.series"
-        [chart]="barHorizontalChart.chart"
-        [dataLabels]="barHorizontalChart.dataLabels"
-        [plotOptions]="barHorizontalChart.plotOptions"
-        [stroke]="barHorizontalChart.stroke"
-        [xaxis]="barHorizontalChart.xaxis"
-        [tooltip]="barHorizontalChart.tooltip"
-        [colors]="bHorizontalColor"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Bar chart horizontal stacked">
-      <apx-chart
-        [series]="barHStackChart.series"
-        [chart]="barHStackChart.chart"
-        [dataLabels]="barHStackChart.dataLabels"
-        [plotOptions]="barHStackChart.plotOptions"
-        [stroke]="barHStackChart.stroke"
-        [xaxis]="barHStackChart.xaxis"
-        [title]="barHStackChart.title"
-        [colors]="barHStackChart.colors"
-        [fill]="barHStackChart.fill"
-        [tooltip]="barHStackChart.tooltip"
-        [legend]="barHStackChart.legend"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Pie Charts">
-      <apx-chart
-        [series]="pieChart.series"
-        [chart]="pieChart.chart"
-        [dataLabels]="pieChart.dataLabels"
-        [plotOptions]="pieChart.plotOptions"
-        [colors]="pie_color"
-        [legend]="pieChart.legend"
-        [labels]="pieChart.labels"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Pie Charts donut">
-      <apx-chart
-        [series]="donutChart.series"
-        [chart]="donutChart.chart"
-        [dataLabels]="donutChart.dataLabels"
-        [plotOptions]="donutChart.plotOptions"
-        [colors]="pie_color"
-        [legend]="donutChart.legend"
-        [responsive]="donutChart.responsive"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="RadialBar Charts">
-      <apx-chart
-        [series]="radialChart.series"
-        [chart]="radialChart.chart"
-        [plotOptions]="radialChart.plotOptions"
-        [colors]="radialColor"
-        [labels]="radialChart.labels"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="RadialBar Charts Custom Angle">
-      <apx-chart
-        [series]="customsAngleChart.series"
-        [chart]="customsAngleChart.chart"
-        [plotOptions]="customsAngleChart.plotOptions"
-        [colors]="customs_color"
-        [legend]="customsAngleChart.legend"
-        [responsive]="customsAngleChart.responsive"
-        [labels]="customsAngleChart.labels"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-12">
-    <app-card cardTitle="Basic line chart">
-      <apx-chart
-        [series]="lineChart.series"
-        [chart]="lineChart.chart"
-        [dataLabels]="lineChart.dataLabels"
-        [colors]="radialColor"
-        [stroke]="lineChart.stroke"
-        [title]="lineChart.title"
-        [grid]="lineChart.grid"
-        [xaxis]="lineChart.xaxis"
-        [tooltip]="lineChart.tooltip"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-12">
-    <app-card cardTitle="Realtime Chart">
-      <apx-chart
-        [series]="realTimeChart.series"
-        [chart]="realTimeChart.chart"
-        [dataLabels]="realTimeChart.dataLabels"
-        [colors]="realTimeChart.colors"
-        [stroke]="realTimeChart.stroke"
-        [title]="realTimeChart.title"
-        [xaxis]="realTimeChart.xaxis"
-        [grid]="realTimeChart.grid"
-        [tooltip]="realTimeChart.tooltip"
-        [markers]="realTimeChart.markers"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Area chart">
-      <apx-chart
-        [series]="areaChart.series"
-        [chart]="areaChart.chart"
-        [dataLabels]="areaChart.dataLabels"
-        [colors]="areaChart.colors"
-        [stroke]="areaChart.stroke"
-        [xaxis]="areaChart.xaxis"
-        [tooltip]="areaChart.tooltip"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Area chart DateTime X-Axis">
-      <div class="toolbar btn-group">
-        <button id="one_month" mat-stroked-button>1M</button>
-        <button id="six_months" mat-stroked-button>6M</button>
-        <button id="one_year" mat-flat-button color="primary">1Y</button>
-        <button id="ytd" mat-stroked-button>YTD</button>
-        <button id="all" mat-stroked-button>ALL</button>
+
+  <div class="col-xl-4 col-lg-5">
+    <div class="row g-3">
+      <div class="col-12">
+        <app-card cardTitle="توزيع المشتركين (دونات)">
+          <apx-chart
+            [series]="donutChart.series"
+            [chart]="donutChart.chart"
+            [dataLabels]="donutChart.dataLabels"
+            [legend]="donutChart.legend"
+            [labels]="donutChart.labels"
+            [colors]="pie_color"
+            [tooltip]="donutChart.tooltip"
+          ></apx-chart>
+        </app-card>
       </div>
-      <apx-chart
-        [series]="dateTimeChart.series"
-        [chart]="dateTimeChart.chart"
-        [dataLabels]="dateTimeChart.dataLabels"
-        [colors]="dateTimeChart.colors"
-        [stroke]="dateTimeChart.stroke"
-        [xaxis]="dateTimeChart.xaxis"
-        [tooltip]="dateTimeChart.tooltip"
-        [annotations]="dateTimeChart.annotations"
-        [markers]="dateTimeChart.markers"
-        [labels]="dateTimeChart.labels"
-      ></apx-chart>
-    </app-card>
+      <div class="col-12">
+        <app-card cardTitle="توزيع المشتركين (باي)">
+          <apx-chart
+            [series]="pieChart.series"
+            [chart]="pieChart.chart"
+            [dataLabels]="pieChart.dataLabels"
+            [legend]="pieChart.legend"
+            [labels]="pieChart.labels"
+            [colors]="pie_color"
+            [tooltip]="pieChart.tooltip"
+          ></apx-chart>
+        </app-card>
+      </div>
+      <div class="col-12">
+        <app-card cardTitle="تفاصيل التوزيع">
+          <div class="list-group list-group-flush" *ngIf="distributionSlices.length; else distributionEmpty">
+            <div class="list-group-item px-0 border-0" *ngFor="let slice of distributionSlices; trackBy: trackBySlice">
+              <div class="d-flex justify-content-between align-items-center gap-3">
+                <div>
+                  <span class="d-block fw-semibold">{{ slice.label }}</span>
+                  <small class="text-muted">{{ (slice.percentage ?? 0) | number: '1.0-2' }}%</small>
+                </div>
+                <div class="text-end">
+                  <span class="fw-semibold">{{ slice.value | number }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <ng-template #distributionEmpty>
+            <p class="mb-0 text-center text-muted">لا توجد بيانات توزيع متاحة.</p>
+          </ng-template>
+        </app-card>
+      </div>
+    </div>
   </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Mixed chart">
-      <apx-chart
-        [series]="mixedChart.series"
-        [chart]="mixedChart.chart"
-        [colors]="mixedChart.colors"
-        [stroke]="mixedChart.stroke"
-        [xaxis]="mixedChart.xaxis"
-        [yaxis]="mixedChart.yaxis"
-        [labels]="mixedChart.labels"
-        [title]="mixedChart.title"
-        [tooltip]="mixedChart.tooltip"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Line Column Area Chart">
-      <apx-chart
-        [series]="lineAreaChart.series"
-        [chart]="lineAreaChart.chart"
-        [plotOptions]="lineAreaChart.plotOptions"
-        [colors]="lineAreaChart.colors"
-        [stroke]="lineAreaChart.stroke"
-        [xaxis]="lineAreaChart.xaxis"
-        [yaxis]="lineAreaChart.yaxis"
-        [labels]="lineAreaChart.labels"
-        [tooltip]="lineAreaChart.tooltip"
-        [fill]="lineAreaChart.fill"
-        [markers]="lineAreaChart.markers"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-12">
-    <app-card cardTitle="Candlestick Chart">
-      <apx-chart
-        [series]="candlestickChart.series"
-        [chart]="candlestickChart.chart"
-        [colors]="candlestickChart.colors"
-        [xaxis]="candlestickChart.xaxis"
-        [yaxis]="candlestickChart.yaxis"
-        [title]="candlestickChart.title"
-        [tooltip]="candlestickChart.tooltip"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Bubble Chart">
-      <apx-chart
-        [series]="bubbleChart.series"
-        [chart]="bubbleChart.chart"
-        [dataLabels]="bubbleChart.dataLabels"
-        [colors]="bubbleChart.colors"
-        [xaxis]="bubbleChart.xaxis"
-        [yaxis]="bubbleChart.yaxis"
-        [title]="bubbleChart.title"
-        [fill]="bubbleChart.fill"
-        [tooltip]="bubbleChart.tooltip"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Bubble Chart 3D">
-      <apx-chart
-        [series]="bubble3DChart.series"
-        [chart]="bubble3DChart.chart"
-        [dataLabels]="bubble3DChart.dataLabels"
-        [colors]="bubble3DChart.colors"
-        [xaxis]="bubble3DChart.xaxis"
-        [yaxis]="bubble3DChart.yaxis"
-        [title]="bubble3DChart.title"
-        [fill]="bubble3DChart.fill"
-        [tooltip]="bubble3DChart.tooltip"
-        [theme]="bubble3DChart.theme"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Scatter Chart">
-      <apx-chart
-        [series]="scatterChart.series"
-        [chart]="scatterChart.chart"
-        [colors]="scatterChart.colors"
-        [xaxis]="scatterChart.xaxis"
-        [yaxis]="scatterChart.yaxis"
-        [tooltip]="scatterChart.tooltip"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Scatter Chart Datetime">
-      <apx-chart
-        [series]="scatterDateTimeChart.series"
-        [chart]="scatterDateTimeChart.chart"
-        [colors]="scatterDateTimeChart.colors"
-        [xaxis]="scatterDateTimeChart.xaxis"
-        [yaxis]="scatterDateTimeChart.yaxis"
-        [grid]="scatterDateTimeChart.grid"
-        [dataLabels]="scatterDateTimeChart.dataLabels"
-        [tooltip]="scatterDateTimeChart.tooltip"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Heatmap Charts">
-      <apx-chart
-        [series]="heatmapChart.series"
-        [chart]="heatmapChart.chart"
-        [colors]="heatmapChart.colors"
-        [dataLabels]="heatmapChart.dataLabels"
-        [title]="heatmapChart.title"
-        [tooltip]="heatmapChart.tooltip"
-      ></apx-chart>
-    </app-card>
-  </div>
-  <div class="col-md-6">
-    <app-card cardTitle="Heatmap Charts Rounded">
-      <apx-chart
-        [series]="heatmapRoundedChart.series"
-        [chart]="heatmapRoundedChart.chart"
-        [colors]="heatmapRoundedChart.colors"
-        [dataLabels]="heatmapRoundedChart.dataLabels"
-        [title]="heatmapRoundedChart.title"
-        [stroke]="heatmapRoundedChart.stroke"
-        [xaxis]="heatmapRoundedChart.xaxis"
-        [tooltip]="heatmapRoundedChart.tooltip"
-        [plotOptions]="heatmapRoundedChart.plotOptions"
-      ></apx-chart>
+
+  <div class="col-12">
+    <app-card cardTitle="تفاصيل المشتركين حسب النوع">
+      <div class="table-responsive" *ngIf="breakdown.length && breakdownColumns.length; else emptyBreakdown">
+        <table class="table table-hover mb-0">
+          <thead>
+            <tr>
+              <th *ngFor="let column of breakdownColumns">{{ toDisplayLabel(column) }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let row of breakdown; trackBy: trackByBreakdown">
+              <td *ngFor="let column of breakdownColumns">{{ getDisplayValue(row, column) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <ng-template #emptyBreakdown>
+        <p class="mb-0 text-center text-muted">لا توجد بيانات تفصيلية متاحة.</p>
+      </ng-template>
     </app-card>
   </div>
 </div>

--- a/src/app/demo/pages/chart/apex-charts/apex-charts.component.ts
+++ b/src/app/demo/pages/chart/apex-charts/apex-charts.component.ts
@@ -1,17 +1,12 @@
-// angular import
-import { Component, OnInit, effect, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
-// project import
-import { SharedModule } from 'src/app/demo/shared/shared.module';
-import { ChartDB } from 'src/app/fake-data/chartDB';
-import { ThemeLayoutService } from 'src/app/@theme/services/theme-layout.service';
-
-// const
-import { DARK, LIGHT } from 'src/app/@theme/const';
-
-// third party
+import { Component, OnInit, effect, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgApexchartsModule, ApexOptions } from 'ng-apexcharts';
+
+import { DARK, LIGHT } from 'src/app/@theme/const';
+import { ThemeLayoutService } from 'src/app/@theme/services/theme-layout.service';
+import { DashboardService, SubscriberDistributionSliceDto, SubscriberTypeAnalyticsDto, SubscriberTypeBreakdownDto } from 'src/app/core/services/dashboard.service';
+import { SharedModule } from 'src/app/demo/shared/shared.module';
 
 @Component({
   selector: 'app-apex-charts',
@@ -20,126 +15,255 @@ import { NgApexchartsModule, ApexOptions } from 'ng-apexcharts';
   styleUrls: ['./apex-charts.component.scss']
 })
 export class ApexChartsComponent implements OnInit {
-  private themeService = inject(ThemeLayoutService);
+  private readonly themeService = inject(ThemeLayoutService);
+  private readonly dashboardService = inject(DashboardService);
 
-  // public props
-  barChart: Partial<ApexOptions>;
-  barStackedChart: Partial<ApexOptions>;
-  barHorizontalChart: Partial<ApexOptions>;
-  barHStackChart: Partial<ApexOptions>;
-  pieChart: Partial<ApexOptions>;
-  donutChart: Partial<ApexOptions>;
-  radialChart: Partial<ApexOptions>;
-  customsAngleChart: Partial<ApexOptions>;
-  lineChart: Partial<ApexOptions>;
-  realTimeChart: Partial<ApexOptions>;
-  areaChart: Partial<ApexOptions>;
-  dateTimeChart: Partial<ApexOptions>;
-  mixedChart: Partial<ApexOptions>;
-  lineAreaChart: Partial<ApexOptions>;
-  candlestickChart: Partial<ApexOptions>;
-  bubbleChart: Partial<ApexOptions>;
-  bubble3DChart: Partial<ApexOptions>;
-  scatterChart: Partial<ApexOptions>;
-  scatterDateTimeChart: Partial<ApexOptions>;
-  heatmapChart: Partial<ApexOptions>;
-  heatmapRoundedChart: Partial<ApexOptions>;
-  // eslint-disable-next-line
-  chartDB: any;
+  barChart: Partial<ApexOptions> = {
+    chart: {
+      type: 'bar',
+      height: 360,
+      toolbar: {
+        show: false
+      }
+    },
+    plotOptions: {
+      bar: {
+        borderRadius: 6,
+        columnWidth: '40%'
+      }
+    },
+    dataLabels: {
+      enabled: false
+    },
+    xaxis: {
+      categories: []
+    },
+    grid: {
+      strokeDashArray: 4
+    },
+    series: []
+  };
 
-  // color change while theme color change
-  preset = ['#0050B3', 'var(--primary-500)', '#52C41A'];
-  barChartColor = ['var(--primary-500)', '#52c41a', '#faad14', '#13c2c2'];
-  bHorizontalColor = ['var(--primary-500)', '#52c41a'];
-  pie_color = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F', '#FAAD14'];
-  radialColor = ['var(--primary-500)'];
-  customs_color = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F'];
+  pieChart: Partial<ApexOptions> = {
+    chart: {
+      type: 'pie',
+      height: 320
+    },
+    dataLabels: {
+      enabled: false
+    },
+    labels: [],
+    legend: {
+      position: 'bottom'
+    },
+    series: []
+  };
 
-  // constructor
+  donutChart: Partial<ApexOptions> = {
+    chart: {
+      type: 'donut',
+      height: 320
+    },
+    dataLabels: {
+      enabled: false
+    },
+    labels: [],
+    legend: {
+      position: 'bottom'
+    },
+    series: []
+  };
+
+  preset: string[] = [];
+  pie_color: string[] = [];
+
+  distributionSlices: SubscriberDistributionSliceDto[] = [];
+  breakdown: SubscriberTypeBreakdownDto[] = [];
+  breakdownColumns: string[] = [];
+  totalsList: { key: string; label: string; value: number }[] = [];
+
+  totalSubscribers = 0;
+  uniqueSubscribers = 0;
+  newSubscribers = 0;
+  returningSubscribers = 0;
+
+  startDate?: string;
+  endDate?: string;
+
   constructor() {
     effect(() => {
       this.isDarkTheme(this.themeService.isDarkMode());
     });
-    this.chartDB = ChartDB;
-    const {
-      barChart,
-      bubbleChart,
-      bubble3DChart,
-      scatterChart,
-      scatterDateTimeChart,
-      heatmapChart,
-      heatmapRoundedChart,
-      lineAreaChart,
-      candlestickChart,
-      barStackedChart,
-      barHorizontalChart,
-      barHStackChart,
-      pieChart,
-      donutChart,
-      radialChart,
-      customsAngleChart,
-      lineChart,
-      realTimeChart,
-      areaChart,
-      dateTimeChart,
-      mixedChart
-    } = this.chartDB;
-
-    // eslint-disable-next-line
-    ((this.barChart = barChart),
-      (this.barStackedChart = barStackedChart),
-      (this.barHorizontalChart = barHorizontalChart),
-      (this.barHStackChart = barHStackChart),
-      (this.pieChart = pieChart),
-      (this.donutChart = donutChart),
-      (this.radialChart = radialChart),
-      (this.customsAngleChart = customsAngleChart),
-      (this.lineChart = lineChart),
-      (this.realTimeChart = realTimeChart),
-      (this.areaChart = areaChart),
-      (this.dateTimeChart = dateTimeChart),
-      (this.mixedChart = mixedChart),
-      (this.lineAreaChart = lineAreaChart),
-      (this.candlestickChart = candlestickChart),
-      (this.bubbleChart = bubbleChart),
-      (this.bubble3DChart = bubble3DChart),
-      (this.scatterChart = scatterChart),
-      (this.scatterDateTimeChart = scatterDateTimeChart),
-      (this.heatmapChart = heatmapChart),
-      (this.heatmapRoundedChart = heatmapRoundedChart));
   }
 
-  // lifecycle hooks
   ngOnInit(): void {
-    this.preset = ['#0050B3', 'var(--primary-500)', '#52C41A'];
-    this.barChartColor = ['var(--primary-500)', '#52c41a', '#faad14', '#13c2c2'];
-    this.bHorizontalColor = ['var(--primary-500)', '#52c41a'];
-    this.pie_color = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F', '#FAAD14'];
-    this.radialColor = ['var(--primary-500)'];
-    this.customs_color = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F'];
+    this.resetColorPalette();
+    this.loadAnalytics();
   }
 
-  // private methods
-  private isDarkTheme(isDark: string) {
+  getDisplayValue(item: SubscriberTypeBreakdownDto, key: string): string {
+    const value = item[key];
+
+    if (typeof value === 'number') {
+      return new Intl.NumberFormat().format(value);
+    }
+
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (value == null) {
+      return '-';
+    }
+
+    return String(value);
+  }
+
+  trackByKey(_: number, item: { key: string }): string {
+    return item.key;
+  }
+
+  trackBySlice(_: number, item: SubscriberDistributionSliceDto): string {
+    return item.label;
+  }
+
+  trackByBreakdown(_: number, item: SubscriberTypeBreakdownDto): string {
+    return `${item.label ?? item.type ?? item.name ?? ''}`;
+  }
+
+  private loadAnalytics(): void {
+    this.dashboardService
+      .getSubscribersByType(this.startDate, this.endDate)
+      .pipe(takeUntilDestroyed())
+      .subscribe((response) => {
+        this.applyAnalytics(response);
+      });
+  }
+
+  private applyAnalytics(data: SubscriberTypeAnalyticsDto): void {
+    const subscribersByType = data?.subscribersByType ?? {};
+    const distributionSlices = data?.distribution?.slices ?? [];
+    const breakdown = data?.breakdown ?? [];
+
+    this.barChart = {
+      ...this.barChart,
+      chart: subscribersByType.chart ?? this.barChart.chart,
+      xaxis: subscribersByType.xaxis ?? this.barChart.xaxis,
+      series: subscribersByType.series ?? []
+    };
+
+    this.distributionSlices = distributionSlices;
+
+    const pieLabels = distributionSlices.map((slice) => slice.label);
+    const pieSeries = distributionSlices.map((slice) => slice.value);
+    const pieColors = distributionSlices.map((slice, index) =>
+      slice.color ?? this.getDefaultPieColor(index)
+    );
+
+    this.pieChart = {
+      ...this.pieChart,
+      labels: pieLabels,
+      series: pieSeries
+    };
+
+    this.donutChart = {
+      ...this.donutChart,
+      labels: pieLabels,
+      series: pieSeries
+    };
+
+    this.pie_color = pieColors.length ? pieColors : [...this.pie_color];
+
+    this.breakdown = breakdown;
+    this.updateBreakdownColumns(breakdown);
+    this.updateTotals(data);
+  }
+
+  private updateBreakdownColumns(breakdown: SubscriberTypeBreakdownDto[]): void {
+    if (!breakdown?.length) {
+      this.breakdownColumns = [];
+      return;
+    }
+
+    const uniqueKeys = new Set<string>();
+    breakdown.forEach((item) => {
+      Object.keys(item ?? {}).forEach((key) => uniqueKeys.add(key));
+    });
+
+    const ordered: string[] = [];
+    const labelKey = ['label', 'type', 'name'].find((key) => uniqueKeys.has(key));
+
+    if (labelKey) {
+      ordered.push(labelKey);
+      uniqueKeys.delete(labelKey);
+    }
+
+    const remaining = Array.from(uniqueKeys).sort((a, b) => a.localeCompare(b));
+
+    this.breakdownColumns = [...ordered, ...remaining];
+  }
+
+  private updateTotals(data: SubscriberTypeAnalyticsDto): void {
+    const totals: Record<string, number> = {};
+    const predefinedTotals: Record<string, unknown> = {
+      ...data?.totals,
+      totalSubscribers: data?.totalSubscribers,
+      uniqueSubscribers: data?.uniqueSubscribers,
+      newSubscribers: data?.newSubscribers,
+      returningSubscribers: data?.returningSubscribers,
+      activeSubscribers: data?.activeSubscribers,
+      inactiveSubscribers: data?.inactiveSubscribers,
+      churnedSubscribers: data?.churnedSubscribers
+    };
+
+    Object.entries(predefinedTotals).forEach(([key, value]) => {
+      if (typeof value === 'number' && !Number.isNaN(value)) {
+        totals[key] = value;
+      }
+    });
+
+    this.totalsList = Object.entries(totals).map(([key, value]) => ({
+      key,
+      label: this.toDisplayLabel(key),
+      value
+    }));
+
+    this.totalSubscribers = totals.totalSubscribers ?? 0;
+    this.uniqueSubscribers = totals.uniqueSubscribers ?? 0;
+    this.newSubscribers = totals.newSubscribers ?? 0;
+    this.returningSubscribers = totals.returningSubscribers ?? 0;
+  }
+
+  private resetColorPalette(): void {
+    const defaultPalette = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F', '#FAAD14'];
+    this.preset = ['#0050B3', 'var(--primary-500)', '#52C41A'];
+    this.pie_color = [...defaultPalette];
+  }
+
+  private getDefaultPieColor(index: number): string {
+    const palette = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F', '#FAAD14'];
+    return palette[index % palette.length];
+  }
+
+  protected toDisplayLabel(key: string): string {
+    if (!key) {
+      return key;
+    }
+
+    const spaced = key
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .replace(/_/g, ' ')
+      .trim();
+
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+  }
+
+  private isDarkTheme(isDark: string): void {
     const tooltipTheme = isDark === DARK ? DARK : LIGHT;
     const tooltip = { theme: tooltipTheme };
 
     this.barChart = { ...this.barChart, tooltip };
-    this.barStackedChart = { ...this.barStackedChart, tooltip };
-    this.barHorizontalChart = { ...this.barHorizontalChart, tooltip };
-    this.barHStackChart = { ...this.barHStackChart, tooltip };
-    this.lineChart = { ...this.lineChart, tooltip };
-    this.realTimeChart = { ...this.realTimeChart, tooltip };
-    this.areaChart = { ...this.areaChart, tooltip };
-    this.dateTimeChart = { ...this.dateTimeChart, tooltip };
-    this.mixedChart = { ...this.mixedChart, tooltip };
-    this.lineAreaChart = { ...this.lineAreaChart, tooltip };
-    this.candlestickChart = { ...this.candlestickChart, tooltip };
-    this.bubbleChart = { ...this.bubbleChart, tooltip };
-    this.bubble3DChart = { ...this.bubble3DChart, tooltip };
-    this.scatterChart = { ...this.scatterChart, tooltip };
-    this.scatterDateTimeChart = { ...this.scatterDateTimeChart, tooltip };
-    this.heatmapChart = { ...this.heatmapChart, tooltip };
-    this.heatmapRoundedChart = { ...this.heatmapRoundedChart, tooltip };
+    this.pieChart = { ...this.pieChart, tooltip };
+    this.donutChart = { ...this.donutChart, tooltip };
   }
 }


### PR DESCRIPTION
## Summary
- add a core dashboard service that retrieves subscriber type analytics from the API
- refactor the apex charts component to consume the new data, recomputing chart options, totals, and breakdown rows dynamically
- refresh the component template to render service-driven bar/pie/donut charts alongside aggregated metrics and distribution details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cab4acf3b0832294988dfb89a5b505