### PR TITLE
Integrate circle schedule and upcoming endpoints

### DIFF
--- a/src/app/@theme/services/circle.service.ts
+++ b/src/app/@theme/services/circle.service.ts
@@ -13,26 +13,22 @@ import { TimeSpanDto } from '../utils/time';
 
 export type CircleTimeValue = TimeSpanDto | number | string | null | undefined;
 
-export interface CircleDto {
-  id: number;
-  name?: string | null;
-  teacherId?: number | null;
-  teacher?: LookUpUserDto;
-  teacherName?: string | null;
-  managers?: CircleManagerDto[];
-  students?: CircleStudentDto[];
-  day?: DayValue;
-  dayId?: DayValue;
-  dayName?: string | null;
+export interface CircleDayRequestDto {
+  dayId: DaysEnum | number;
+  time?: string | null;
+}
+
+export interface CircleDayDto {
+  dayId: DaysEnum | number;
   time?: CircleTimeValue;
-  startTime?: CircleTimeValue;
+  dayName?: string | null;
 }
 
 export interface CircleManagerDto {
   managerId: number;
-  manager?: LookUpUserDto;
+  manager?: LookUpUserDto | string | null;
+  managerName?: string | null;
   circleId?: number;
-
 }
 
 export interface CircleStudentDto {
@@ -43,19 +39,48 @@ export interface CircleStudentDto {
   [key: string]: unknown;
 }
 
+export interface CircleDto {
+  id: number;
+  name?: string | null;
+  teacherId?: number | null;
+  teacher?: LookUpUserDto;
+  teacherName?: string | null;
+  managers?: CircleManagerDto[] | null;
+  students?: CircleStudentDto[] | null;
+  day?: DayValue;
+  dayId?: DayValue;
+  dayIds?: (DaysEnum | number)[] | null;
+  dayName?: string | null;
+  dayNames?: string[] | null;
+  days?: CircleDayDto[] | null;
+  time?: CircleTimeValue;
+  startTime?: CircleTimeValue;
+}
+
 export interface CreateCircleDto {
   name?: string | null;
   teacherId?: number | null;
+  days?: CircleDayRequestDto[] | null;
   managers?: number[] | null;
   studentsIds?: number[] | null;
-  dayId?: DaysEnum | null;
-  startTime?: string | null;
-
-  time?: number | null;
 }
 
 export interface UpdateCircleDto extends CreateCircleDto {
   id: number;
+}
+
+export interface UpcomingCircleDto {
+  id: number;
+  name?: string | null;
+  nextDayId?: DaysEnum | number | null;
+  nextDayName?: string | null;
+  nextOccurrenceDate?: string | null;
+  startTime?: CircleTimeValue;
+  teacherId?: number | null;
+  teacher?: LookUpUserDto;
+  teacherName?: string | null;
+  managers?: CircleManagerDto[] | null;
+  days?: CircleDayDto[] | null;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -95,44 +120,74 @@ export class CircleService {
 
   getAll(
     filter: FilteredResultRequestDto,
-    managerId?: number,
-    teacherId?: number
+    managerId?: number | null,
+    teacherId?: number | null
   ): Observable<ApiResponse<PagedResultDto<CircleDto>>> {
     let params = new HttpParams();
+
     if (filter.skipCount !== undefined) {
       params = params.set('SkipCount', filter.skipCount.toString());
     }
+
     if (filter.maxResultCount !== undefined) {
       params = params.set('MaxResultCount', filter.maxResultCount.toString());
     }
-    const searchWord = filter.searchWord ?? filter.searchTerm;
 
     if (filter.searchTerm) {
       params = params.set('SearchTerm', filter.searchTerm);
     }
-    if (searchWord) {
-      params = params.set('SearchWord', searchWord);
-    }
+
     if (filter.filter) {
       params = params.set('Filter', filter.filter);
     }
+
     if (filter.lang) {
       params = params.set('Lang', filter.lang);
     }
+
     if (filter.sortingDirection) {
       params = params.set('SortingDirection', filter.sortingDirection);
     }
+
     if (filter.sortBy) {
       params = params.set('SortBy', filter.sortBy);
     }
-    if (managerId !== undefined) {
+
+    if (managerId !== undefined && managerId !== null) {
       params = params.set('managerId', managerId.toString());
     }
-    if (teacherId !== undefined) {
+
+    if (teacherId !== undefined && teacherId !== null) {
       params = params.set('teacherId', teacherId.toString());
     }
+
     return this.http.get<ApiResponse<PagedResultDto<CircleDto>>>(
       `${environment.apiUrl}/api/Circle/GetResultsByFilter`,
+      { params }
+    );
+  }
+
+  getUpcoming(
+    managerId?: number | null,
+    teacherId?: number | null,
+    take?: number | null
+  ): Observable<ApiResponse<UpcomingCircleDto[]>> {
+    let params = new HttpParams();
+
+    if (managerId !== undefined && managerId !== null) {
+      params = params.set('managerId', managerId.toString());
+    }
+
+    if (teacherId !== undefined && teacherId !== null) {
+      params = params.set('teacherId', teacherId.toString());
+    }
+
+    if (take !== undefined && take !== null) {
+      params = params.set('take', take.toString());
+    }
+
+    return this.http.get<ApiResponse<UpcomingCircleDto[]>>(
+      `${environment.apiUrl}/api/Circle/Upcoming`,
       { params }
     );
   }

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
@@ -18,10 +18,7 @@ import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { DAY_OPTIONS, DayValue, coerceDayValue } from 'src/app/@theme/types/DaysEnum';
 
-import {
-  timeStringToMinutes,
-  timeStringToTimeSpanString
-} from 'src/app/@theme/utils/time';
+import { timeStringToTimeSpanString } from 'src/app/@theme/utils/time';
 
 
 interface CircleFormValue {
@@ -87,16 +84,18 @@ export class CoursesAddComponent implements OnInit {
     }
     const formValue = this.circleForm.value as CircleFormValue;
 
-    const dayValue = coerceDayValue(formValue.dayId) ?? null;
-    const startTimeValue = timeStringToTimeSpanString(formValue.startTime) ?? null;
+    const dayValue = coerceDayValue(formValue.dayId);
+    const startTimeValue = timeStringToTimeSpanString(formValue.startTime);
 
-    const timeValue = timeStringToMinutes(formValue.startTime);
+    const schedule =
+      dayValue !== undefined
+        ? [{ dayId: dayValue, time: startTimeValue ?? null }]
+        : [];
+
     const model: CreateCircleDto = {
       name: formValue.name,
       teacherId: formValue.teacherId,
-      dayId: dayValue ?? null,
-      startTime: startTimeValue ?? null,
-      time: timeValue ?? null,
+      days: schedule.length ? schedule : null,
       managers: formValue.managers,
       studentsIds: formValue.studentsIds
     };

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
@@ -6,24 +6,27 @@
         <div *ngIf="course?.teacher || course?.teacherName || course?.teacherId">
           Teacher: {{ course?.teacher?.fullName || course?.teacherName || course?.teacherId }}
         </div>
-        <div
-          *ngIf="
-            course &&
-            ((course.day !== undefined && course.day !== null) ||
-              (course.dayId !== undefined && course.dayId !== null) ||
-              course.dayName)
-          "
-        >
-          Day: {{ getDayLabel(course) }}
-        </div>
-        <div
-          *ngIf="
-            course &&
-            ((course.time !== undefined && course.time !== null) ||
-              (course.startTime !== undefined && course.startTime !== null))
-          "
-        >
-          Start Time: {{ getFormattedStartTime(course) }}
+        <div *ngIf="course as currentCourse">
+          <ng-container *ngIf="getSchedule(currentCourse).length; else fallbackSchedule">
+            <div>Schedule:</div>
+            <ul class="m-b-10">
+              <li *ngFor="let day of getSchedule(currentCourse)" class="schedule-item">
+                <span class="schedule-day">{{ getScheduleDayLabel(day) }}</span>
+                <ng-container *ngIf="getScheduleTimeLabel(day) as time">
+                  <span class="schedule-separator">•</span>
+                  <span class="schedule-time">{{ time }}</span>
+                </ng-container>
+              </li>
+            </ul>
+          </ng-container>
+          <ng-template #fallbackSchedule>
+            <div *ngIf="getDayLabel(currentCourse)">
+              Day: {{ getDayLabel(currentCourse) }}
+            </div>
+            <div *ngIf="getFormattedStartTime(currentCourse)">
+              Start Time: {{ getFormattedStartTime(currentCourse) }}
+            </div>
+          </ng-template>
         </div>
       </div>
       <div class="p-b-15">

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.ts
@@ -3,7 +3,11 @@ import { RouterModule } from '@angular/router';
 import { MatTableDataSource } from '@angular/material/table';
 
 import { SharedModule } from 'src/app/demo/shared/shared.module';
-import { CircleDto, CircleStudentDto } from 'src/app/@theme/services/circle.service';
+import {
+  CircleDayDto,
+  CircleDto,
+  CircleStudentDto
+} from 'src/app/@theme/services/circle.service';
 import { formatDayValue } from 'src/app/@theme/types/DaysEnum';
 import { formatTimeValue } from 'src/app/@theme/utils/time';
 
@@ -29,13 +33,61 @@ export class CoursesDetailsComponent implements OnInit {
     }
   }
 
+  getSchedule(circle?: CircleDto): CircleDayDto[] {
+    if (!circle || !Array.isArray(circle.days)) {
+      return [];
+    }
+
+    return circle.days.filter((day): day is CircleDayDto => Boolean(day));
+  }
+
+  getScheduleDayLabel(day?: CircleDayDto): string {
+    if (!day) {
+      return '';
+    }
+
+    if (day.dayName) {
+      return day.dayName;
+    }
+
+    return formatDayValue(day.dayId);
+  }
+
+  getScheduleTimeLabel(day?: CircleDayDto): string {
+    if (!day) {
+      return '';
+    }
+
+    return formatTimeValue(day.time);
+  }
+
   getDayLabel(circle?: CircleDto): string {
     if (!circle) {
       return '';
     }
+
+    const primaryDay = this.resolvePrimaryDay(circle);
+    if (primaryDay) {
+      if (primaryDay.dayName) {
+        return primaryDay.dayName;
+      }
+
+      if (primaryDay.dayId !== undefined && primaryDay.dayId !== null) {
+        return formatDayValue(primaryDay.dayId);
+      }
+    }
+
+    if (circle.dayNames?.length) {
+      const candidate = circle.dayNames[0];
+      if (candidate) {
+        return candidate;
+      }
+    }
+
     if (circle.dayName) {
       return circle.dayName;
     }
+
     return formatDayValue(circle.dayId ?? circle.day);
   }
 
@@ -43,7 +95,18 @@ export class CoursesDetailsComponent implements OnInit {
     if (!circle) {
       return '';
     }
-    return formatTimeValue(circle.startTime ?? circle.time);
 
+    const primaryDay = this.resolvePrimaryDay(circle);
+    const timeSource = primaryDay?.time ?? circle.startTime ?? circle.time;
+
+    return formatTimeValue(timeSource);
+  }
+
+  private resolvePrimaryDay(circle?: CircleDto | null): CircleDayDto | undefined {
+    if (!circle || !Array.isArray(circle.days)) {
+      return undefined;
+    }
+
+    return circle.days.find((day): day is CircleDayDto => Boolean(day)) ?? undefined;
   }
 }

--- a/src/app/demo/pages/admin-panel/online-courses/online-dashboard/online-dashboard.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/online-dashboard/online-dashboard.component.html
@@ -28,19 +28,33 @@
     <app-invites-goal-chart />
   </div>
   <div class="col-lg-5 col-md-12">
-    <app-card cardTitle="Upcoming Course" [padding]="0" cardClass="upcoming-course">
+    <app-card cardTitle="Upcoming Courses" [padding]="0" cardClass="upcoming-course">
       <ul class="list-group list-group-flush">
-        @for (item of course_list; track item) {
+        <li class="list-group-item" *ngIf="upcomingLoading">
+          <div class="flex align-item-center">Loading upcoming circles…</div>
+        </li>
+        <li class="list-group-item" *ngIf="!upcomingLoading && !upcomingCircles.length">
+          <div class="flex align-item-center">No upcoming circles found</div>
+        </li>
+        @for (circle of upcomingCircles; track circle?.id ?? circle?.name ?? circle) {
           <li class="list-group-item">
             <div class="flex align-item-center">
               <div class="flex-shrink-0 flex">
-                <img src="{{ item.image }}" alt="img" class="wid-40" />
+                <div class="avatar avatar-s bg-primary-50 text-primary-500 f-w-600">
+                  {{ getCircleInitials(circle.name) }}
+                </div>
               </div>
-              <div class="flex-grow-1 m-x-15">{{ item.title }}</div>
-              <div class="flex-shrink-0">
-                <a href="javascript:" class="avatar avatar-s hover text-accent-500">
-                  <i class="ti ti-chevron-right f-20"></i>
-                </a>
+              <div class="flex-grow-1 m-x-15">
+                <div class="f-14 f-w-600">{{ circle.name || 'Unnamed Circle' }}</div>
+                <div class="text-muted f-12">
+                  {{ getUpcomingScheduleLabel(circle) || 'Schedule TBD' }}
+                </div>
+                <div class="text-muted f-12" *ngIf="getUpcomingManagersLabel(circle) as managers">
+                  Managers: {{ managers }}
+                </div>
+              </div>
+              <div class="flex-shrink-0" *ngIf="getUpcomingTeacherName(circle) as teacher">
+                <span class="badge bg-light-primary text-primary-500 f-12">{{ teacher }}</span>
               </div>
             </div>
           </li>
@@ -184,19 +198,27 @@
     </app-card>
   </div>
   <div class="col-lg-6 col-md-12">
-    <app-card cardTitle="Upcoming Course" [padding]="0" cardClass="upcoming-course">
+    <app-card cardTitle="Upcoming Courses" [padding]="0" cardClass="upcoming-course">
       <ul class="list-group list-group-flush">
-        @for (item of trendingCourse; track item) {
+        <li class="list-group-item" *ngIf="upcomingLoading">
+          <div class="flex align-item-center">Loading upcoming circles…</div>
+        </li>
+        <li class="list-group-item" *ngIf="!upcomingLoading && !upcomingCircles.length">
+          <div class="flex align-item-center">No upcoming circles found</div>
+        </li>
+        @for (circle of upcomingCircles; track circle?.id ?? circle?.name ?? circle) {
           <li class="list-group-item">
             <div class="flex align-item-center">
-              <div class="flex-shrink-0 flex">
-                <img src="{{ item.image }}" alt="img" class="wid-40" />
+              <div class="flex-grow-1">
+                <div class="f-14 f-w-600">{{ circle.name || 'Unnamed Circle' }}</div>
+                <div class="text-muted f-12">
+                  {{ getUpcomingScheduleLabel(circle) || 'Schedule TBD' }}
+                </div>
               </div>
-              <div class="flex-grow-1 m-x-15">{{ item.title }}</div>
-              <div class="flex-shrink-0">
-                <a href="javascript:" class="avatar avatar-s hover text-accent-500">
-                  <i class="ti ti-chevron-right f-20"></i>
-                </a>
+              <div class="flex-shrink-0 text-end">
+                <div class="text-muted f-12" *ngIf="getUpcomingTeacherName(circle) as teacher">
+                  {{ teacher }}
+                </div>
               </div>
             </div>
           </li>


### PR DESCRIPTION
## Summary
- align the circle service contracts with the backend schedule payloads and expose the upcoming circles endpoint
- update course creation and editing flows to send day/time arrays and surface schedule details across the UI
- hook the dashboard "Upcoming Courses" widgets to the real API response with teacher and manager metadata

## Testing
- npm run lint *(fails: pre-existing lint violations in teacher-salary.service.ts and apex-charts.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a8cc8d8c8322878cb7fc13c40365