### PR TITLE
Display circle schedules in courses view

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
@@ -32,14 +32,34 @@
               </ng-container>
               <ng-container matColumnDef="day">
                 <th mat-header-cell *matHeaderCellDef>DAY</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">
-                  {{ getDayLabel(element) }}
+                <td mat-cell *matCellDef="let element">
+                  <ng-container *ngIf="element.scheduleEntries?.length; else noDay">
+                    <div class="schedule-cell">
+                      <div
+                        *ngFor="let schedule of element.scheduleEntries"
+                        class="schedule-cell__item"
+                      >
+                        {{ schedule.day || '-' }}
+                      </div>
+                    </div>
+                  </ng-container>
+                  <ng-template #noDay>-</ng-template>
                 </td>
               </ng-container>
               <ng-container matColumnDef="time">
                 <th mat-header-cell *matHeaderCellDef>START TIME</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">
-                  {{ getFormattedStartTime(element) }}
+                <td mat-cell *matCellDef="let element">
+                  <ng-container *ngIf="element.scheduleEntries?.length; else noTime">
+                    <div class="schedule-cell">
+                      <div
+                        *ngFor="let schedule of element.scheduleEntries"
+                        class="schedule-cell__item schedule-cell__time"
+                      >
+                        {{ schedule.time || '-' }}
+                      </div>
+                    </div>
+                  </ng-container>
+                  <ng-template #noTime>-</ng-template>
                 </td>
               </ng-container>
               <ng-container matColumnDef="managers">

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.scss
@@ -38,3 +38,19 @@
     }
   }
 }
+
+.schedule-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  white-space: normal;
+}
+
+.schedule-cell__item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.schedule-cell__time {
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Summary
- compute schedule entries for each circle so the view can display all configured day/time pairs
- update the courses view table to render the full schedule per course and add basic styling for stacked entries

## Testing
- npm run lint *(fails: existing lint violations in teacher-salary.service.ts and apex-charts.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f0f6bcd08322bbb62c3b88728e12