### PR TITLE
Improve course list array presentation

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
@@ -30,42 +30,58 @@
                   {{ element.teacher?.fullName || element.teacherName || element.teacherId }}
                 </td>
               </ng-container>
-              <ng-container matColumnDef="day">
-                <th mat-header-cell *matHeaderCellDef>DAY</th>
-                <td mat-cell *matCellDef="let element">
-                  <ng-container *ngIf="element.scheduleEntries?.length; else noDay">
-                    <div class="schedule-cell">
-                      <div
-                        *ngFor="let schedule of element.scheduleEntries"
-                        class="schedule-cell__item"
+              <ng-container matColumnDef="schedule">
+                <th mat-header-cell *matHeaderCellDef>SCHEDULE</th>
+                <td mat-cell *matCellDef="let element" class="chip-cell">
+                  <ng-container *ngIf="element.scheduleEntries?.length; else noSchedule">
+                    <mat-chip-set aria-label="Course schedule" class="table-chip-set">
+                      <mat-chip
+                        *ngFor="let schedule of element.scheduleEntries; trackBy: trackBySchedule"
+                        appearance="outlined"
+                        class="table-chip"
+                        [matTooltip]="formatSchedule(schedule)"
                       >
-                        {{ schedule.day || '-' }}
-                      </div>
-                    </div>
+                        {{ formatSchedule(schedule) }}
+                      </mat-chip>
+                    </mat-chip-set>
                   </ng-container>
-                  <ng-template #noDay>-</ng-template>
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="time">
-                <th mat-header-cell *matHeaderCellDef>START TIME</th>
-                <td mat-cell *matCellDef="let element">
-                  <ng-container *ngIf="element.scheduleEntries?.length; else noTime">
-                    <div class="schedule-cell">
-                      <div
-                        *ngFor="let schedule of element.scheduleEntries"
-                        class="schedule-cell__item schedule-cell__time"
-                      >
-                        {{ schedule.time || '-' }}
-                      </div>
-                    </div>
-                  </ng-container>
-                  <ng-template #noTime>-</ng-template>
+                  <ng-template #noSchedule>-</ng-template>
                 </td>
               </ng-container>
               <ng-container matColumnDef="managers">
                 <th mat-header-cell *matHeaderCellDef>MANAGERS</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">
-                  {{ displayManagers(element.managers) }}
+                <td mat-cell *matCellDef="let element" class="chip-cell">
+                  <ng-container *ngIf="element.managerLabels?.length; else noManagers">
+                    <mat-chip-set aria-label="Course managers" class="table-chip-set">
+                      <mat-chip
+                        *ngFor="let manager of element.managerLabels; trackBy: trackByLabel"
+                        appearance="outlined"
+                        class="table-chip"
+                        [matTooltip]="manager"
+                      >
+                        {{ manager }}
+                      </mat-chip>
+                    </mat-chip-set>
+                  </ng-container>
+                  <ng-template #noManagers>-</ng-template>
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="students">
+                <th mat-header-cell *matHeaderCellDef>STUDENTS</th>
+                <td mat-cell *matCellDef="let element" class="chip-cell">
+                  <ng-container *ngIf="element.studentLabels?.length; else noStudents">
+                    <mat-chip-set aria-label="Course students" class="table-chip-set">
+                      <mat-chip
+                        *ngFor="let student of element.studentLabels; trackBy: trackByLabel"
+                        appearance="outlined"
+                        class="table-chip"
+                        [matTooltip]="student"
+                      >
+                        {{ student }}
+                      </mat-chip>
+                    </mat-chip-set>
+                  </ng-container>
+                  <ng-template #noStudents>-</ng-template>
                 </td>
               </ng-container>
               <ng-container matColumnDef="action">

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.scss
@@ -39,18 +39,18 @@
   }
 }
 
-.schedule-cell {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.chip-cell {
   white-space: normal;
+  vertical-align: top;
 }
 
-.schedule-cell__item {
-  display: inline-flex;
-  align-items: center;
+.table-chip-set {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
-.schedule-cell__time {
-  font-variant-numeric: tabular-nums;
+.table-chip {
+  max-width: 100%;
+  white-space: normal;
 }


### PR DESCRIPTION
## Summary
- render course schedules, managers, and students as Material chip sets in the courses view
- derive readable labels for managers and students when loading courses so arrays display cleanly
- add helper formatting utilities and styles to keep the new chip lists responsive

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8facd482883229aaa216356ff610d