### PR TITLE
Add PDF upload flow to teacher salary management

### DIFF
--- a/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.html
+++ b/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.html
@@ -281,6 +281,33 @@
             </td>
           </ng-container>
 
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef class="actions-header">
+              Invoice
+            </th>
+            <td mat-cell *matCellDef="let row" class="actions-cell">
+              <button
+                mat-icon-button
+                type="button"
+                color="primary"
+                class="action-button"
+                matTooltip="Generate & upload invoice PDF"
+                aria-label="Generate invoice PDF"
+                (click)="onGenerateInvoiceReceipt($event, row)"
+                (mousedown)="$event.preventDefault()"
+                [disabled]="
+                  !canGenerateInvoices || !isInvoicePaid(row) || isReceiptUploading(row.id)
+                "
+              >
+                @if (isReceiptUploading(row.id)) {
+                  <mat-icon class="spin">autorenew</mat-icon>
+                } @else {
+                  <mat-icon>picture_as_pdf</mat-icon>
+                }
+              </button>
+            </td>
+          </ng-container>
+
           <ng-container matColumnDef="toggle">
             <th mat-header-cell *matHeaderCellDef class="toggle-header">Paid?</th>
             <td mat-cell *matCellDef="let row" class="toggle-cell">

--- a/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.scss
+++ b/src/app/demo/pages/admin-panel/teacher-salary/teacher-salary.component.scss
@@ -210,12 +210,39 @@
 }
 
 .toggle-header,
-.toggle-cell {
+.toggle-cell,
+.actions-header,
+.actions-cell {
   text-align: center;
 }
 
 .toggle-cell mat-slide-toggle {
   pointer-events: auto;
+}
+
+.actions-cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.action-button {
+  --button-size: 36px;
+  width: var(--button-size);
+  height: var(--button-size);
+}
+
+.action-button .spin {
+  animation: invoice-spin 0.9s linear infinite;
+}
+
+@keyframes invoice-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .teacher-salary-table tr.mat-row {


### PR DESCRIPTION
## Summary
- update the teacher salary service to use the new `/admin/teacher-salary` endpoints and expose an API for uploading generated receipts
- extend the teacher salary component with a PDF-generation pipeline, upload handling, and state tracking for newly generated receipts
- surface an invoice action column with a PDF icon button, tooltip, and styling so paid rows can trigger generation and upload from the UI

## Testing
- `npm run lint` *(fails: existing lint errors in src/app/demo/pages/chart/apex-charts/apex-charts.component.ts)*
- `npx ng lint --lint-file-patterns src/app/demo/pages/admin-panel/teacher-salary/**/*`


------
https://chatgpt.com/codex/tasks/task_e_68cfd254396483228a6b92150d59c273