### PR TITLE
Stop auto PDF generation when toggling salary status

### DIFF
--- a/src/app/@theme/services/teacher-salary.service.ts
+++ b/src/app/@theme/services/teacher-salary.service.ts
@@ -21,12 +21,17 @@ export interface TeacherSalaryInvoice {
   teacherId?: number;
   teacherName?: string;
   month?: string;
+  salary?: number;
   salaryAmount?: number;
   totalSalary?: number;
   isPayed?: boolean;
   payedAt?: string | null;
   receiptUrl?: string | null;
+  receiptPath?: string | null;
   receiptId?: number | null;
+  createdAt?: string | null;
+  modifiedAt?: string | null;
+  modefiedAt?: string | null;
   status?: string | null;
   [key: string]: unknown;
 }
@@ -35,9 +40,13 @@ export interface TeacherMonthlySummary {
   month?: string;
   teacherId?: number;
   teacherName?: string;
+  totalReports?: number;
+  presentCount?: number;
   attendanceCount?: number;
   totalAttendance?: number;
   attendedSessions?: number;
+  absentWithExcuseCount?: number;
+  absentWithoutExcuseCount?: number;
   absenceCount?: number;
   totalAbsence?: number;
   missedSessions?: number;
@@ -46,6 +55,7 @@ export interface TeacherMonthlySummary {
   overtimeMinutes?: number;
   sessionCount?: number;
   lessonsCount?: number;
+  salary?: number;
   salaryTotal?: number;
   totalSalary?: number;
   baseSalary?: number;
@@ -124,16 +134,21 @@ export class TeacherSalaryService {
   ): Observable<
     ApiResponse<TeacherSalaryInvoice | TeacherSalaryInvoiceDetails | boolean | null>
   > {
-    const formData = new FormData();
-    Object.entries(model).forEach(([key, value]) => {
-      if (value !== undefined && value !== null) {
-        formData.append(key, String(value));
-      }
-    });
+    const createFormData = () => {
+      const formData = new FormData();
+      Object.entries(model).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          formData.append(key, String(value));
+        }
+      });
+      return formData;
+    };
 
-    return this.http.patch<
+    const endpoint = `${this.baseUrl}/invoices/${model.id}/payment`;
+
+    return this.http.post<
       ApiResponse<TeacherSalaryInvoice | TeacherSalaryInvoiceDetails | boolean | null>
-    >(`${this.baseUrl}/invoices/${model.id}/payment`, formData);
+    >(endpoint, createFormData());
   }
 
   uploadInvoiceReceipt(


### PR DESCRIPTION
## Summary
- update the paid toggle handler to only apply the status change and refresh invoice data instead of queueing PDF generation

## Testing
- npm run lint *(fails: existing lint errors in src/app/demo/pages/chart/apex-charts/apex-charts.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd94ff06c8322a321a963b9a3533b