### PR TITLE
feat: show course participants in view popup

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.html
@@ -86,14 +86,13 @@
                   <div class="text-center text-nowrap">
                     <ul class="list-inline p-l-0">
                       <li class="list-inline-item m-r-10" matTooltip="View">
-                        <a
-                          [routerLink]="['/online-course/courses/details', element.id]"
-                          [state]="{ course: element }"
+                        <button
+                          type="button"
                           class="avatar avatar-xs text-muted"
+                          (click)="openParticipantsDialog(element)"
                         >
-
                           <i class="ti ti-eye f-18"></i>
-                        </a>
+                        </button>
                       </li>
                       <li class="list-inline-item m-r-10" matTooltip="Edit" *ngIf="!isTeacherOrStudent">
                         <a

--- a/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/courses/courses-view/courses-view.component.ts
@@ -1,11 +1,19 @@
 // angular import
 import { AfterViewInit, Component, OnInit, inject, viewChild } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { NgFor, NgIf } from '@angular/common';
 
 // angular material
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
-import { MatDialog, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
+import {
+  MAT_DIALOG_DATA,
+  MatDialog,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogTitle
+} from '@angular/material/dialog';
 import { MatButton } from '@angular/material/button';
 
 
@@ -37,6 +45,12 @@ type CircleViewModel = CircleDto & {
   managerLabels: string[];
   studentLabels: string[];
 };
+
+interface CourseParticipantsDialogData {
+  name?: string | null;
+  managers: string[];
+  students: string[];
+}
 
 @Component({
   selector: 'app-courses-view',
@@ -113,6 +127,17 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
           },
           error: () => this.toast.error('Error deleting course')
         });
+      }
+    });
+  }
+
+  openParticipantsDialog(course: CircleViewModel): void {
+    this.dialog.open(CourseParticipantsDialogComponent, {
+      width: '480px',
+      data: {
+        name: course.name,
+        managers: course.managerLabels ?? [],
+        students: course.studentLabels ?? []
       }
     });
   }
@@ -322,4 +347,74 @@ export class CoursesViewComponent implements OnInit, AfterViewInit {
   imports: [MatDialogActions, MatButton, MatDialogClose]
 })
 export class DeleteConfirmDialogComponent {}
+
+@Component({
+  selector: 'app-course-participants-dialog',
+  template: `
+    <div mat-dialog-title>{{ data.name?.trim() || 'Course' }} participants</div>
+    <div mat-dialog-content class="participants-dialog">
+      <section class="participants-section">
+        <h3>Managers</h3>
+        <ng-container *ngIf="data.managers.length; else noManagers">
+          <ul>
+            <li *ngFor="let manager of data.managers">{{ manager }}</li>
+          </ul>
+        </ng-container>
+        <ng-template #noManagers>
+          <p class="empty-state">No managers assigned.</p>
+        </ng-template>
+      </section>
+      <section class="participants-section">
+        <h3>Students</h3>
+        <ng-container *ngIf="data.students.length; else noStudents">
+          <ul>
+            <li *ngFor="let student of data.students">{{ student }}</li>
+          </ul>
+        </ng-container>
+        <ng-template #noStudents>
+          <p class="empty-state">No students enrolled.</p>
+        </ng-template>
+      </section>
+    </div>
+    <div mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Close</button>
+    </div>
+  `,
+  styles: [
+    `
+      .participants-dialog {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        max-height: 60vh;
+        overflow: auto;
+      }
+
+      .participants-section h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+      }
+
+      .participants-section ul {
+        margin: 0;
+        padding-left: 1.25rem;
+      }
+
+      .participants-section li {
+        margin-bottom: 0.35rem;
+      }
+
+      .empty-state {
+        margin: 0;
+        color: rgba(0, 0, 0, 0.54);
+        font-style: italic;
+      }
+    `
+  ],
+  imports: [MatDialogTitle, MatDialogContent, NgIf, NgFor, MatDialogActions, MatButton, MatDialogClose]
+})
+export class CourseParticipantsDialogComponent {
+  readonly data = inject<CourseParticipantsDialogData>(MAT_DIALOG_DATA);
+}
 


### PR DESCRIPTION
## Summary
- replace the course "View" action with a dialog trigger so managers and students appear in a modal
- add a reusable dialog component that lists assigned managers and enrolled students with empty-state messaging

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d91c8468108322a910a76e750fa0fd