### PR TITLE
Render course arrays as styled lists

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
@@ -30,42 +30,51 @@
                   {{ element.teacher?.fullName || element.teacherName || element.teacherId }}
                 </td>
               </ng-container>
-              <ng-container matColumnDef="day">
-                <th mat-header-cell *matHeaderCellDef>DAY</th>
-                <td mat-cell *matCellDef="let element">
-                  <ng-container *ngIf="element.scheduleEntries?.length; else noDay">
-                    <div class="schedule-cell">
-                      <div
-                        *ngFor="let schedule of element.scheduleEntries"
-                        class="schedule-cell__item"
-                      >
-                        {{ schedule.day || '-' }}
-                      </div>
-                    </div>
+              <ng-container matColumnDef="schedule">
+                <th mat-header-cell *matHeaderCellDef>SCHEDULE</th>
+                <td mat-cell *matCellDef="let element" class="multi-value-cell">
+                  <ng-container *ngIf="element.scheduleEntries?.length; else noSchedule">
+                    <ul class="multi-value-list" aria-label="Course schedule">
+                      <li *ngFor="let schedule of element.scheduleEntries; trackBy: trackBySchedule">
+                        {{ formatSchedule(schedule) }}
+                      </li>
+                    </ul>
                   </ng-container>
-                  <ng-template #noDay>-</ng-template>
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="time">
-                <th mat-header-cell *matHeaderCellDef>START TIME</th>
-                <td mat-cell *matCellDef="let element">
-                  <ng-container *ngIf="element.scheduleEntries?.length; else noTime">
-                    <div class="schedule-cell">
-                      <div
-                        *ngFor="let schedule of element.scheduleEntries"
-                        class="schedule-cell__item schedule-cell__time"
-                      >
-                        {{ schedule.time || '-' }}
-                      </div>
-                    </div>
-                  </ng-container>
-                  <ng-template #noTime>-</ng-template>
+                  <ng-template #noSchedule>-</ng-template>
                 </td>
               </ng-container>
               <ng-container matColumnDef="managers">
                 <th mat-header-cell *matHeaderCellDef>MANAGERS</th>
-                <td mat-cell *matCellDef="let element" class="text-nowrap">
-                  {{ displayManagers(element.managers) }}
+                <td mat-cell *matCellDef="let element" class="multi-value-cell">
+                  <ng-container *ngIf="element.managerLabels?.length; else managersFallback">
+                    <ul class="multi-value-list" aria-label="Course managers">
+                      <li *ngFor="let manager of element.managerLabels; trackBy: trackByLabel">
+                        {{ manager }}
+                      </li>
+                    </ul>
+                  </ng-container>
+                  <ng-template #managersFallback>
+                    <span class="multi-value-fallback">
+                      {{ displayManagers(element.managers) || '-' }}
+                    </span>
+                  </ng-template>
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="students">
+                <th mat-header-cell *matHeaderCellDef>STUDENTS</th>
+                <td mat-cell *matCellDef="let element" class="multi-value-cell">
+                  <ng-container *ngIf="element.studentLabels?.length; else studentsFallback">
+                    <ul class="multi-value-list" aria-label="Course students">
+                      <li *ngFor="let student of element.studentLabels; trackBy: trackByLabel">
+                        {{ student }}
+                      </li>
+                    </ul>
+                  </ng-container>
+                  <ng-template #studentsFallback>
+                    <span class="multi-value-fallback">
+                      {{ displayStudents(element.students) || '-' }}
+                    </span>
+                  </ng-template>
                 </td>
               </ng-container>
               <ng-container matColumnDef="action">

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.scss
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.scss
@@ -39,18 +39,34 @@
   }
 }
 
-.schedule-cell {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.multi-value-cell {
   white-space: normal;
+  vertical-align: top;
 }
 
-.schedule-cell__item {
+.multi-value-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.multi-value-list li {
   display: inline-flex;
   align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background-color: rgba(var(--accent-500-rgb, 96, 93, 255), 0.12);
+  color: var(--accent-900, #2c2b6f);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  max-width: 100%;
 }
 
-.schedule-cell__time {
-  font-variant-numeric: tabular-nums;
+.multi-value-fallback {
+  display: inline-block;
+  max-width: 100%;
+  white-space: normal;
 }

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
@@ -14,7 +14,8 @@ import {
   CircleService,
   CircleDayDto,
   CircleDto,
-  CircleManagerDto
+  CircleManagerDto,
+  CircleStudentDto
 } from 'src/app/@theme/services/circle.service';
 import {
   FilteredResultRequestDto
@@ -30,7 +31,11 @@ interface CircleScheduleEntry {
   time: string;
 }
 
-type CircleViewModel = CircleDto & { scheduleEntries: CircleScheduleEntry[] };
+type CircleViewModel = CircleDto & {
+  scheduleEntries: CircleScheduleEntry[];
+  managerLabels: string[];
+  studentLabels: string[];
+};
 
 @Component({
   selector: 'app-courses-view',
@@ -45,7 +50,7 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
   private auth = inject(AuthenticationService);
 
 
-  displayedColumns: string[] = ['name', 'teacher', 'day', 'time', 'managers', 'action'];
+  displayedColumns: string[] = ['name', 'teacher', 'schedule', 'managers', 'students', 'action'];
   dataSource = new MatTableDataSource<CircleViewModel>();
   totalCount = 0;
   filter: FilteredResultRequestDto = { skipCount: 0, maxResultCount: 10 };
@@ -61,7 +66,9 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
       if (res.isSuccess && res.data?.items) {
         this.dataSource.data = res.data.items.map((circle) => ({
           ...circle,
-          scheduleEntries: this.buildScheduleEntries(circle)
+          scheduleEntries: this.buildScheduleEntries(circle),
+          managerLabels: this.buildManagerLabels(circle.managers),
+          studentLabels: this.buildStudentLabels(circle.students)
         }));
         this.totalCount = res.data.totalCount;
       } else {
@@ -163,53 +170,133 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
     return '';
   }
 
-  displayManagers(
-    managers?: (CircleManagerDto | number | string | null | undefined)[]
-  ): string {
-    if (!managers || !managers.length) {
-      return '';
+  private buildManagerLabels(
+    managers?: (CircleManagerDto | string | number | null | undefined)[] | null
+  ): string[] {
+    return this.extractManagerLabels(managers);
+  }
+
+  private buildStudentLabels(students?: (CircleStudentDto | null | undefined)[] | null): string[] {
+    return this.extractStudentLabels(students);
+  }
+
+  formatSchedule(schedule: CircleScheduleEntry): string {
+    const day = schedule.day?.trim();
+    const time = schedule.time?.trim();
+
+    if (day && time) {
+      return `${day} • ${time}`;
     }
 
-    const names = managers
-      .map((m) => {
-        if (m === null || m === undefined) {
+    return day || time || '-';
+  }
+
+  private extractManagerLabels(
+    managers?: (CircleManagerDto | string | number | null | undefined)[] | null
+  ): string[] {
+    if (!Array.isArray(managers)) {
+      return [];
+    }
+
+    const labels = managers
+      .map((manager) => {
+        if (manager === null || manager === undefined) {
           return '';
         }
 
-        if (typeof m === 'number' || typeof m === 'string') {
-          return String(m);
+        if (typeof manager === 'string' || typeof manager === 'number') {
+          return String(manager).trim();
         }
 
-        const manager = m.manager;
+        const value = manager.manager;
 
-        if (typeof manager === 'string') {
-          return manager;
+        if (typeof value === 'string') {
+          return value.trim();
         }
 
-        if (manager && typeof manager === 'object') {
-          const lookUp = manager as { fullName?: string; name?: string };
-          if (lookUp.fullName) {
-            return lookUp.fullName;
+        if (value && typeof value === 'object') {
+          const lookUp = value as { fullName?: string | null; name?: string | null };
+          if (lookUp.fullName && lookUp.fullName.trim()) {
+            return lookUp.fullName.trim();
           }
 
-          if (lookUp.name) {
-            return lookUp.name;
+          if (lookUp.name && lookUp.name.trim()) {
+            return lookUp.name.trim();
           }
         }
 
-        if (m.managerName) {
-          return m.managerName;
+        if (manager.managerName && manager.managerName.trim()) {
+          return manager.managerName.trim();
         }
 
-        if (m.managerId !== undefined && m.managerId !== null) {
-          return String(m.managerId);
+        if (manager.managerId !== undefined && manager.managerId !== null) {
+          return `#${manager.managerId}`;
         }
 
         return '';
       })
-      .filter((name) => !!name);
+      .filter((label) => !!label) as string[];
 
-    return names.join(', ');
+    return Array.from(new Set(labels));
+  }
+
+  private extractStudentLabels(students?: (CircleStudentDto | null | undefined)[] | null): string[] {
+    if (!Array.isArray(students)) {
+      return [];
+    }
+
+    const labels = students
+      .map((student) => {
+        if (!student) {
+          return '';
+        }
+
+        if (student.fullName && student.fullName.trim()) {
+          return student.fullName.trim();
+        }
+
+        if (student.student) {
+          const lookUp = student.student as { fullName?: string | null; name?: string | null };
+          if (lookUp.fullName && lookUp.fullName.trim()) {
+            return lookUp.fullName.trim();
+          }
+
+          if (lookUp.name && lookUp.name.trim()) {
+            return lookUp.name.trim();
+          }
+        }
+
+        if (student.studentId !== undefined && student.studentId !== null) {
+          return `#${student.studentId}`;
+        }
+
+        if (student.id !== undefined && student.id !== null) {
+          return `#${student.id}`;
+        }
+
+        return '';
+      })
+      .filter((label) => !!label) as string[];
+
+    return Array.from(new Set(labels));
+  }
+
+  displayManagers(
+    managers?: (CircleManagerDto | string | number | null | undefined)[] | null
+  ): string {
+    return this.extractManagerLabels(managers).join(', ');
+  }
+
+  displayStudents(students?: (CircleStudentDto | null | undefined)[] | null): string {
+    return this.extractStudentLabels(students).join(', ');
+  }
+
+  trackBySchedule(_index: number, schedule: CircleScheduleEntry): string {
+    return `${schedule.day ?? ''}-${schedule.time ?? ''}`;
+  }
+
+  trackByLabel(_index: number, label: string): string {
+    return label;
   }
 
 }


### PR DESCRIPTION
## Summary
- replace the chip-based schedule, manager, and student renders with flex pill lists so values are always visible
- add multi-value pill styling to keep array entries readable inside the table while preserving graceful fallbacks

## Testing
- npm run lint *(fails: existing lint violations in teacher-salary.service.ts and apex-charts.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d8facd482883229aaa216356ff610d