### PR TITLE
feat: add teacher salary management page

### DIFF
--- a/src/app/@theme/services/teacher-salary.service.ts
+++ b/src/app/@theme/services/teacher-salary.service.ts
@@ -1,0 +1,156 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface ApiError {
+  fieldName?: string;
+  code?: string;
+  message?: string;
+  fieldLang?: string | null;
+}
+
+export interface ApiResponse<T> {
+  isSuccess: boolean;
+  data: T;
+  errors: ApiError[];
+}
+
+export interface TeacherSalaryInvoice {
+  id: number;
+  teacherId?: number;
+  teacherName?: string;
+  month?: string;
+  salaryAmount?: number;
+  totalSalary?: number;
+  isPayed?: boolean;
+  payedAt?: string | null;
+  receiptUrl?: string | null;
+  receiptId?: number | null;
+  status?: string | null;
+  [key: string]: unknown;
+}
+
+export interface TeacherMonthlySummary {
+  month?: string;
+  teacherId?: number;
+  teacherName?: string;
+  attendanceCount?: number;
+  totalAttendance?: number;
+  attendedSessions?: number;
+  absenceCount?: number;
+  totalAbsence?: number;
+  missedSessions?: number;
+  teachingMinutes?: number;
+  totalMinutes?: number;
+  overtimeMinutes?: number;
+  sessionCount?: number;
+  lessonsCount?: number;
+  salaryTotal?: number;
+  totalSalary?: number;
+  baseSalary?: number;
+  bonusTotal?: number;
+  bonuses?: number;
+  totalBonus?: number;
+  deductionTotal?: number;
+  deductions?: number;
+  totalDeduction?: number;
+  netSalary?: number;
+  takeHomePay?: number;
+  hourlyRate?: number;
+  attendanceRate?: number;
+  invoice?: TeacherSalaryInvoice | null;
+  [key: string]: unknown;
+}
+
+export interface TeacherSalaryInvoiceDetails {
+  invoice: TeacherSalaryInvoice | null;
+  monthlySummary?: TeacherMonthlySummary | null;
+  [key: string]: unknown;
+}
+
+export interface UpdateInvoiceStatusRequest {
+  isPayed: boolean;
+  payedAt?: string | null;
+}
+
+export interface GenerateMonthlyResponse {
+  createdCount?: number;
+  updatedCount?: number;
+  skippedCount?: number;
+  [key: string]: unknown;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TeacherSalaryService {
+  private http = inject(HttpClient);
+
+  getInvoices(
+    month?: string | null,
+    teacherId?: number | null
+  ): Observable<ApiResponse<TeacherSalaryInvoice[]>> {
+    let params = new HttpParams();
+    if (month) {
+      params = params.set('month', month);
+    }
+    if (teacherId) {
+      params = params.set('teacherId', teacherId.toString());
+    }
+
+    return this.http.get<ApiResponse<TeacherSalaryInvoice[]>>(
+      `${environment.apiUrl}/api/TeacherSallary/Invoices`,
+      { params }
+    );
+  }
+
+  getInvoiceDetails(
+    invoiceId: number
+  ): Observable<ApiResponse<TeacherSalaryInvoiceDetails>> {
+    return this.http.get<ApiResponse<TeacherSalaryInvoiceDetails>>(
+      `${environment.apiUrl}/api/TeacherSallary/Invoice/${invoiceId}/Details`
+    );
+  }
+
+  updateInvoiceStatus(
+    invoiceId: number,
+    body: UpdateInvoiceStatusRequest
+  ): Observable<ApiResponse<TeacherSalaryInvoice | boolean | null>> {
+    return this.http.put<ApiResponse<TeacherSalaryInvoice | boolean | null>>(
+      `${environment.apiUrl}/api/TeacherSallary/Invoice/${invoiceId}/Status`,
+      body
+    );
+  }
+
+  getMonthlySummary(
+    month?: string | null,
+    teacherId?: number | null
+  ): Observable<ApiResponse<TeacherMonthlySummary | null>> {
+    let params = new HttpParams();
+    if (month) {
+      params = params.set('month', month);
+    }
+    if (teacherId) {
+      params = params.set('teacherId', teacherId.toString());
+    }
+
+    return this.http.get<ApiResponse<TeacherMonthlySummary | null>>(
+      `${environment.apiUrl}/api/TeacherSallary/MonthlySummary`,
+      { params }
+    );
+  }
+
+  generateMonthly(
+    month?: string | null
+  ): Observable<ApiResponse<GenerateMonthlyResponse | null>> {
+    let params = new HttpParams();
+    if (month) {
+      params = params.set('month', month);
+    }
+
+    return this.http.post<ApiResponse<GenerateMonthlyResponse | null>>(
+      `${environment.apiUrl}/api/TeacherSallary/GenerateMonthly`,
+      {},
+      { params }
+    );
+  }
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -75,6 +75,16 @@ const routes: Routes = [
         data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager] }
       },
       {
+        path: 'teacher-salary',
+        loadChildren: () =>
+          import('./demo/pages/admin-panel/teacher-salary/teacher-salary.module').then(
+            (m) => m.TeacherSalaryModule
+          ),
+        data: {
+          roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.Teacher]
+        }
+      },
+      {
         path: 'application',
         loadChildren: () => import('./demo/pages/application/application.module').then((m) => m.ApplicationModule),
         data: { roles: [UserTypesEnum.Admin, UserTypesEnum.Manager] }

--- a/src/app/demo/data/menu.ts
+++ b/src/app/demo/data/menu.ts
@@ -619,6 +619,18 @@ export const menus: Navigation[] = [
           //   ]
           // }
         ]
+      },
+      {
+        id: 'teacher-salary',
+        title: 'Teacher Salary',
+        type: 'item',
+        icon: '#custom-dollar-square',
+        url: '/teacher-salary',
+        role: [
+          UserTypesEnum.Admin.toString(),
+          UserTypesEnum.Manager.toString(),
+          UserTypesEnum.Teacher.toString()
+        ]
       }
     ]
   },

--- a/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary-routing.module.ts
+++ b/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+import { TeacherSalaryComponent } from './teacher-salary.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: TeacherSalaryComponent,
+    data: {
+      roles: [UserTypesEnum.Admin, UserTypesEnum.Manager, UserTypesEnum.Teacher]
+    }
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class TeacherSalaryRoutingModule {}

--- a/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.html
+++ b/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.html
@@ -1,0 +1,348 @@
+<mat-drawer-container class="teacher-salary-container">
+  <mat-drawer
+    #detailDrawer
+    class="teacher-salary-drawer"
+    mode="over"
+    position="end"
+    (closedStart)="onDrawerClosed()"
+  >
+    <div class="drawer-content">
+      <div class="drawer-header">
+        <div>
+          <h3 class="drawer-title">Invoice details</h3>
+          @if (selectedInvoice?.teacherName || detailSummary?.teacherName) {
+            <p class="drawer-subtitle">
+              {{ selectedInvoice?.teacherName ?? detailSummary?.teacherName }}
+            </p>
+          }
+        </div>
+        <button mat-icon-button type="button" (click)="closeDetails()">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+      <mat-divider></mat-divider>
+
+      @if (detailsLoading) {
+        <div class="drawer-loading">
+          <mat-progress-spinner diameter="40" mode="indeterminate"></mat-progress-spinner>
+        </div>
+      } @else if (invoiceDetails || selectedInvoice) {
+        <div class="drawer-section">
+          <h4>Invoice</h4>
+          <div class="detail-grid">
+            <div class="detail-item">
+              <span class="label">Month</span>
+              <span class="value">{{ formatMonth(selectedInvoice) }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="label">Salary</span>
+              <span class="value">{{ formatSalary(selectedInvoice) }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="label">Status</span>
+              <span class="value">{{ getStatusLabel(selectedInvoice) }}</span>
+            </div>
+            <div class="detail-item">
+              <span class="label">Paid at</span>
+              <span class="value">
+                @if (selectedInvoice?.payedAt) {
+                  {{ selectedInvoice?.payedAt | date: 'medium' }}
+                } @else {
+                  —
+                }
+              </span>
+            </div>
+            <div class="detail-item">
+              <span class="label">Receipt</span>
+              <span class="value">
+                @if (selectedInvoice && getReceiptUrl(selectedInvoice)) {
+                  <a
+                    [href]="getReceiptUrl(selectedInvoice)"
+                    target="_blank"
+                    rel="noopener"
+                  >
+                    View receipt
+                  </a>
+                } @else {
+                  —
+                }
+              </span>
+            </div>
+          </div>
+        </div>
+        <mat-divider></mat-divider>
+        <div class="drawer-section">
+          <div class="section-header">
+            <h4>Monthly summary</h4>
+          </div>
+          @if (detailSummaryMetrics.length > 0) {
+            <div class="summary-metrics">
+              @for (metric of detailSummaryMetrics; track metric.label) {
+                <div class="metric-card">
+                  <span class="metric-label">{{ metric.label }}</span>
+                  <span class="metric-value">{{ formatMetricValue(metric) }}</span>
+                </div>
+              }
+            </div>
+          } @else {
+            <p class="empty-state">No summary data available for this invoice.</p>
+          }
+        </div>
+      } @else {
+        <div class="drawer-empty">
+          <p>Select an invoice to view its details.</p>
+        </div>
+      }
+    </div>
+  </mat-drawer>
+
+  <mat-drawer-content>
+    <div class="page-header">
+      <div>
+        <h2 class="page-title">Teacher Salary</h2>
+        <p class="page-subtitle">
+          Review salary invoices, update payment status, and monitor monthly performance.
+        </p>
+      </div>
+      @if (canGenerateInvoices) {
+        <button
+          mat-flat-button
+          color="primary"
+          type="button"
+          (click)="onGenerateMonthly()"
+          [disabled]="manualGenerationLoading"
+        >
+          <mat-icon>cached</mat-icon>
+          Generate monthly invoices
+        </button>
+      }
+    </div>
+
+    @if (generationResult) {
+      <mat-card class="generation-card">
+        <div class="generation-content">
+          <div class="generation-title">Last generation summary</div>
+          <div class="generation-stats">
+            <span><strong>{{ generationResult?.createdCount ?? 0 }}</strong> created</span>
+            <span><strong>{{ generationResult?.updatedCount ?? 0 }}</strong> updated</span>
+            <span><strong>{{ generationResult?.skippedCount ?? 0 }}</strong> skipped</span>
+          </div>
+        </div>
+      </mat-card>
+    }
+
+    <mat-card class="filters-card">
+      <div class="filters-grid">
+        <mat-form-field appearance="outline">
+          <mat-label>Month</mat-label>
+          <input matInput [matDatepicker]="monthPicker" [formControl]="selectedMonth" />
+          <mat-datepicker-toggle matIconSuffix [for]="monthPicker"></mat-datepicker-toggle>
+          <mat-datepicker
+            #monthPicker
+            startView="multi-year"
+            (monthSelected)="setMonth($event, monthPicker)"
+            panelClass="month-picker"
+          ></mat-datepicker>
+        </mat-form-field>
+
+        @if (canManagePayments) {
+          <mat-form-field appearance="outline" class="teacher-select">
+            <mat-label>Teacher</mat-label>
+            <mat-select [formControl]="selectedTeacher" [disabled]="teacherLoading">
+              <mat-option [value]="null">All teachers</mat-option>
+              @for (teacher of teachers; track teacher.id) {
+                <mat-option [value]="teacher.id">{{ teacher.fullName }}</mat-option>
+              }
+            </mat-select>
+            @if (teacherLoading) {
+              <mat-progress-spinner
+                matSuffix
+                diameter="20"
+                mode="indeterminate"
+              ></mat-progress-spinner>
+            }
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="teacher-search">
+            <mat-label>Search teacher</mat-label>
+            <input
+              matInput
+              placeholder="Search by name or email"
+              [formControl]="teacherSearchControl"
+            />
+            @if (teacherSearchControl.value) {
+              <button
+                mat-icon-button
+                matSuffix
+                type="button"
+                (click)="clearTeacherSearch()"
+                [disabled]="teacherLoading"
+              >
+                <mat-icon>close</mat-icon>
+              </button>
+            }
+          </mat-form-field>
+
+          <button
+            mat-stroked-button
+            type="button"
+            class="refresh-button"
+            (click)="refreshTeachers()"
+            [disabled]="teacherLoading"
+          >
+            <mat-icon>refresh</mat-icon>
+            Refresh
+          </button>
+        } @else {
+          <div class="teacher-context">
+            <mat-icon>person</mat-icon>
+            <span>Showing salary information for your account.</span>
+          </div>
+        }
+
+        <button
+          mat-stroked-button
+          color="primary"
+          type="button"
+          class="reload-button"
+          (click)="reloadAll()"
+          [disabled]="invoicesLoading || summaryLoading"
+        >
+          <mat-icon>refresh</mat-icon>
+          Reload
+        </button>
+      </div>
+    </mat-card>
+
+    @if (invoicesLoading) {
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    }
+
+    <mat-card class="table-card">
+      <div class="table-container">
+        <table mat-table [dataSource]="dataSource" class="teacher-salary-table">
+          <ng-container matColumnDef="teacher">
+            <th mat-header-cell *matHeaderCellDef>Teacher</th>
+            <td mat-cell *matCellDef="let row">
+              <div class="cell-primary">{{ row.teacherName ?? '—' }}</div>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="month">
+            <th mat-header-cell *matHeaderCellDef>Month</th>
+            <td mat-cell *matCellDef="let row">{{ getMonthDisplay(row) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="salary">
+            <th mat-header-cell *matHeaderCellDef>Salary</th>
+            <td mat-cell *matCellDef="let row">{{ formatSalary(row) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="status">
+            <th mat-header-cell *matHeaderCellDef>Status</th>
+            <td mat-cell *matCellDef="let row">
+              <span
+                class="status-badge"
+                [class.status-paid]="isInvoicePaid(row)"
+                [class.status-unpaid]="!isInvoicePaid(row)"
+              >
+                <mat-icon>{{ isInvoicePaid(row) ? 'check_circle' : 'hourglass_bottom' }}</mat-icon>
+                {{ getStatusLabel(row) }}
+              </span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="paidAt">
+            <th mat-header-cell *matHeaderCellDef>Paid at</th>
+            <td mat-cell *matCellDef="let row">
+              @if (row.payedAt) {
+                {{ row.payedAt | date: 'medium' }}
+              } @else {
+                —
+              }
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="receipt">
+            <th mat-header-cell *matHeaderCellDef>Receipt</th>
+            <td mat-cell *matCellDef="let row">
+              @if (getReceiptUrl(row)) {
+                <a
+                  [href]="getReceiptUrl(row)"
+                  target="_blank"
+                  rel="noopener"
+                  (click)="$event.stopPropagation()"
+                >
+                  View
+                </a>
+              } @else {
+                —
+              }
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="toggle">
+            <th mat-header-cell *matHeaderCellDef class="toggle-header">Paid?</th>
+            <td mat-cell *matCellDef="let row" class="toggle-cell">
+              <mat-slide-toggle
+                color="primary"
+                [checked]="isInvoicePaid(row)"
+                [disabled]="isStatusUpdating(row.id)"
+                (click)="$event.stopPropagation()"
+                (change)="onTogglePaid($event, row)"
+              ></mat-slide-toggle>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr
+            mat-row
+            *matRowDef="let row; columns: displayedColumns"
+            (click)="openInvoice(row)"
+            [class.is-selected]="selectedInvoice?.id === row.id"
+          ></tr>
+        </table>
+      </div>
+      <mat-paginator [pageSize]="10" [pageSizeOptions]="[5, 10, 25, 50]" showFirstLastButtons></mat-paginator>
+      @if (!invoicesLoading && dataSource.data.length === 0) {
+        <div class="empty-state">No invoices found for the selected filters.</div>
+      }
+    </mat-card>
+
+    <mat-card class="summary-card">
+      <div class="summary-header">
+        <div>
+          <h3>Monthly summary</h3>
+          <p class="summary-subtitle">
+            Attendance and salary overview for
+            <strong>{{ formatSummaryMonth() }}</strong>.
+          </p>
+        </div>
+        <button
+          mat-icon-button
+          type="button"
+          (click)="loadMonthlySummary()"
+          [disabled]="summaryLoading"
+        >
+          <mat-icon>refresh</mat-icon>
+        </button>
+      </div>
+      @if (summaryLoading) {
+        <div class="summary-loading">
+          <mat-progress-spinner diameter="40" mode="indeterminate"></mat-progress-spinner>
+        </div>
+      } @else if (summaryMetrics.length > 0) {
+        <div class="summary-grid">
+          @for (metric of summaryMetrics; track metric.label) {
+            <div class="summary-card-item">
+              <span class="metric-label">{{ metric.label }}</span>
+              <span class="metric-value">{{ formatMetricValue(metric) }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="empty-state">No summary data available for this month.</div>
+      }
+    </mat-card>
+  </mat-drawer-content>
+</mat-drawer-container>

--- a/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.scss
+++ b/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.scss
@@ -1,0 +1,315 @@
+.teacher-salary-container {
+  height: 100%;
+  min-height: 600px;
+}
+
+.teacher-salary-drawer {
+  width: min(420px, 100vw);
+  max-width: 420px;
+  padding: 0;
+}
+
+.drawer-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.drawer-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.drawer-subtitle {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 0.875rem;
+}
+
+.drawer-loading,
+.drawer-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.drawer-section {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.detail-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.detail-item .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.detail-item .value {
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.87);
+  word-break: break-word;
+}
+
+.summary-metrics {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.metric-card {
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(63, 81, 181, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.metric-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.metric-value {
+  font-weight: 600;
+  font-size: 1rem;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.page-title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.page-subtitle {
+  margin: 0.25rem 0 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.filters-card {
+  margin-bottom: 1.5rem;
+}
+
+.filters-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.teacher-select,
+.teacher-search {
+  min-width: 220px;
+}
+
+.teacher-context {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(0, 0, 0, 0.6);
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background-color: rgba(63, 81, 181, 0.08);
+}
+
+.refresh-button,
+.reload-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.table-card {
+  margin-bottom: 1.5rem;
+  overflow: hidden;
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+.teacher-salary-table {
+  width: 100%;
+  min-width: 720px;
+}
+
+.teacher-salary-table .cell-primary {
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  background-color: rgba(158, 158, 158, 0.15);
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.status-badge mat-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.status-badge.status-paid {
+  background-color: rgba(46, 125, 50, 0.15);
+  color: #2e7d32;
+}
+
+.status-badge.status-unpaid {
+  background-color: rgba(229, 57, 53, 0.12);
+  color: #c62828;
+}
+
+.toggle-header,
+.toggle-cell {
+  text-align: center;
+}
+
+.toggle-cell mat-slide-toggle {
+  pointer-events: auto;
+}
+
+.teacher-salary-table tr.mat-row {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.teacher-salary-table tr.mat-row:hover {
+  background-color: rgba(63, 81, 181, 0.08);
+}
+
+.teacher-salary-table tr.mat-row.is-selected {
+  background-color: rgba(63, 81, 181, 0.12);
+}
+
+.empty-state {
+  padding: 1.5rem;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.summary-subtitle {
+  margin: 0.25rem 0 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.summary-loading {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 0;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.summary-card-item {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(63, 81, 181, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.generation-card {
+  margin-bottom: 1.5rem;
+}
+
+.generation-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.generation-title {
+  font-weight: 600;
+}
+
+.generation-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+@media (max-width: 768px) {
+  .teacher-salary-table {
+    min-width: 100%;
+  }
+
+  .filters-grid {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .refresh-button,
+  .reload-button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.ts
+++ b/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.ts
@@ -1,0 +1,786 @@
+import {
+  AfterViewInit,
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  inject
+} from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatDrawer } from '@angular/material/sidenav';
+import { MatDatepicker } from '@angular/material/datepicker';
+import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+  MAT_DATE_LOCALE
+} from '@angular/material/core';
+import {
+  MomentDateAdapter,
+  MAT_MOMENT_DATE_ADAPTER_OPTIONS
+} from '@angular/material-moment-adapter';
+import moment, { Moment } from 'moment';
+import { MatSlideToggleChange } from '@angular/material/slide-toggle';
+import { Subscription } from 'rxjs';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  finalize
+} from 'rxjs/operators';
+
+import {
+  TeacherSalaryService,
+  TeacherSalaryInvoice,
+  TeacherMonthlySummary,
+  TeacherSalaryInvoiceDetails,
+  ApiError,
+  GenerateMonthlyResponse
+} from 'src/app/@theme/services/teacher-salary.service';
+import { ToastService } from 'src/app/@theme/services/toast.service';
+import {
+  LookupService,
+  LookUpUserDto,
+  FilteredResultRequestDto
+} from 'src/app/@theme/services/lookup.service';
+import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
+import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+
+export const MONTH_FORMATS = {
+  parse: { dateInput: 'MMMM YYYY' },
+  display: {
+    dateInput: 'MMMM YYYY',
+    monthYearLabel: 'MMM YYYY',
+    dateA11yLabel: 'LL',
+    monthYearA11yLabel: 'MMMM YYYY'
+  }
+};
+
+interface SummaryMetric {
+  label: string;
+  value: number | string;
+  type: 'number' | 'currency' | 'percentage' | 'text';
+  suffix?: string;
+}
+
+@Component({
+  selector: 'app-teacher-salary',
+  templateUrl: './teacher-salary.component.html',
+  styleUrls: ['./teacher-salary.component.scss'],
+  providers: [
+    {
+      provide: DateAdapter,
+      useClass: MomentDateAdapter,
+      deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS]
+    },
+    { provide: MAT_DATE_FORMATS, useValue: MONTH_FORMATS }
+  ]
+})
+export class TeacherSalaryComponent
+  implements OnInit, AfterViewInit, OnDestroy
+{
+  private teacherSalaryService = inject(TeacherSalaryService);
+  private toastService = inject(ToastService);
+  private lookupService = inject(LookupService);
+  private authenticationService = inject(AuthenticationService);
+
+  private subscriptions = new Subscription();
+  private readonly numberFormatter = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 0
+  });
+  private readonly percentFormatter = new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2
+  });
+  private readonly currencyFormatter = new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+
+  readonly selectedMonth = new FormControl<Moment>(
+    moment().startOf('month').subtract(1, 'month').utc(true)
+  );
+  readonly selectedTeacher = new FormControl<number | null>(null);
+  readonly teacherSearchControl = new FormControl<string>('');
+
+  readonly dataSource = new MatTableDataSource<TeacherSalaryInvoice>([]);
+  displayedColumns: string[] = [];
+
+  teachers: LookUpUserDto[] = [];
+  teacherLoading = false;
+
+  invoicesLoading = false;
+  summaryLoading = false;
+  detailsLoading = false;
+  manualGenerationLoading = false;
+
+  selectedInvoice: TeacherSalaryInvoice | null = null;
+  invoiceDetails: TeacherSalaryInvoiceDetails | null = null;
+  detailSummary: TeacherMonthlySummary | null = null;
+  summary: TeacherMonthlySummary | null = null;
+
+  summaryMetrics: SummaryMetric[] = [];
+  detailSummaryMetrics: SummaryMetric[] = [];
+
+  generationResult: GenerateMonthlyResponse | null = null;
+
+  private readonly updatingStatusIds = new Set<number>();
+  private readonly role = this.authenticationService.getRole();
+  readonly canManagePayments =
+    this.role === UserTypesEnum.Admin || this.role === UserTypesEnum.Manager;
+  readonly canGenerateInvoices = this.role === UserTypesEnum.Admin;
+  readonly isTeacher = this.role === UserTypesEnum.Teacher;
+
+  @ViewChild(MatPaginator) paginator?: MatPaginator;
+  @ViewChild('detailDrawer') detailDrawer?: MatDrawer;
+
+  ngOnInit(): void {
+    this.updateDisplayedColumns();
+    if (this.canManagePayments) {
+      this.loadTeachers();
+      this.subscriptions.add(
+        this.teacherSearchControl.valueChanges
+          .pipe(debounceTime(300), distinctUntilChanged())
+          .subscribe((value) => {
+            this.loadTeachers(value ?? '');
+          })
+      );
+    }
+
+    this.subscriptions.add(
+      this.selectedTeacher.valueChanges
+        .pipe(distinctUntilChanged())
+        .subscribe(() => {
+          this.resetPaginator();
+          this.loadInvoices();
+          this.loadMonthlySummary();
+        })
+    );
+
+    this.loadInvoices();
+    this.loadMonthlySummary();
+  }
+
+  ngAfterViewInit(): void {
+    if (this.paginator) {
+      this.dataSource.paginator = this.paginator;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+    this.updatingStatusIds.clear();
+  }
+
+  setMonth(normalizedMonthAndYear: Moment, datepicker: MatDatepicker<Moment>): void {
+    const normalized = normalizedMonthAndYear
+      .clone()
+      .startOf('month')
+      .utc(true);
+    this.selectedMonth.setValue(normalized);
+    datepicker.close();
+    this.resetPaginator();
+    this.loadInvoices();
+    this.loadMonthlySummary();
+  }
+
+  reloadAll(): void {
+    this.loadInvoices();
+    this.loadMonthlySummary();
+  }
+
+  refreshTeachers(): void {
+    if (this.canManagePayments) {
+      this.loadTeachers(this.teacherSearchControl.value ?? '');
+    }
+  }
+
+  clearTeacherSearch(): void {
+    if (this.canManagePayments) {
+      this.teacherSearchControl.setValue('', { emitEvent: false });
+      this.loadTeachers('');
+    }
+  }
+
+  openInvoice(invoice: TeacherSalaryInvoice): void {
+    if (!invoice) {
+      return;
+    }
+    this.selectedInvoice = invoice;
+    this.loadInvoiceDetails(invoice.id);
+  }
+
+  closeDetails(): void {
+    this.selectedInvoice = null;
+    this.invoiceDetails = null;
+    this.detailSummary = null;
+    this.detailSummaryMetrics = [];
+    this.detailDrawer?.close();
+  }
+
+  onDrawerClosed(): void {
+    this.selectedInvoice = null;
+    this.invoiceDetails = null;
+    this.detailSummary = null;
+    this.detailSummaryMetrics = [];
+  }
+
+  onTogglePaid(
+    event: MatSlideToggleChange,
+    invoice: TeacherSalaryInvoice
+  ): void {
+    event.source.checked = event.checked;
+    const invoiceId = invoice.id;
+    const newValue = event.checked;
+    const payload = {
+      isPayed: newValue,
+      payedAt: newValue ? undefined : null
+    };
+    this.updatingStatusIds.add(invoiceId);
+
+    this.teacherSalaryService
+      .updateInvoiceStatus(invoiceId, payload)
+      .pipe(
+        finalize(() => {
+          this.updatingStatusIds.delete(invoiceId);
+        })
+      )
+      .subscribe({
+        next: (response) => {
+          if (response.isSuccess) {
+            this.toastService.success(
+              `Invoice marked as ${newValue ? 'paid' : 'unpaid'}.`
+            );
+            this.loadInvoices();
+            if (this.selectedInvoice?.id === invoiceId) {
+              this.loadInvoiceDetails(invoiceId, false);
+            }
+          } else {
+            event.source.checked = !newValue;
+            this.handleErrors(
+              response.errors,
+              'Failed to update invoice payment status.'
+            );
+          }
+        },
+        error: () => {
+          event.source.checked = !newValue;
+          this.toastService.error('Failed to update invoice payment status.');
+        }
+      });
+  }
+
+  isStatusUpdating(invoiceId: number): boolean {
+    return this.updatingStatusIds.has(invoiceId);
+  }
+
+  onGenerateMonthly(): void {
+    if (this.manualGenerationLoading) {
+      return;
+    }
+    const monthParam = this.toMonthParam(this.selectedMonth.value);
+    this.manualGenerationLoading = true;
+    this.teacherSalaryService
+      .generateMonthly(monthParam)
+      .pipe(finalize(() => (this.manualGenerationLoading = false)))
+      .subscribe({
+        next: (response) => {
+          if (response.isSuccess) {
+            this.generationResult = response.data ?? null;
+            const created = this.generationResult?.createdCount ?? 0;
+            const updated = this.generationResult?.updatedCount ?? 0;
+            const skipped = this.generationResult?.skippedCount ?? 0;
+            this.toastService.success(
+              `Generation complete. Created ${created}, updated ${updated}, skipped ${skipped}.`
+            );
+            this.loadInvoices();
+            this.loadMonthlySummary();
+          } else {
+            this.handleErrors(
+              response.errors,
+              'Failed to generate monthly invoices.'
+            );
+          }
+        },
+        error: () => {
+          this.toastService.error('Failed to generate monthly invoices.');
+        }
+      });
+  }
+
+  formatMonth(invoice: TeacherSalaryInvoice | null): string {
+    if (!invoice) {
+      return '—';
+    }
+    return this.formatMonthString(this.extractMonthValue(invoice));
+  }
+
+  formatSummaryMonth(): string {
+    const summaryMonth = this.summary?.month;
+    if (summaryMonth) {
+      return this.formatMonthString(summaryMonth);
+    }
+    const selected = this.selectedMonth.value;
+    return selected ? this.formatMonthString(selected.toISOString()) : '—';
+  }
+
+  formatSalary(invoice: TeacherSalaryInvoice | null): string {
+    const amount = this.getSalaryAmount(invoice);
+    return this.formatCurrency(amount);
+  }
+
+  formatCurrency(value: number | null | undefined): string {
+    if (value === null || value === undefined || Number.isNaN(value)) {
+      return '—';
+    }
+    try {
+      return this.currencyFormatter.format(value);
+    } catch {
+      return value.toFixed(2);
+    }
+  }
+
+  formatMetricValue(metric: SummaryMetric): string {
+    if (metric.value === null || metric.value === undefined || metric.value === '') {
+      return '—';
+    }
+    if (metric.type === 'currency') {
+      const num = this.coerceNumber(metric.value);
+      return num !== null ? this.formatCurrency(num) : String(metric.value);
+    }
+    if (metric.type === 'number') {
+      const num = this.coerceNumber(metric.value);
+      if (num !== null) {
+        const formatted = this.numberFormatter.format(num);
+        return metric.suffix ? `${formatted} ${metric.suffix}` : formatted;
+      }
+      return String(metric.value);
+    }
+    if (metric.type === 'percentage') {
+      const num = this.coerceNumber(metric.value);
+      if (num !== null) {
+        const percent = Math.abs(num) <= 1 ? num * 100 : num;
+        return `${this.percentFormatter.format(percent)}%`;
+      }
+      return String(metric.value);
+    }
+    return String(metric.value);
+  }
+
+  getStatusLabel(invoice: TeacherSalaryInvoice | null): string {
+    if (!invoice) {
+      return 'Unpaid';
+    }
+    const statusCandidates: unknown[] = [
+      invoice.status,
+      (invoice as Record<string, unknown>)['paymentStatus'],
+      this.isInvoicePaid(invoice) ? 'Paid' : 'Unpaid'
+    ];
+    for (const candidate of statusCandidates) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate;
+      }
+    }
+    return this.isInvoicePaid(invoice) ? 'Paid' : 'Unpaid';
+  }
+
+  isInvoicePaid(invoice: TeacherSalaryInvoice | null): boolean {
+    if (!invoice) {
+      return false;
+    }
+    const candidateValues: unknown[] = [
+      invoice.isPayed,
+      (invoice as Record<string, unknown>)['isPaid'],
+      (invoice as Record<string, unknown>)['paid']
+    ];
+    for (const candidate of candidateValues) {
+      if (typeof candidate === 'boolean') {
+        return candidate;
+      }
+      if (typeof candidate === 'string') {
+        const normalized = candidate.toLowerCase();
+        if (normalized === 'paid' || normalized === 'true') {
+          return true;
+        }
+        if (normalized === 'unpaid' || normalized === 'false') {
+          return false;
+        }
+      }
+    }
+    const statusString =
+      typeof invoice.status === 'string'
+        ? invoice.status.toLowerCase()
+        : typeof (invoice as Record<string, unknown>)['paymentStatus'] === 'string'
+        ? String((invoice as Record<string, unknown>)['paymentStatus']).toLowerCase()
+        : undefined;
+    if (statusString) {
+      if (statusString.includes('paid') && !statusString.includes('un')) {
+        return true;
+      }
+      if (statusString.includes('unpaid')) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  getReceiptUrl(invoice: TeacherSalaryInvoice): string | null {
+    const candidates: unknown[] = [
+      invoice.receiptUrl,
+      (invoice as Record<string, unknown>)['receiptLink'],
+      (invoice as Record<string, unknown>)['receipt'],
+      (invoice as Record<string, unknown>)['receiptUrl']
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  getMonthDisplay(invoice: TeacherSalaryInvoice): string {
+    return this.formatMonth(invoice);
+  }
+
+  handleRowKey(index: number, invoice: TeacherSalaryInvoice): number {
+    return invoice.id ?? index;
+  }
+
+  private loadTeachers(searchTerm?: string): void {
+    if (!this.canManagePayments) {
+      return;
+    }
+    const filter: FilteredResultRequestDto = {
+      skipCount: 0,
+      maxResultCount: 50,
+      searchTerm: searchTerm?.trim() ?? undefined
+    };
+    this.teacherLoading = true;
+    this.lookupService
+      .getUsersForSelects(
+        filter,
+        Number(UserTypesEnum.Teacher),
+        0,
+        0,
+        0
+      )
+      .pipe(finalize(() => (this.teacherLoading = false)))
+      .subscribe({
+        next: (response) => {
+          if (response.isSuccess) {
+            this.teachers = response.data?.items ?? [];
+          } else {
+            this.teachers = [];
+            this.handleErrors(response.errors, 'Failed to load teachers.');
+          }
+        },
+        error: () => {
+          this.teachers = [];
+          this.toastService.error('Failed to load teachers.');
+        }
+      });
+  }
+
+  private loadInvoices(): void {
+    const monthParam = this.toMonthParam(this.selectedMonth.value);
+    const teacherId = this.canManagePayments ? this.selectedTeacher.value : null;
+    this.invoicesLoading = true;
+    this.teacherSalaryService
+      .getInvoices(monthParam, teacherId ?? null)
+      .pipe(finalize(() => (this.invoicesLoading = false)))
+      .subscribe({
+        next: (response) => {
+          if (response.isSuccess) {
+            const invoices = Array.isArray(response.data)
+              ? response.data
+              : [];
+            this.applyInvoices(invoices);
+          } else {
+            this.applyInvoices([]);
+            this.handleErrors(
+              response.errors,
+              'Failed to load teacher salary invoices.'
+            );
+          }
+        },
+        error: () => {
+          this.applyInvoices([]);
+          this.toastService.error('Failed to load teacher salary invoices.');
+        }
+      });
+  }
+
+  private loadMonthlySummary(): void {
+    const monthParam = this.toMonthParam(this.selectedMonth.value);
+    const teacherId = this.canManagePayments ? this.selectedTeacher.value : null;
+    this.summaryLoading = true;
+    this.teacherSalaryService
+      .getMonthlySummary(monthParam, teacherId ?? null)
+      .pipe(finalize(() => (this.summaryLoading = false)))
+      .subscribe({
+        next: (response) => {
+          if (response.isSuccess) {
+            this.summary = response.data ?? null;
+            this.summaryMetrics = this.buildSummaryMetrics(this.summary);
+          } else {
+            this.summary = null;
+            this.summaryMetrics = [];
+            this.handleErrors(
+              response.errors,
+              'Failed to load teacher monthly summary.'
+            );
+          }
+        },
+        error: () => {
+          this.summary = null;
+          this.summaryMetrics = [];
+          this.toastService.error('Failed to load teacher monthly summary.');
+        }
+      });
+  }
+
+  private loadInvoiceDetails(invoiceId: number, openDrawer = true): void {
+    this.detailsLoading = true;
+    this.teacherSalaryService
+      .getInvoiceDetails(invoiceId)
+      .pipe(finalize(() => (this.detailsLoading = false)))
+      .subscribe({
+        next: (response) => {
+          if (response.isSuccess) {
+            this.invoiceDetails = response.data;
+            this.detailSummary = response.data?.monthlySummary ?? null;
+            const invoiceCandidate =
+              this.detailSummary?.invoice ?? response.data?.invoice ?? this.selectedInvoice;
+            this.selectedInvoice = this.findInvoiceById(invoiceId) ?? invoiceCandidate ?? null;
+            this.detailSummaryMetrics = this.buildSummaryMetrics(this.detailSummary);
+            if (openDrawer) {
+              setTimeout(() => this.detailDrawer?.open(), 0);
+            }
+          } else {
+            this.handleErrors(response.errors, 'Failed to load invoice details.');
+          }
+        },
+        error: () => {
+          this.toastService.error('Failed to load invoice details.');
+        }
+      });
+  }
+
+  private updateDisplayedColumns(): void {
+    const baseColumns = ['teacher', 'month', 'salary', 'status', 'paidAt', 'receipt'];
+    this.displayedColumns = this.canManagePayments
+      ? [...baseColumns, 'toggle']
+      : baseColumns;
+  }
+
+  private resetPaginator(): void {
+    if (this.paginator) {
+      this.paginator.firstPage();
+    }
+  }
+
+  private toMonthParam(month: Moment | null): string | null {
+    if (!month) {
+      return null;
+    }
+    return month.clone().startOf('month').utc(true).format('YYYY-MM-DD');
+  }
+
+  private applyInvoices(invoices: TeacherSalaryInvoice[]): void {
+    const sorted = [...invoices].sort((a, b) => this.compareByMonthDesc(a, b));
+    this.dataSource.data = sorted;
+    if (this.paginator) {
+      this.dataSource.paginator = this.paginator;
+    }
+    if (this.selectedInvoice) {
+      const updated = sorted.find((invoice) => invoice.id === this.selectedInvoice?.id);
+      if (updated) {
+        this.selectedInvoice = updated;
+      } else {
+        this.closeDetails();
+      }
+    }
+  }
+
+  private compareByMonthDesc(
+    a: TeacherSalaryInvoice,
+    b: TeacherSalaryInvoice
+  ): number {
+    const aTime = this.resolveInvoiceTime(a);
+    const bTime = this.resolveInvoiceTime(b);
+    if (bTime !== aTime) {
+      return bTime - aTime;
+    }
+    return (b.id ?? 0) - (a.id ?? 0);
+  }
+
+  private resolveInvoiceTime(invoice: TeacherSalaryInvoice): number {
+    const monthValue = this.extractMonthValue(invoice);
+    if (monthValue) {
+      const parsed = new Date(monthValue);
+      if (!Number.isNaN(parsed.getTime())) {
+        return parsed.getTime();
+      }
+    }
+    const fallbackCandidates: unknown[] = [
+      invoice.payedAt,
+      (invoice as Record<string, unknown>)['createdAt'],
+      (invoice as Record<string, unknown>)['invoiceDate'],
+      (invoice as Record<string, unknown>)['updatedAt']
+    ];
+    for (const candidate of fallbackCandidates) {
+      if (candidate instanceof Date) {
+        return candidate.getTime();
+      }
+      if (typeof candidate === 'string') {
+        const parsed = new Date(candidate);
+        if (!Number.isNaN(parsed.getTime())) {
+          return parsed.getTime();
+        }
+      }
+    }
+    return invoice.id ?? 0;
+  }
+
+  private extractMonthValue(invoice: TeacherSalaryInvoice): string | undefined {
+    const candidates: unknown[] = [
+      invoice.month,
+      (invoice as Record<string, unknown>)['monthDate'],
+      (invoice as Record<string, unknown>)['monthValue'],
+      (invoice as Record<string, unknown>)['monthStart'],
+      (invoice as Record<string, unknown>)['period'],
+      (invoice as Record<string, unknown>)['month'],
+      (invoice as Record<string, unknown>)['monthUtc']
+    ];
+    for (const candidate of candidates) {
+      if (candidate instanceof Date) {
+        return candidate.toISOString();
+      }
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate;
+      }
+    }
+    return undefined;
+  }
+
+  private formatMonthString(value?: string | null): string {
+    if (!value) {
+      return '—';
+    }
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return new Intl.DateTimeFormat(undefined, {
+        month: 'long',
+        year: 'numeric'
+      }).format(parsed);
+    }
+    return value;
+  }
+
+  private getSalaryAmount(invoice: TeacherSalaryInvoice | null): number | null {
+    if (!invoice) {
+      return null;
+    }
+    const fields = [
+      'salaryAmount',
+      'totalSalary',
+      'salaryTotal',
+      'netSalary',
+      'amount'
+    ];
+    for (const field of fields) {
+      const raw = (invoice as Record<string, unknown>)[field];
+      const numeric = this.coerceNumber(raw);
+      if (numeric !== null) {
+        return numeric;
+      }
+    }
+    return null;
+  }
+
+  private buildSummaryMetrics(
+    summary: TeacherMonthlySummary | null
+  ): SummaryMetric[] {
+    if (!summary) {
+      return [];
+    }
+    const metrics: SummaryMetric[] = [];
+    const addMetric = (
+      label: string,
+      keys: string[],
+      type: SummaryMetric['type'],
+      suffix?: string
+    ) => {
+      for (const key of keys) {
+        const raw = (summary as Record<string, unknown>)[key];
+        if (raw === null || raw === undefined || raw === '') {
+          continue;
+        }
+        if (type === 'currency' || type === 'number' || type === 'percentage') {
+          const numeric = this.coerceNumber(raw);
+          if (numeric !== null) {
+            metrics.push({ label, value: numeric, type, suffix });
+            return;
+          }
+        }
+        if (typeof raw === 'string' && raw.trim().length > 0) {
+          metrics.push({ label, value: raw, type: 'text', suffix });
+          return;
+        }
+      }
+    };
+
+    addMetric('Attendance', ['attendanceCount', 'totalAttendance', 'attendedSessions'], 'number');
+    addMetric('Absence', ['absenceCount', 'totalAbsence', 'missedSessions'], 'number');
+    addMetric('Sessions', ['sessionCount', 'lessonsCount'], 'number');
+    addMetric('Teaching Minutes', ['teachingMinutes', 'totalMinutes'], 'number', 'min');
+    addMetric('Overtime Minutes', ['overtimeMinutes'], 'number', 'min');
+    addMetric('Base Salary', ['baseSalary'], 'currency');
+    addMetric('Salary Total', ['salaryTotal', 'totalSalary'], 'currency');
+    addMetric('Bonuses', ['bonusTotal', 'bonuses', 'totalBonus'], 'currency');
+    addMetric('Deductions', ['deductionTotal', 'deductions', 'totalDeduction'], 'currency');
+    addMetric('Net Salary', ['netSalary', 'takeHomePay'], 'currency');
+    addMetric('Hourly Rate', ['hourlyRate'], 'currency');
+    addMetric('Attendance Rate', ['attendanceRate'], 'percentage');
+
+    return metrics;
+  }
+
+  private coerceNumber(value: unknown): number | null {
+    if (typeof value === 'number' && !Number.isNaN(value)) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        return null;
+      }
+      const parsed = Number(trimmed);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return null;
+  }
+
+  private handleErrors(errors: ApiError[] | undefined, fallback: string): void {
+    if (errors && errors.length > 0) {
+      const message = errors
+        .map((error) => error.message || error.code)
+        .filter((msg): msg is string => !!msg && msg.trim().length > 0)
+        .join(' \u2022 ');
+      if (message.length > 0) {
+        this.toastService.error(message);
+        return;
+      }
+    }
+    this.toastService.error(fallback);
+  }
+
+  private findInvoiceById(id: number): TeacherSalaryInvoice | null {
+    return this.dataSource.data.find((invoice) => invoice.id === id) ?? null;
+  }
+}

--- a/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.module.ts
+++ b/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { SharedModule } from 'src/app/demo/shared/shared.module';
+import { TeacherSalaryRoutingModule } from './teacher-salary-routing.module';
+import { TeacherSalaryComponent } from './teacher-salary.component';
+
+@NgModule({
+  declarations: [TeacherSalaryComponent],
+  imports: [CommonModule, SharedModule, TeacherSalaryRoutingModule]
+})
+export class TeacherSalaryModule {}


### PR DESCRIPTION
## Summary
- add a dedicated `TeacherSalaryService` for invoice, summary, status update, and generation APIs
- build a teacher salary management UI with filtering, payment toggles, detail drawer, and monthly summary widgets
- expose the new page to admins, managers, and teachers via routing and navigation updates

## Testing
- `npm run lint` *(fails: existing lint errors in apex chart files)*
- `npx eslint src/app/@theme/services/teacher-salary.service.ts src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ce7edd59ac8322b7396c8f283eefa5