### PR TITLE
Adjust circle time payload to TimeSpan

### DIFF
--- a/src/app/@theme/services/circle.service.ts
+++ b/src/app/@theme/services/circle.service.ts
@@ -15,7 +15,7 @@ export type CircleTimeValue = TimeSpanDto | number | string | null | undefined;
 
 export interface CircleDayRequestDto {
   dayId: DaysEnum | number;
-  time?: string | null;
+  time?: CircleTimeValue;
 }
 
 export interface CircleDayDto {

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
@@ -18,7 +18,7 @@ import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { DAY_OPTIONS, DayValue, coerceDayValue } from 'src/app/@theme/types/DaysEnum';
 
-import { timeStringToTimeSpanString } from 'src/app/@theme/utils/time';
+import { timeStringToTimeSpan } from 'src/app/@theme/utils/time';
 
 
 interface CircleFormValue {
@@ -85,7 +85,7 @@ export class CoursesAddComponent implements OnInit {
     const formValue = this.circleForm.value as CircleFormValue;
 
     const dayValue = coerceDayValue(formValue.dayId);
-    const startTimeValue = timeStringToTimeSpanString(formValue.startTime);
+    const startTimeValue = timeStringToTimeSpan(formValue.startTime);
 
     const schedule =
       dayValue !== undefined

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
@@ -21,7 +21,7 @@ import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 import { DAY_OPTIONS, DayValue, coerceDayValue } from 'src/app/@theme/types/DaysEnum';
-import { formatTimeValue, timeStringToTimeSpanString } from 'src/app/@theme/utils/time';
+import { formatTimeValue, timeStringToTimeSpan } from 'src/app/@theme/utils/time';
 
 interface CircleFormValue {
   name: string;
@@ -253,7 +253,7 @@ export class CoursesUpdateComponent implements OnInit {
     const formValue = this.circleForm.getRawValue() as CircleFormValue;
 
     const dayValue = coerceDayValue(formValue.dayId);
-    const startTimeValue = timeStringToTimeSpanString(formValue.startTime);
+    const startTimeValue = timeStringToTimeSpan(formValue.startTime);
 
     const schedule =
       dayValue !== undefined


### PR DESCRIPTION
## Summary
- allow circle day requests to carry TimeSpan-based time values
- update add and update circle forms to send TimeSpan payloads for schedules

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b69f7460832296a05133d225948f