### PR TITLE
Attach generated receipt PDFs when updating payments

### DIFF
--- a/src/app/@theme/services/student-payment.service.ts
+++ b/src/app/@theme/services/student-payment.service.ts
@@ -77,6 +77,14 @@ export class StudentPaymentService {
     );
   }
 
+  downloadPaymentReceipt(paymentId: number): Observable<Blob> {
+    const params = new HttpParams().set('paymentId', paymentId.toString());
+    return this.http.get(`${environment.apiUrl}/api/StudentPayment/GetPaymentReceipt`, {
+      params,
+      responseType: 'blob'
+    });
+  }
+
   updatePayment(
     model: UpdatePaymentDto,
     receipt?: File


### PR DESCRIPTION
## Summary
- add StudentPaymentService.downloadPaymentReceipt to call `/api/StudentPayment/GetPaymentReceipt` and retrieve receipt PDFs for updates
- refactor the payment edit dialog to fetch the generated receipt automatically when toggling payment status and submit it with the update request

## Testing
- npm run lint *(fails: existing lint violations in src/app/demo/pages/chart/apex-charts/apex-charts.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cfaba553748322b62e492381e6275b