### PR TITLE
feat: support updated circle time and day models

### DIFF
--- a/src/app/@theme/services/circle.service.ts
+++ b/src/app/@theme/services/circle.service.ts
@@ -8,7 +8,10 @@ import {
   LookUpUserDto,
   PagedResultDto
 } from './lookup.service';
-import { DaysEnum } from '../types/DaysEnum';
+import { DayValue, DaysEnum } from '../types/DaysEnum';
+import { TimeSpanDto } from '../utils/time';
+
+export type CircleTimeValue = TimeSpanDto | number | string | null;
 
 export interface CircleDto {
   id: number;
@@ -18,8 +21,8 @@ export interface CircleDto {
   managers?: CircleManagerDto[];
 
   students?: CircleStudentDto[];
-  day?: DaysEnum | string | null;
-  time?: number | string | null;
+  day?: DayValue;
+  time?: CircleTimeValue;
 }
 
 export interface CircleManagerDto {
@@ -43,7 +46,7 @@ export interface CreateCircleDto {
   managers?: number[];
   studentsIds?: number[];
   day?: DaysEnum | null;
-  time?: number | null;
+  time?: TimeSpanDto | null;
 }
 
 export interface UpdateCircleDto extends CreateCircleDto {

--- a/src/app/@theme/utils/time.ts
+++ b/src/app/@theme/utils/time.ts
@@ -1,3 +1,22 @@
+export interface TimeSpanDto {
+  ticks?: number | null;
+  days?: number | null;
+  hours?: number | null;
+  minutes?: number | null;
+  seconds?: number | null;
+  milliseconds?: number | null;
+  totalDays?: number | null;
+  totalHours?: number | null;
+  totalMinutes?: number | null;
+  totalSeconds?: number | null;
+  totalMilliseconds?: number | null;
+  [key: string]: unknown;
+}
+
+export const TICKS_PER_MILLISECOND = 10_000;
+export const TICKS_PER_SECOND = 10_000_000;
+export const TICKS_PER_MINUTE = 60 * TICKS_PER_SECOND;
+
 export function timeStringToMinutes(time?: string | null): number | undefined {
   if (!time) {
     return undefined;
@@ -19,13 +38,34 @@ export function timeStringToMinutes(time?: string | null): number | undefined {
   return hours * 60 + minutes;
 }
 
+export function timeStringToTimeSpan(
+  time?: string | null
+): TimeSpanDto | undefined {
+  const minutes = timeStringToMinutes(time);
+  if (minutes === undefined) {
+    return undefined;
+  }
+
+  const ticks = Math.round(minutes * TICKS_PER_MINUTE);
+  if (!Number.isFinite(ticks)) {
+    return undefined;
+  }
+
+  return { ticks };
+}
+
 export function minutesToTimeString(value?: number | null): string {
-  if (value === null || value === undefined) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
     return '';
   }
 
-  const hours = Math.floor(value / 60);
-  const minutes = value % 60;
+  const totalMinutes = Math.round(value);
+  if (!Number.isFinite(totalMinutes)) {
+    return '';
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
 
   const paddedHours = hours.toString().padStart(2, '0');
   const paddedMinutes = minutes.toString().padStart(2, '0');
@@ -33,8 +73,65 @@ export function minutesToTimeString(value?: number | null): string {
   return `${paddedHours}:${paddedMinutes}`;
 }
 
-export function formatTimeValue(value?: number | string | null): string {
+function timeSpanToMinutes(value?: TimeSpanDto | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value.totalMinutes === 'number') {
+    return value.totalMinutes;
+  }
+
+  if (typeof value.ticks === 'number') {
+    return value.ticks / TICKS_PER_MINUTE;
+  }
+
+  if (typeof value.totalSeconds === 'number') {
+    return value.totalSeconds / 60;
+  }
+
+  if (typeof value.totalMilliseconds === 'number') {
+    return value.totalMilliseconds / 60_000;
+  }
+
+  const hasHMS =
+    'hours' in value || 'minutes' in value || 'seconds' in value || 'milliseconds' in value;
+  if (hasHMS) {
+    const hours = typeof value.hours === 'number' ? value.hours : 0;
+    const minutes = typeof value.minutes === 'number' ? value.minutes : 0;
+    const seconds = typeof value.seconds === 'number' ? value.seconds : 0;
+    const milliseconds = typeof value.milliseconds === 'number' ? value.milliseconds : 0;
+
+    return hours * 60 + minutes + seconds / 60 + milliseconds / 60_000;
+  }
+
+  return undefined;
+}
+
+export function formatTimeValue(
+  value?: number | string | TimeSpanDto | null
+): string {
   if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    const minutes = timeSpanToMinutes(value);
+    if (minutes !== undefined) {
+      return minutesToTimeString(minutes);
+    }
+
+    const labelKeys = ['formatted', 'value', 'display', 'text'];
+    for (const key of labelKeys) {
+      const candidate = value[key];
+      if (typeof candidate === 'string') {
+        const trimmedCandidate = candidate.trim();
+        if (trimmedCandidate) {
+          return trimmedCandidate;
+        }
+      }
+    }
+
     return '';
   }
 

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
@@ -18,7 +18,7 @@ import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { DAY_OPTIONS, DaysEnum, coerceDayValue } from 'src/app/@theme/types/DaysEnum';
 
-import { timeStringToMinutes } from 'src/app/@theme/utils/time';
+import { timeStringToTimeSpan } from 'src/app/@theme/utils/time';
 
 @Component({
   selector: 'app-courses-add',
@@ -81,7 +81,7 @@ export class CoursesAddComponent implements OnInit {
     };
 
     const dayValue = coerceDayValue(formValue.day) ?? null;
-    const timeValue = timeStringToMinutes(formValue.time) ?? null;
+    const timeValue = timeStringToTimeSpan(formValue.time) ?? null;
 
     const model: CreateCircleDto = {
       name: formValue.name,

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
@@ -20,8 +20,6 @@ export class CoursesDetailsComponent implements OnInit {
   course?: CircleDto;
   displayedColumns: string[] = ['fullName', 'action'];
   dataSource = new MatTableDataSource<CircleStudentDto>();
-  private readonly dayLabelMap = DAY_LABELS;
-
   ngOnInit() {
     const course = history.state.course as CircleDto | undefined;
     if (course) {

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
@@ -20,7 +20,7 @@ import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 import { DAY_OPTIONS, DaysEnum, coerceDayValue } from 'src/app/@theme/types/DaysEnum';
-import { formatTimeValue, timeStringToMinutes } from 'src/app/@theme/utils/time';
+import { formatTimeValue, timeStringToTimeSpan } from 'src/app/@theme/utils/time';
 
 
 @Component({
@@ -206,7 +206,7 @@ export class CoursesUpdateComponent implements OnInit {
     };
 
     const dayValue = coerceDayValue(formValue.day) ?? null;
-    const timeValue = timeStringToMinutes(formValue.time) ?? null;
+    const timeValue = timeStringToTimeSpan(formValue.time) ?? null;
 
     const model: UpdateCircleDto = {
       id: this.id,

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
@@ -45,8 +45,6 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
 
   readonly paginator = viewChild.required(MatPaginator);
   isTeacherOrStudent = [UserTypesEnum.Teacher, UserTypesEnum.Student].includes(this.auth.getRole()!);
-  private readonly dayLabelMap = DAY_LABELS;
-
   ngOnInit() {
     this.loadCircles();
   }


### PR DESCRIPTION
## Summary
- adjust the circle DTOs to accept the backend's TimeSpan payload and updated day values
- add TimeSpan conversion/format helpers and extend day coercion/formatting for object-based values
- submit the new TimeSpan payload from the course forms and rely on the helpers when rendering day/time in the views

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1189694988322a421e7ac514cd44d