### PR TITLE
Handle subscribe statistics color palette

### DIFF
--- a/src/app/demo/pages/chart/apex-charts/apex-charts.component.ts
+++ b/src/app/demo/pages/chart/apex-charts/apex-charts.component.ts
@@ -36,6 +36,7 @@ export class ApexChartsComponent implements OnInit, OnDestroy {
   private readonly themeService: ThemeLayoutService = inject(ThemeLayoutService);
   private readonly dashboardService: DashboardService = inject(DashboardService);
   private readonly destroy$ = new Subject<void>();
+  private readonly defaultPiePalette = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F', '#FAAD14'];
 
   public barChart: Partial<ApexOptions> = {
     chart: {
@@ -258,8 +259,13 @@ export class ApexChartsComponent implements OnInit, OnDestroy {
     this.updateBreakdownColumns(breakdown);
     this.updateTotals(data);
   }
-  getDefaultPieColor(index: number): any {
-    throw new Error('Method not implemented.');
+  private getDefaultPieColor(index: number): string {
+    if (this.defaultPiePalette.length === 0) {
+      return '#CCCCCC';
+    }
+
+    const paletteIndex = index % this.defaultPiePalette.length;
+    return this.defaultPiePalette[paletteIndex];
   }
 
   private updateBreakdownColumns(breakdown: SubscriberTypeBreakdownDto[]): void {
@@ -318,14 +324,14 @@ export class ApexChartsComponent implements OnInit, OnDestroy {
   }
 
   private resetColorPalette(): void {
-    const defaultPalette = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F', '#FAAD14'];
+    const defaultPalette = this.defaultPiePalette;
 
-    this.preset = ['#0050B3', 'var(--primary-500)', '#52C41A'];
+    this.preset = defaultPalette.slice(0, 3);
     this.barChartColor = ['var(--primary-500)', '#52c41a', '#faad14', '#13c2c2'];
     this.bHorizontalColor = ['var(--primary-500)', '#52c41a'];
-    this.pie_color = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F', '#FAAD14'];
+    this.pie_color = [...defaultPalette];
     this.radialColor = ['var(--primary-500)'];
-    this.customs_color = ['#0050B3', 'var(--primary-500)', '#52C41A', '#FF4D4F'];
+    this.customs_color = defaultPalette.slice(0, 4);
   }
 
   // private methods


### PR DESCRIPTION
## Summary
- use the slice colors from the TypeStatistics payload and normalize fallbacks so the overview widget renders the new API contract
- provide a reusable default palette for the demo apex charts page to satisfy linting while keeping consistent fallback colors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbc89cd67c8322a8e1495d7f0255da