### PR TITLE
Add day and time handling to circle management

### DIFF
--- a/src/app/@theme/services/circle.service.ts
+++ b/src/app/@theme/services/circle.service.ts
@@ -8,6 +8,7 @@ import {
   LookUpUserDto,
   PagedResultDto
 } from './lookup.service';
+import { DaysEnum } from '../types/DaysEnum';
 
 export interface CircleDto {
   id: number;
@@ -17,6 +18,8 @@ export interface CircleDto {
   managers?: CircleManagerDto[];
 
   students?: CircleStudentDto[];
+  day?: DaysEnum | null;
+  time?: number | null;
 }
 
 export interface CircleManagerDto {
@@ -39,6 +42,8 @@ export interface CreateCircleDto {
   teacherId?: number;
   managers?: number[];
   studentsIds?: number[];
+  day?: DaysEnum | null;
+  time?: number | null;
 }
 
 export interface UpdateCircleDto extends CreateCircleDto {

--- a/src/app/@theme/types/DaysEnum.ts
+++ b/src/app/@theme/types/DaysEnum.ts
@@ -1,0 +1,28 @@
+export enum DaysEnum {
+  Saturday = 1,
+  Sunday = 2,
+  Monday = 3,
+  Tuesday = 4,
+  Wednesday = 5,
+  Thursday = 6,
+  Friday = 7
+}
+
+export interface DayOption {
+  label: string;
+  value: DaysEnum;
+}
+
+export const DAY_OPTIONS: DayOption[] = [
+  { label: 'Saturday', value: DaysEnum.Saturday },
+  { label: 'Sunday', value: DaysEnum.Sunday },
+  { label: 'Monday', value: DaysEnum.Monday },
+  { label: 'Tuesday', value: DaysEnum.Tuesday },
+  { label: 'Wednesday', value: DaysEnum.Wednesday },
+  { label: 'Thursday', value: DaysEnum.Thursday },
+  { label: 'Friday', value: DaysEnum.Friday }
+];
+
+export const DAY_LABELS = new Map<DaysEnum, string>(
+  DAY_OPTIONS.map((option) => [option.value, option.label])
+);

--- a/src/app/@theme/utils/time.ts
+++ b/src/app/@theme/utils/time.ts
@@ -1,0 +1,28 @@
+export function timeStringToMinutes(time?: string | null): number | undefined {
+  if (!time) {
+    return undefined;
+  }
+  const [hoursPart, minutesPart] = time.split(':');
+  const hours = Number(hoursPart);
+  const minutes = Number(minutesPart);
+
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    return undefined;
+  }
+
+  return hours * 60 + minutes;
+}
+
+export function minutesToTimeString(value?: number | null): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const hours = Math.floor(value / 60);
+  const minutes = value % 60;
+
+  const paddedHours = hours.toString().padStart(2, '0');
+  const paddedMinutes = minutes.toString().padStart(2, '0');
+
+  return `${paddedHours}:${paddedMinutes}`;
+}

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.html
@@ -18,6 +18,20 @@
         </div>
         <div class="col-md-6">
           <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Day</mat-label>
+            <mat-select formControlName="day">
+              <mat-option *ngFor="let day of days" [value]="day.value">{{ day.label }}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Time</mat-label>
+            <input matInput type="time" formControlName="time" placeholder="Select Time" />
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
             <mat-label>Managers</mat-label>
             <mat-select formControlName="managers" multiple>
               <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
@@ -16,6 +16,8 @@ import {
 } from 'src/app/@theme/services/circle.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+import { DAY_OPTIONS, DaysEnum } from 'src/app/@theme/types/DaysEnum';
+import { timeStringToMinutes } from 'src/app/@theme/utils/time';
 
 @Component({
   selector: 'app-courses-add',
@@ -33,11 +35,14 @@ export class CoursesAddComponent implements OnInit {
   teachers: LookUpUserDto[] = [];
   managers: LookUpUserDto[] = [];
   students: LookUpUserDto[] = [];
+  days = DAY_OPTIONS;
 
   ngOnInit(): void {
     this.circleForm = this.fb.group({
       name: ['', Validators.required],
       teacherId: [null, Validators.required],
+      day: [null, Validators.required],
+      time: ['', Validators.required],
       managers: [[]],
       studentsIds: [[]]
     });
@@ -65,12 +70,35 @@ export class CoursesAddComponent implements OnInit {
       this.circleForm.markAllAsTouched();
       return;
     }
-    const model: CreateCircleDto = this.circleForm.value;
+    const formValue = this.circleForm.value as {
+      name: string;
+      teacherId: number;
+      day: DaysEnum;
+      time: string;
+      managers: number[];
+      studentsIds: number[];
+    };
+
+    const model: CreateCircleDto = {
+      name: formValue.name,
+      teacherId: formValue.teacherId,
+      day: formValue.day,
+      time: timeStringToMinutes(formValue.time),
+      managers: formValue.managers,
+      studentsIds: formValue.studentsIds
+    };
     this.circle.create(model).subscribe({
       next: (res) => {
         if (res.isSuccess) {
           this.toast.success('Circle created successfully');
-          this.circleForm.reset();
+          this.circleForm.reset({
+            name: '',
+            teacherId: null,
+            day: null,
+            time: '',
+            managers: [],
+            studentsIds: []
+          });
         } else if (res.errors?.length) {
           res.errors.forEach((e) => this.toast.error(e.message));
         } else {

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
@@ -4,6 +4,12 @@
       <div class="p-10">
         <h5 class="m-b-10">{{ course?.name }}</h5>
         <div *ngIf="course?.teacher">Teacher: {{ course.teacher.fullName || course.teacher.id }}</div>
+        <div *ngIf="course?.day !== undefined && course?.day !== null">
+          Day: {{ getDayLabel(course?.day) }}
+        </div>
+        <div *ngIf="course?.time !== undefined && course?.time !== null">
+          Time: {{ getFormattedTime(course?.time) }}
+        </div>
       </div>
       <div class="p-b-15">
         <div class="table-containe table-reponsive">

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
@@ -4,6 +4,8 @@ import { MatTableDataSource } from '@angular/material/table';
 
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { CircleDto, CircleStudentDto } from 'src/app/@theme/services/circle.service';
+import { DAY_LABELS, DaysEnum } from 'src/app/@theme/types/DaysEnum';
+import { minutesToTimeString } from 'src/app/@theme/utils/time';
 
 
 @Component({
@@ -17,6 +19,7 @@ export class CoursesDetailsComponent implements OnInit {
   course?: CircleDto;
   displayedColumns: string[] = ['fullName', 'action'];
   dataSource = new MatTableDataSource<CircleStudentDto>();
+  private readonly dayLabelMap = DAY_LABELS;
 
   ngOnInit() {
     const course = history.state.course as CircleDto | undefined;
@@ -25,5 +28,25 @@ export class CoursesDetailsComponent implements OnInit {
       this.dataSource.data = course.students || [];
 
     }
+  }
+
+  getDayLabel(day?: DaysEnum | number | null | string): string {
+    if (day === null || day === undefined) {
+      return '';
+    }
+    if (typeof day === 'string') {
+      return day;
+    }
+    return this.dayLabelMap.get(day as DaysEnum) ?? '';
+  }
+
+  getFormattedTime(time?: number | string | null): string {
+    if (time === null || time === undefined) {
+      return '';
+    }
+    if (typeof time === 'string') {
+      return time;
+    }
+    return minutesToTimeString(time);
   }
 }

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.html
@@ -18,6 +18,20 @@
         </div>
         <div class="col-md-6">
           <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Day</mat-label>
+            <mat-select formControlName="day">
+              <mat-option *ngFor="let day of days" [value]="day.value">{{ day.label }}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
+            <mat-label>Time</mat-label>
+            <input matInput type="time" formControlName="time" placeholder="Select Time" />
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="outline" class="w-100">
             <mat-label>Managers</mat-label>
             <mat-select formControlName="managers" multiple [disabled]="isManager">
               <mat-option *ngFor="let m of managers" [value]="m.id">{{ m.fullName }}</mat-option>

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
@@ -30,6 +30,18 @@
                   {{ element.teacher?.fullName || element.teacherName || element.teacherId }}
                 </td>
               </ng-container>
+              <ng-container matColumnDef="day">
+                <th mat-header-cell *matHeaderCellDef>DAY</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  {{ getDayLabel(element.day) }}
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="time">
+                <th mat-header-cell *matHeaderCellDef>TIME</th>
+                <td mat-cell *matCellDef="let element" class="text-nowrap">
+                  {{ getFormattedTime(element.time) }}
+                </td>
+              </ng-container>
               <ng-container matColumnDef="managers">
                 <th mat-header-cell *matHeaderCellDef>MANAGERS</th>
                 <td mat-cell *matCellDef="let element" class="text-nowrap">
@@ -72,7 +84,7 @@
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
               <tr class="mat-row" *matNoDataRow>
-                <td class="mat-cell" colspan="4">No data matching the filter "{{ input.value }}"</td>
+                <td class="mat-cell" colspan="6">No data matching the filter "{{ input.value }}"</td>
               </tr>
             </table>
             <mat-paginator

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
@@ -21,6 +21,8 @@ import {
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
+import { DAY_LABELS, DaysEnum } from 'src/app/@theme/types/DaysEnum';
+import { minutesToTimeString } from 'src/app/@theme/utils/time';
 
 @Component({
   selector: 'app-courses-view',
@@ -35,13 +37,14 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
   private auth = inject(AuthenticationService);
 
 
-  displayedColumns: string[] = ['name', 'teacher', 'managers', 'action'];
+  displayedColumns: string[] = ['name', 'teacher', 'day', 'time', 'managers', 'action'];
   dataSource = new MatTableDataSource<CircleDto>();
   totalCount = 0;
   filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 10 };
 
   readonly paginator = viewChild.required(MatPaginator);
   isTeacherOrStudent = [UserTypesEnum.Teacher, UserTypesEnum.Student].includes(this.auth.getRole()!);
+  private readonly dayLabelMap = DAY_LABELS;
 
   ngOnInit() {
     this.loadCircles();
@@ -97,6 +100,26 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
         .join(', ') || ''
     );
 
+  }
+
+  getDayLabel(day?: DaysEnum | number | null | string): string {
+    if (day === null || day === undefined) {
+      return '';
+    }
+    if (typeof day === 'string') {
+      return day;
+    }
+    return this.dayLabelMap.get(day as DaysEnum) ?? '';
+  }
+
+  getFormattedTime(time?: number | string | null): string {
+    if (time === null || time === undefined) {
+      return '';
+    }
+    if (typeof time === 'string') {
+      return time;
+    }
+    return minutesToTimeString(time);
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared day enumeration and time conversion helpers for circle scheduling
- capture day and time in circle create/update forms and send them to the API
- surface the selected day and time in course listings and detail views

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d10cd0e6ac8322813de44059705f83