### PR TITLE
Align course management with updated circle DTOs

### DIFF
--- a/src/app/@theme/services/circle.service.ts
+++ b/src/app/@theme/services/circle.service.ts
@@ -15,14 +15,15 @@ export type CircleTimeValue = TimeSpanDto | number | string | null | undefined;
 
 export interface CircleDto {
   id: number;
-  name: string;
-  teacherId?: number;
+  name?: string | null;
+  teacherId?: number | null;
   teacher?: LookUpUserDto;
+  teacherName?: string | null;
   managers?: CircleManagerDto[];
-
   students?: CircleStudentDto[];
   day?: DayValue;
   dayId?: DayValue;
+  dayName?: string | null;
   time?: CircleTimeValue;
   startTime?: CircleTimeValue;
 }
@@ -43,13 +44,13 @@ export interface CircleStudentDto {
 }
 
 export interface CreateCircleDto {
-  name?: string;
-  teacherId?: number;
-  managers?: number[];
-  studentsIds?: number[];
+  name?: string | null;
+  teacherId?: number | null;
+  managers?: number[] | null;
+  studentsIds?: number[] | null;
   dayId?: DaysEnum | null;
-  day?: DaysEnum | null;
-  time?: TimeSpanDto | null;
+  startTime?: TimeSpanDto | null;
+  time?: number | null;
 }
 
 export interface UpdateCircleDto extends CreateCircleDto {

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.html
@@ -27,7 +27,7 @@
         <div class="col-md-6">
           <mat-form-field appearance="outline" class="w-100">
             <mat-label>Start Time</mat-label>
-            <input matInput type="time" formControlName="time" placeholder="Select Start Time" />
+            <input matInput type="time" formControlName="startTime" placeholder="Select Start Time" />
           </mat-form-field>
         </div>
         <div class="col-md-6">

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
@@ -16,19 +16,15 @@ import {
 } from 'src/app/@theme/services/circle.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
-import {
-  DAY_OPTIONS,
-  DayValue,
-  coerceDayValue
-} from 'src/app/@theme/types/DaysEnum';
+import { DAY_OPTIONS, DayValue, coerceDayValue } from 'src/app/@theme/types/DaysEnum';
 
-import { timeStringToTimeSpan } from 'src/app/@theme/utils/time';
+import { timeStringToMinutes, timeStringToTimeSpan } from 'src/app/@theme/utils/time';
 
 interface CircleFormValue {
   name: string;
   teacherId: number;
-  day: DayValue;
-  time: string;
+  dayId: DayValue;
+  startTime: string;
   managers: number[];
   studentsIds: number[];
 }
@@ -87,13 +83,15 @@ export class CoursesAddComponent implements OnInit {
     }
     const formValue = this.circleForm.value as CircleFormValue;
 
-    const dayValue = coerceDayValue(formValue.day) ?? null;
-    const timeValue = timeStringToTimeSpan(formValue.time) ?? null;
+    const dayValue = coerceDayValue(formValue.dayId) ?? null;
+    const startTimeValue = timeStringToTimeSpan(formValue.startTime) ?? null;
+    const timeValue = timeStringToMinutes(formValue.startTime);
     const model: CreateCircleDto = {
       name: formValue.name,
       teacherId: formValue.teacherId,
-      day: dayValue,
-      time: timeValue,
+      dayId: dayValue ?? null,
+      startTime: startTimeValue ?? null,
+      time: timeValue ?? null,
       managers: formValue.managers,
       studentsIds: formValue.studentsIds
     };

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
@@ -3,12 +3,15 @@
     <app-card cardTitle="Course Details" padding="0" cardClass="sm-block">
       <div class="p-10">
         <h5 class="m-b-10">{{ course?.name }}</h5>
-        <div *ngIf="course?.teacher">Teacher: {{ course.teacher.fullName || course.teacher.id }}</div>
+        <div *ngIf="course?.teacher || course?.teacherName || course?.teacherId">
+          Teacher: {{ course?.teacher?.fullName || course?.teacherName || course?.teacherId }}
+        </div>
         <div
           *ngIf="
             course &&
             ((course.day !== undefined && course.day !== null) ||
-              (course.dayId !== undefined && course.dayId !== null))
+              (course.dayId !== undefined && course.dayId !== null) ||
+              course.dayName)
           "
         >
           Day: {{ getDayLabel(course) }}

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
@@ -4,7 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 
 import { SharedModule } from 'src/app/demo/shared/shared.module';
 import { CircleDto, CircleStudentDto } from 'src/app/@theme/services/circle.service';
-import { DAY_LABELS, formatDayValue } from 'src/app/@theme/types/DaysEnum';
+import { formatDayValue } from 'src/app/@theme/types/DaysEnum';
 import { formatTimeValue } from 'src/app/@theme/utils/time';
 
 
@@ -33,14 +33,17 @@ export class CoursesDetailsComponent implements OnInit {
     if (!circle) {
       return '';
     }
-    return formatDayValue(circle.day ?? circle.dayId);
+    if (circle.dayName) {
+      return circle.dayName;
+    }
+    return formatDayValue(circle.dayId ?? circle.day);
   }
 
   getFormattedStartTime(circle?: CircleDto): string {
     if (!circle) {
       return '';
     }
-    return formatTimeValue(circle.time ?? circle.startTime);
+    return formatTimeValue(circle.startTime ?? circle.time);
 
   }
 }

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.html
@@ -27,7 +27,7 @@
         <div class="col-md-6">
           <mat-form-field appearance="outline" class="w-100">
             <mat-label>Start Time</mat-label>
-            <input matInput type="time" formControlName="time" placeholder="Select Start Time" />
+            <input matInput type="time" formControlName="startTime" placeholder="Select Start Time" />
           </mat-form-field>
         </div>
         <div class="col-md-6">

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
@@ -19,18 +19,18 @@ import {
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
+import { DAY_OPTIONS, DayValue, coerceDayValue } from 'src/app/@theme/types/DaysEnum';
 import {
-  DAY_OPTIONS,
-  DayValue,
-  coerceDayValue
-} from 'src/app/@theme/types/DaysEnum';
-import { formatTimeValue, timeStringToTimeSpan } from 'src/app/@theme/utils/time';
+  formatTimeValue,
+  timeStringToMinutes,
+  timeStringToTimeSpan
+} from 'src/app/@theme/utils/time';
 
 interface CircleFormValue {
   name: string;
   teacherId: number;
-  day: DayValue;
-  time: string;
+  dayId: DayValue;
+  startTime: string;
   managers: number[];
   studentsIds: number[];
 }
@@ -114,11 +114,11 @@ export class CoursesUpdateComponent implements OnInit {
           ?.map((s: CircleStudentDto) => s.id ?? s.studentId ?? s.student?.id)
           .filter((id): id is number => id !== undefined) ?? [];
       const resolvedDay = coerceDayValue(course.day ?? course.dayId) ?? null;
-      const resolvedTime = formatTimeValue(course.time ?? course.startTime);
+      const resolvedStartTime = formatTimeValue(course.startTime ?? course.time);
       this.circleForm.patchValue({
-        name: course.name,
-        teacherId: course.teacherId,
-        dayId: resolvedDay,
+        name: course.name ?? '',
+        teacherId: course.teacherId ?? null,
+        dayId: resolvedDay ?? null,
         startTime: resolvedStartTime,
         managers:
           course.managers?.map((m: CircleManagerDto | number) =>
@@ -146,9 +146,8 @@ export class CoursesUpdateComponent implements OnInit {
                 .filter((id): id is number => id !== undefined) ?? [];
             this.circleForm.patchValue({ studentsIds: fetchedStudents });
             this.circleForm.patchValue({
-              day: coerceDayValue(res.data.day ?? res.data.dayId) ?? null,
-              time: formatTimeValue(res.data.time ?? res.data.startTime)
-
+              dayId: coerceDayValue(res.data.day ?? res.data.dayId) ?? null,
+              startTime: formatTimeValue(res.data.startTime ?? res.data.time)
             });
             if (res.data.students?.length) {
               const courseStudents = res.data.students.map(
@@ -177,10 +176,10 @@ export class CoursesUpdateComponent implements OnInit {
                 )
                 .filter((id): id is number => id !== undefined) ?? [];
             this.circleForm.patchValue({
-              name: res.data.name,
-              teacherId: res.data.teacherId,
-              day: coerceDayValue(res.data.day ?? res.data.dayId) ?? null,
-              time: formatTimeValue(res.data.time ?? res.data.startTime),
+              name: res.data.name ?? '',
+              teacherId: res.data.teacherId ?? null,
+              dayId: coerceDayValue(res.data.day ?? res.data.dayId) ?? null,
+              startTime: formatTimeValue(res.data.startTime ?? res.data.time),
               managers: res.data.managers
                 ? res.data.managers.map((m: CircleManagerDto | number) =>
                     typeof m === 'number' ? m : m.managerId
@@ -211,18 +210,17 @@ export class CoursesUpdateComponent implements OnInit {
     }
     const formValue = this.circleForm.getRawValue() as CircleFormValue;
 
-    const dayValue = coerceDayValue(formValue.day) ?? null;
-    const timeValue = timeStringToTimeSpan(formValue.time) ?? null;
+    const dayValue = coerceDayValue(formValue.dayId) ?? null;
+    const startTimeValue = timeStringToTimeSpan(formValue.startTime) ?? null;
+    const minutesValue = timeStringToMinutes(formValue.startTime);
 
     const model: UpdateCircleDto = {
       id: this.id,
       name: formValue.name,
       teacherId: formValue.teacherId,
-      day: dayValue,
-      dayId: dayValue,
-      startTime: startTimeValue,
-      time: timeValue ?? null,
-
+      dayId: dayValue ?? null,
+      startTime: startTimeValue ?? null,
+      time: minutesValue ?? null,
       managers: formValue.managers,
       studentsIds: formValue.studentsIds
     };

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
@@ -21,7 +21,7 @@ import {
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
-import { DAY_LABELS, formatDayValue } from 'src/app/@theme/types/DaysEnum';
+import { formatDayValue } from 'src/app/@theme/types/DaysEnum';
 import { formatTimeValue } from 'src/app/@theme/utils/time';
 
 
@@ -102,11 +102,14 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
   }
 
   getDayLabel(circle: CircleDto): string {
-    return formatDayValue(circle.day ?? circle.dayId);
+    if (circle.dayName) {
+      return circle.dayName;
+    }
+    return formatDayValue(circle.dayId ?? circle.day);
   }
 
   getFormattedStartTime(circle: CircleDto): string {
-    return formatTimeValue(circle.time ?? circle.startTime);
+    return formatTimeValue(circle.startTime ?? circle.time);
   }
 }
 


### PR DESCRIPTION
## Summary
- align circle service DTOs with the backend changes (dayName, startTime, numeric time)
- update course add/update forms to capture dayId and start time correctly
- ensure course detail and list views display new teacher/day information

## Testing
- npm run lint *(fails: existing lint errors in unrelated files such as teacher-salary.service.ts and apex-charts.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d1303ea9508322b8a15990ccc2e7a7