### PR TITLE
feat: show course managers on details view

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.html
@@ -16,19 +16,50 @@
             </mat-select>
           </mat-form-field>
         </div>
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Day</mat-label>
-            <mat-select formControlName="dayId">
-              <mat-option *ngFor="let day of days" [value]="day.value">{{ day.label }}</mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
-        <div class="col-md-6">
-          <mat-form-field appearance="outline" class="w-100">
-            <mat-label>Start Time</mat-label>
-            <input matInput type="time" formControlName="startTime" placeholder="Select Start Time" />
-          </mat-form-field>
+        <div class="col-12">
+          <div formArrayName="days">
+            <ng-container *ngFor="let dayGroup of daysArray.controls; let i = index; trackBy: trackByIndex">
+              <div class="row" [formGroupName]="i">
+                <div class="col-md-5">
+                  <mat-form-field appearance="outline" class="w-100">
+                    <mat-label>Day</mat-label>
+                    <mat-select formControlName="dayId">
+                      <mat-option *ngFor="let day of days" [value]="day.value">{{ day.label }}</mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
+                <div class="col-md-5">
+                  <mat-form-field appearance="outline" class="w-100">
+                    <mat-label>Start Time</mat-label>
+                    <input matInput type="time" formControlName="startTime" placeholder="Select Start Time" />
+                  </mat-form-field>
+                </div>
+                <div class="col-md-2 d-flex align-items-center">
+                  <button
+                    mat-icon-button
+                    color="warn"
+                    type="button"
+                    class="m-r-10"
+                    aria-label="Remove day"
+                    (click)="removeDay(i)"
+                    *ngIf="daysArray.length > 1"
+                  >
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                  <button
+                    mat-icon-button
+                    color="primary"
+                    type="button"
+                    aria-label="Add day"
+                    (click)="addDay()"
+                    *ngIf="i === daysArray.length - 1"
+                  >
+                    <mat-icon>add</mat-icon>
+                  </button>
+                </div>
+              </div>
+            </ng-container>
+          </div>
         </div>
         <div class="col-md-6">
           <mat-form-field appearance="outline" class="w-100">

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-add/courses-add.component.ts
@@ -1,7 +1,7 @@
 // angular imports
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 // project import
 import { SharedModule } from 'src/app/demo/shared/shared.module';
@@ -12,20 +12,25 @@ import {
 } from 'src/app/@theme/services/lookup.service';
 import {
   CircleService,
+  CircleDayRequestDto,
   CreateCircleDto
 } from 'src/app/@theme/services/circle.service';
 import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { DAY_OPTIONS, DayValue, coerceDayValue } from 'src/app/@theme/types/DaysEnum';
 
-import { timeStringToTimeSpan } from 'src/app/@theme/utils/time';
+import { timeStringToTimeSpanString } from 'src/app/@theme/utils/time';
 
+
+interface CircleScheduleFormValue {
+  dayId: DayValue | null;
+  startTime: string | null;
+}
 
 interface CircleFormValue {
   name: string;
   teacherId: number;
-  dayId: DayValue;
-  startTime: string;
+  days: CircleScheduleFormValue[];
   managers: number[];
   studentsIds: number[];
 }
@@ -53,8 +58,7 @@ export class CoursesAddComponent implements OnInit {
     this.circleForm = this.fb.group({
       name: ['', Validators.required],
       teacherId: [null, Validators.required],
-      dayId: [null, Validators.required],
-      startTime: ['', Validators.required],
+      days: this.fb.array([this.createDayGroup()]),
       managers: [[]],
       studentsIds: [[]]
     });
@@ -77,20 +81,62 @@ export class CoursesAddComponent implements OnInit {
       });
   }
 
+  get daysArray(): FormArray<FormGroup> {
+    return this.circleForm.get('days') as FormArray<FormGroup>;
+  }
+
+  addDay(): void {
+    this.daysArray.push(this.createDayGroup());
+    this.daysArray.markAsDirty();
+    this.daysArray.markAsTouched();
+    this.daysArray.updateValueAndValidity();
+  }
+
+  removeDay(index: number): void {
+    if (this.daysArray.length <= 1) {
+      this.daysArray.at(0).reset({ dayId: null, startTime: '' });
+      this.daysArray.markAsDirty();
+      this.daysArray.markAsTouched();
+      this.daysArray.updateValueAndValidity();
+      return;
+    }
+
+    this.daysArray.removeAt(index);
+    this.daysArray.markAsDirty();
+    this.daysArray.markAsTouched();
+    this.daysArray.updateValueAndValidity();
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+
+  private createDayGroup(initial?: Partial<CircleScheduleFormValue>): FormGroup {
+    return this.fb.group({
+      dayId: [initial?.dayId ?? null, Validators.required],
+      startTime: [initial?.startTime ?? '', Validators.required]
+    });
+  }
+
   onSubmit() {
     if (this.circleForm.invalid) {
       this.circleForm.markAllAsTouched();
       return;
     }
-    const formValue = this.circleForm.value as CircleFormValue;
+    const formValue = this.circleForm.getRawValue() as CircleFormValue;
 
-    const dayValue = coerceDayValue(formValue.dayId);
-    const startTimeValue = timeStringToTimeSpan(formValue.startTime);
+    const schedule: CircleDayRequestDto[] = Array.isArray(formValue.days)
+      ? formValue.days.reduce<CircleDayRequestDto[]>((acc, entry) => {
+          const dayValue = coerceDayValue(entry?.dayId ?? undefined);
+          if (dayValue === undefined) {
+            return acc;
+          }
 
-    const schedule =
-      dayValue !== undefined
-        ? [{ dayId: dayValue, time: startTimeValue ?? null }]
-        : [];
+          const startTimeValue = timeStringToTimeSpanString(entry?.startTime);
+          acc.push({ dayId: dayValue, time: startTimeValue ?? null });
+          return acc;
+        }, [])
+      : [];
 
     const model: CreateCircleDto = {
       name: formValue.name,
@@ -103,14 +149,7 @@ export class CoursesAddComponent implements OnInit {
       next: (res) => {
         if (res.isSuccess) {
           this.toast.success('Circle created successfully');
-          this.circleForm.reset({
-            name: '',
-            teacherId: null,
-            dayId: null,
-            startTime: '',
-            managers: [],
-            studentsIds: []
-          });
+          this.resetForm();
         } else if (res.errors?.length) {
           res.errors.forEach((e) => this.toast.error(e.message));
         } else {
@@ -119,6 +158,29 @@ export class CoursesAddComponent implements OnInit {
       },
       error: () => this.toast.error('Error creating circle')
     });
+  }
+
+  private resetForm(): void {
+    while (this.daysArray.length > 1) {
+      this.daysArray.removeAt(0);
+    }
+
+    if (!this.daysArray.length) {
+      this.daysArray.push(this.createDayGroup());
+    }
+
+    this.daysArray.at(0).reset({ dayId: null, startTime: '' });
+
+    this.circleForm.reset({
+      name: '',
+      teacherId: null,
+      managers: [],
+      studentsIds: [],
+      days: this.daysArray.value
+    });
+
+    this.circleForm.markAsPristine();
+    this.circleForm.markAsUntouched();
   }
 }
 

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-details/courses-details.component.html
@@ -27,6 +27,16 @@
               Start Time: {{ getFormattedStartTime(currentCourse) }}
             </div>
           </ng-template>
+          <div *ngIf="getManagers(currentCourse) as managers">
+            <ng-container *ngIf="managers.length">
+              <div>Managers:</div>
+              <ul class="m-b-10">
+                <li *ngFor="let manager of managers" class="schedule-item">
+                  <span class="schedule-day">{{ manager }}</span>
+                </li>
+              </ul>
+            </ng-container>
+          </div>
         </div>
       </div>
       <div class="p-b-15">

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-update/courses-update.component.ts
@@ -21,7 +21,7 @@ import { ToastService } from 'src/app/@theme/services/toast.service';
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { AuthenticationService } from 'src/app/@theme/services/authentication.service';
 import { DAY_OPTIONS, DayValue, coerceDayValue } from 'src/app/@theme/types/DaysEnum';
-import { formatTimeValue, timeStringToTimeSpan } from 'src/app/@theme/utils/time';
+import { formatTimeValue, timeStringToTimeSpanString } from 'src/app/@theme/utils/time';
 
 interface CircleFormValue {
   name: string;
@@ -253,7 +253,7 @@ export class CoursesUpdateComponent implements OnInit {
     const formValue = this.circleForm.getRawValue() as CircleFormValue;
 
     const dayValue = coerceDayValue(formValue.dayId);
-    const startTimeValue = timeStringToTimeSpan(formValue.startTime);
+    const startTimeValue = timeStringToTimeSpanString(formValue.startTime);
 
     const schedule =
       dayValue !== undefined


### PR DESCRIPTION
## Summary
- allow the circle creation form to manage multiple day/time schedule entries via a form array with add/remove helpers
- convert the collected schedule rows into the API payload and reset the form after submission
- ensure the computed schedule is typed as CircleDayRequestDto to satisfy CreateCircleDto.days
- send circle schedule start times as HH:mm:ss strings so the API can parse them
- fetch full circle details from the API when opening the course details route and surface manager names alongside the schedule

## Testing
- npm run lint *(fails because of pre-existing lint errors in teacher-salary.service.ts and apex-charts.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bc7eb38c83228a8a4788dde0e8aa