### PR TITLE
Fix conditional circle detail fetch

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
@@ -25,6 +25,8 @@ import { AuthenticationService } from 'src/app/@theme/services/authentication.se
 import { UserTypesEnum } from 'src/app/@theme/types/UserTypesEnum';
 import { DayValue, formatDayValue } from 'src/app/@theme/types/DaysEnum';
 import { formatTimeValue } from 'src/app/@theme/utils/time';
+import { forkJoin, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 
 interface CircleScheduleEntry {
   day: string;
@@ -64,16 +66,71 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
   private loadCircles() {
     this.circleService.getAll(this.filter).subscribe((res) => {
       if (res.isSuccess && res.data?.items) {
-        this.dataSource.data = res.data.items.map((circle) => ({
-          ...circle,
-          scheduleEntries: this.buildScheduleEntries(circle),
-          managerLabels: this.buildManagerLabels(circle.managers),
-          studentLabels: this.buildStudentLabels(circle.students)
-        }));
+        const sourceCircles = res.data.items;
+        const viewModels = sourceCircles.map((circle) => this.buildViewModel(circle));
+        this.dataSource.data = viewModels;
         this.totalCount = res.data.totalCount;
+
+        const circlesRequiringDetails = sourceCircles
+          .map((circle, index) => ({ circle, index }))
+          .filter(({ circle, index }) => this.needsAdditionalDetails(circle, viewModels[index]));
+
+        if (circlesRequiringDetails.length) {
+          this.fetchCircleDetails(circlesRequiringDetails, viewModels);
+        }
       } else {
         this.dataSource.data = [];
         this.totalCount = 0;
+      }
+    });
+  }
+
+  private buildViewModel(circle: CircleDto): CircleViewModel {
+    return {
+      ...circle,
+      scheduleEntries: this.buildScheduleEntries(circle),
+      managerLabels: this.buildManagerLabels(circle.managers),
+      studentLabels: this.buildStudentLabels(circle.students)
+    };
+  }
+
+  private needsAdditionalDetails(circle: CircleDto, viewModel: CircleViewModel): boolean {
+    const managersMissing = circle.managers === undefined || circle.managers === null;
+    const studentsMissing = circle.students === undefined || circle.students === null;
+    const scheduleMissing = circle.days === undefined || circle.days === null;
+
+    return managersMissing || studentsMissing || scheduleMissing || !viewModel.scheduleEntries.length;
+  }
+
+  private fetchCircleDetails(
+    pending: { circle: CircleDto; index: number }[],
+    viewModels: CircleViewModel[]
+  ): void {
+    forkJoin(
+      pending.map(({ circle, index }) =>
+        this.circleService.get(circle.id).pipe(
+          map((res) => ({ index, res })),
+          catchError(() => of({ index, res: null }))
+        )
+      )
+    ).subscribe((responses) => {
+      let updated = false;
+
+      responses.forEach((response) => {
+        if (!response?.res?.isSuccess || !response.res.data) {
+          return;
+        }
+
+        const detailedViewModel = this.buildViewModel(response.res.data);
+        viewModels[response.index] = {
+          ...viewModels[response.index],
+          ...detailedViewModel
+        };
+        updated = true;
+      });
+
+      if (updated) {
+        this.dataSource.data = [...viewModels];
       }
     });
   }


### PR DESCRIPTION
## Summary
- trigger a circle detail fetch only for rows whose list response lacks manager, student, or schedule data
- merge the detailed payload back into the existing view models so the table displays complete labels without redundant requests

## Testing
- npm run lint *(fails: existing lint violations in teacher-salary.service.ts and apex-charts.component.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d9081d60bc8322bb7810965d80608a