### PR TITLE
Integrate subscriber type statistics into overview chart

### DIFF
--- a/src/app/@theme/services/dashboard.service.ts
+++ b/src/app/@theme/services/dashboard.service.ts
@@ -64,6 +64,36 @@ export interface RevenueByCurrencyDto {
   slices: RevenueByCurrencySliceDto[];
 }
 
+export interface SubscribeTypeDistributionSliceDto {
+  label?: string;
+  value?: number;
+  percentage?: number;
+  color?: string;
+}
+
+export interface SubscribeTypeDistributionDto {
+  slices?: SubscribeTypeDistributionSliceDto[];
+  totalValue?: number;
+}
+
+export interface SubscribeTypeBreakdownDto {
+  subscribeTypeId?: number;
+  typeName?: string;
+  subscriberCount?: number;
+  percentage?: number;
+}
+
+export interface SubscribeTypeStatisticsDto {
+  subscribersByType?: ChartDto;
+  distribution?: SubscribeTypeDistributionDto;
+  breakdown?: SubscribeTypeBreakdownDto[];
+  totalSubscribers?: number;
+  uniqueSubscribers?: number;
+  totalSubscriptionTypes?: number;
+  startDate?: string | null;
+  endDate?: string | null;
+}
+
 @Injectable({ providedIn: 'root' })
 export class DashboardService {
   private http = inject(HttpClient);
@@ -93,6 +123,12 @@ export class DashboardService {
     return this.http.get<ApiResponse<RevenueByCurrencyDto>>(
       `${environment.apiUrl}/api/dashboard/revenue-by-currency`,
       { params }
+    );
+  }
+
+  getSubscribeTypeStatistics(): Observable<ApiResponse<SubscribeTypeStatisticsDto>> {
+    return this.http.get<ApiResponse<SubscribeTypeStatisticsDto>>(
+      `${environment.apiUrl}/api/Subscribe/TypeStatistics`
     );
   }
 }

--- a/src/app/demo/pages/apex-chart/overview-product-chart/overview-product-chart.component.html
+++ b/src/app/demo/pages/apex-chart/overview-product-chart/overview-product-chart.component.html
@@ -1,6 +1,6 @@
 <app-card [showHeader]="false">
   <div class="flex align-item-center justify-content-between m-b-15">
-    <div class="f-w-600 f-16">Overview Product</div>
+    <div class="f-w-600 f-16">Subscriber Type Overview</div>
     <a [matMenuTriggerFor]="paymentInfo" class="avatar avatar-s hover"><i class="ti ti-dots-vertical f-18"></i></a>
     <mat-menu #paymentInfo="matMenu">
       <a href="javascript:" mat-menu-item>Name</a>
@@ -20,14 +20,55 @@
       [colors]="chartOptions.colors"
     />
   </div>
+  <div class="row text-center m-t-20">
+    <div class="col-6 col-lg-4 col-xxl-4">
+      <div class="overview-product-legends">
+        <p class="m-b-5">
+          <span>Total Subscribers</span>
+        </p>
+        <div class="f-w-600">{{ totalSubscribers | number: '1.0-0' }}</div>
+      </div>
+    </div>
+    <div class="col-6 col-lg-4 col-xxl-4">
+      <div class="overview-product-legends">
+        <p class="m-b-5">
+          <span>Unique Subscribers</span>
+        </p>
+        <div class="f-w-600">{{ uniqueSubscribers | number: '1.0-0' }}</div>
+      </div>
+    </div>
+    <div class="col-6 col-lg-4 col-xxl-4">
+      <div class="overview-product-legends">
+        <p class="m-b-5">
+          <span>Subscription Types</span>
+        </p>
+        <div class="f-w-600">{{ totalSubscriptionTypes | number: '1.0-0' }}</div>
+      </div>
+    </div>
+  </div>
   <div class="row text-center">
-    @for (task of overView_product; track task) {
-      <div class="col-6 col-lg-4 col-xxl-4">
+    @if (breakdown.length > 0) {
+      @for (
+        item of breakdown;
+        track item.subscribeTypeId ?? item.typeName ?? $index;
+        let idx = $index
+      ) {
+        <div class="col-6 col-lg-4 col-xxl-4">
+          <div class="overview-product-legends" [ngStyle]="{ '--legend-color': getSliceColor(idx) }">
+            <p class="m-b-5">
+              <span>{{ item.typeName ?? 'Unknown' }}</span>
+            </p>
+            <div class="f-w-600">{{ (item.subscriberCount ?? 0) | number: '1.0-0' }}</div>
+            <div class="text-muted f-12">{{ (item.percentage ?? 0) | number: '1.0-2' }}%</div>
+          </div>
+        </div>
+      }
+    } @else {
+      <div class="col-12">
         <div class="overview-product-legends">
           <p class="m-b-5">
-            <span>{{ task.name }}</span>
+            <span>No subscriber data available</span>
           </p>
-          <div class="f-w-600">{{ task.value }}</div>
         </div>
       </div>
     }

--- a/src/app/demo/pages/apex-chart/overview-product-chart/overview-product-chart.component.scss
+++ b/src/app/demo/pages/apex-chart/overview-product-chart/overview-product-chart.component.scss
@@ -1,4 +1,5 @@
 .overview-product-legends {
+  --legend-color: var(--primary-500);
   border: 1px solid var(--accent-300);
   padding: 16px;
   margin-top: 16px;
@@ -18,7 +19,7 @@
       height: 6px;
       border-radius: 50%;
       transform: translate(-50%, -50%);
-      background: currentColor;
+      background: var(--legend-color);
       margin-left: -10px;
     }
 

--- a/src/app/demo/pages/apex-chart/overview-product-chart/overview-product-chart.component.ts
+++ b/src/app/demo/pages/apex-chart/overview-product-chart/overview-product-chart.component.ts
@@ -1,8 +1,16 @@
 // angular import
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
+import {
+  DashboardService,
+  SubscribeTypeBreakdownDto,
+  SubscribeTypeDistributionSliceDto,
+  SubscribeTypeStatisticsDto
+} from 'src/app/@theme/services/dashboard.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+import { ApiError } from 'src/app/@theme/services/lookup.service';
 
 // third party
 import { NgApexchartsModule, ApexOptions } from 'ng-apexcharts';
@@ -13,22 +21,145 @@ import { NgApexchartsModule, ApexOptions } from 'ng-apexcharts';
   templateUrl: './overview-product-chart.component.html',
   styleUrl: './overview-product-chart.component.scss'
 })
-export class OverviewProductChartComponent {
-  // public props
-  chartOptions: Partial<ApexOptions>;
+export class OverviewProductChartComponent implements OnInit {
+  private dashboardService = inject(DashboardService);
+  private toast = inject(ToastService);
 
-  // constructor
-  constructor() {
+  chartOptions: Partial<ApexOptions> = this.createBaseOptions();
+  breakdown: SubscribeTypeBreakdownDto[] = [];
+  totalSubscribers = 0;
+  uniqueSubscribers = 0;
+  totalSubscriptionTypes = 0;
+
+  readonly chartColors = ['var(--primary-500)', '#F97316', '#10B981', '#6366F1', '#F59E0B', '#EF4444'];
+
+  ngOnInit(): void {
+    this.loadSubscribeTypeStatistics();
+  }
+
+  getSliceColor(index: number): string {
+    const colors = (this.chartOptions.colors as string[] | undefined) ?? this.chartColors;
+    if (!colors || colors.length === 0) {
+      return this.chartColors[index % this.chartColors.length];
+    }
+    return colors[index % colors.length];
+  }
+
+  private loadSubscribeTypeStatistics(): void {
+    this.dashboardService.getSubscribeTypeStatistics().subscribe({
+      next: (response) => {
+        if (response.isSuccess && response.data) {
+          this.applyStatistics(response.data);
+        } else {
+          this.handleError(response.errors, 'Failed to load subscriber type statistics.');
+        }
+      },
+      error: () => this.handleError(undefined, 'Failed to load subscriber type statistics.')
+    });
+  }
+
+  private applyStatistics(data: SubscribeTypeStatisticsDto): void {
+    const slices = data.distribution?.slices ?? [];
+    const series = slices.map((slice) => slice.value ?? 0);
+    const labels = slices.map((slice, index) => this.resolveLabel(slice, index));
+
     this.chartOptions = {
+      ...this.chartOptions,
+      series,
+      labels,
+      colors: this.resolveColors(labels.length)
+    };
+
+    this.breakdown = this.combineBreakdown(data.breakdown, slices, data.totalSubscribers ?? data.distribution?.totalValue);
+    this.totalSubscribers = data.totalSubscribers ?? data.distribution?.totalValue ?? 0;
+    this.uniqueSubscribers = data.uniqueSubscribers ?? 0;
+    this.totalSubscriptionTypes = data.totalSubscriptionTypes ?? labels.length;
+  }
+
+  private combineBreakdown(
+    breakdown: SubscribeTypeBreakdownDto[] | undefined,
+    slices: SubscribeTypeDistributionSliceDto[],
+    total?: number
+  ): SubscribeTypeBreakdownDto[] {
+    if (slices.length === 0) {
+      return breakdown ?? [];
+    }
+
+    const map = new Map<string, SubscribeTypeBreakdownDto>();
+    (breakdown ?? []).forEach((item) => {
+      const key = (item.typeName ?? '').toLowerCase();
+      if (key) {
+        map.set(key, item);
+      }
+    });
+
+    const usedKeys = new Set<string>();
+    const combined = slices.map((slice, index) => {
+      const label = this.resolveLabel(slice, index);
+      const key = label.toLowerCase();
+      const matched = map.get(key);
+      usedKeys.add(key);
+      return {
+        subscribeTypeId: matched?.subscribeTypeId,
+        typeName: matched?.typeName ?? label,
+        subscriberCount: matched?.subscriberCount ?? slice.value ?? 0,
+        percentage: matched?.percentage ?? slice.percentage ?? this.calculatePercentage(slice.value ?? 0, total)
+      } satisfies SubscribeTypeBreakdownDto;
+    });
+
+    (breakdown ?? []).forEach((item) => {
+      const key = (item.typeName ?? '').toLowerCase();
+      if (!key || usedKeys.has(key)) {
+        return;
+      }
+      combined.push({
+        subscribeTypeId: item.subscribeTypeId,
+        typeName: item.typeName ?? this.toFallbackLabel(combined.length),
+        subscriberCount: item.subscriberCount ?? 0,
+        percentage: item.percentage ?? this.calculatePercentage(item.subscriberCount ?? 0, total)
+      });
+    });
+
+    return combined;
+  }
+
+  private resolveLabel(slice: SubscribeTypeDistributionSliceDto, index: number): string {
+    return slice.label && slice.label.trim().length > 0 ? slice.label : this.toFallbackLabel(index);
+  }
+
+  private toFallbackLabel(index: number): string {
+    return `Type ${index + 1}`;
+  }
+
+  private calculatePercentage(value: number, total?: number): number {
+    if (!total || total <= 0) {
+      return 0;
+    }
+    return (value / total) * 100;
+  }
+
+  private resolveColors(length: number): string[] {
+    if (length <= this.chartColors.length) {
+      return this.chartColors.slice(0, length);
+    }
+    const colors: string[] = [];
+    for (let index = 0; index < length; index += 1) {
+      colors.push(this.chartColors[index % this.chartColors.length]);
+    }
+    return colors;
+  }
+
+  private createBaseOptions(): Partial<ApexOptions> {
+    return {
       chart: {
         height: 350,
         type: 'pie'
       },
-      labels: ['Components', 'Widgets', 'Pages', 'Forms', 'Other', 'Apps'],
-      series: [40, 20, 10, 15, 5, 10],
-      colors: ['#4680FF', '#4680FF', '#212529', '#212529', '#212529', '#212529'],
+      labels: [],
+      series: [],
+      colors: this.chartColors,
       fill: {
-        opacity: [1, 1, 0.4, 0.6, 0.8, 1]
+        opacity: [1, 1, 0.8, 0.7, 0.6, 0.5]
       },
       legend: {
         show: false
@@ -55,31 +186,8 @@ export class OverviewProductChartComponent {
     };
   }
 
-  // public method
-  overView_product = [
-    {
-      name: 'Apps',
-      value: '10+'
-    },
-    {
-      name: 'Other',
-      value: '5+'
-    },
-    {
-      name: 'Widgets',
-      value: '150+'
-    },
-    {
-      name: 'Forms',
-      value: '50+'
-    },
-    {
-      name: 'Components',
-      value: '200+'
-    },
-    {
-      name: 'Pages',
-      value: '150+'
-    }
-  ];
+  private handleError(errors: ApiError[] | undefined, fallback: string): void {
+    const message = errors && errors.length > 0 ? errors.map((error) => error.message).join('\n') : fallback;
+    this.toast.error(message);
+  }
 }


### PR DESCRIPTION
## Summary
- add DTOs and service endpoint for subscriber type statistics
- load subscriber type data in the overview chart component with error handling
- render totals, breakdown, and color-coordinated legends for chart slices

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cabe2cdd1c8322af4100ab09b59e94