### PR TITLE
Add Today Reports panel to Online Dashboard and integrate CircleReportService

### DIFF
--- a/src/app/demo/pages/admin-panel/online-courses/online-dashboard/online-dashboard.component.html
+++ b/src/app/demo/pages/admin-panel/online-courses/online-dashboard/online-dashboard.component.html
@@ -186,6 +186,7 @@
             <tr>
               <th>{{ 'الطالب' | translate }}</th>
               <th>{{ 'المبلغ' | translate }}</th>
+              <th>{{ 'الدقائق' | translate }}</th>
               <th>{{ 'التاريخ' | translate }}</th>
               <th>{{ 'الحالة' | translate }}</th>
             </tr>
@@ -210,6 +211,45 @@
   <div class="col-12" *ngIf="isAdmin && overviewLoaded && !transactionsView.length">
     <app-card [showHeader]="false" [padding]="20">
       <div class="text-muted">{{ 'لا توجد معاملات حديثة لهذه المدة.' | translate }}</div>
+    </app-card>
+  </div>
+
+  <div class="col-12" *ngIf="canViewTodayReports && todayReportsView.length">
+    <app-card [cardTitle]="'تقارير اليوم' | translate" padding="0">
+      <div class="table-responsive transactions-table">
+        <table class="table table-hover m-b-0">
+          <thead>
+            <tr>
+              <th>{{ 'الطالب' | translate }}</th>
+              <th>{{ 'الحلقة' | translate }}</th>
+              <th>{{ 'المعلم' | translate }}</th>
+              <th>{{ 'الدقائق' | translate }}</th>
+              <th>{{ 'التاريخ' | translate }}</th>
+              <th>{{ 'الحالة' | translate }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (report of todayReportsView; track report.key) {
+              <tr>
+                <td class="student-cell">{{ report.student }}</td>
+                <td>{{ report.circle }}</td>
+                <td>{{ report.teacher }}</td>
+                <td class="amount-cell">{{ report.minutes }}</td>
+                <td class="date-cell">{{ report.date }}</td>
+                <td>
+                  <span class="status-pill {{ report.statusClass }}">{{ report.status }}</span>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </app-card>
+  </div>
+
+  <div class="col-12" *ngIf="canViewTodayReports && reportsLoaded && !todayReportsView.length">
+    <app-card [showHeader]="false" [padding]="20">
+      <div class="text-muted">{{ 'لا توجد تقارير مرفوعة اليوم.' | translate }}</div>
     </app-card>
   </div>
   </div>

--- a/src/app/demo/pages/admin-panel/online-courses/online-dashboard/online-dashboard.component.ts
+++ b/src/app/demo/pages/admin-panel/online-courses/online-dashboard/online-dashboard.component.ts
@@ -13,6 +13,8 @@ import { formatDayValue } from 'src/app/@theme/types/DaysEnum';
 import { formatTimeValue } from 'src/app/@theme/utils/time';
 import { TranslateService } from '@ngx-translate/core';
 import { LoadingOverlayComponent } from 'src/app/@theme/components/loading-overlay/loading-overlay.component';
+import { CircleReportListDto, CircleReportService } from 'src/app/@theme/services/circle-report.service';
+import { AttendStatusEnum } from 'src/app/@theme/types/AttendStatusEnum';
 import {
   DashboardOverviewDto,
   DashboardOverviewMetricsDto,
@@ -41,6 +43,17 @@ interface DashboardTransactionView {
   statusClass: string;
 }
 
+interface DashboardTodayReportView {
+  key: string;
+  student: string;
+  circle: string;
+  teacher: string;
+  minutes: string;
+  date: string;
+  status: string;
+  statusClass: string;
+}
+
 @Component({
   selector: 'app-online-dashboard',
   imports: [
@@ -61,6 +74,7 @@ export class OnlineDashboardComponent implements OnInit {
   private toast = inject(ToastService);
   private translate = inject(TranslateService);
   private dashboardOverview = inject(DashboardOverviewService);
+  private circleReportService = inject(CircleReportService);
   private readonly roleTranslations: Record<string, string> = {
     admin: 'مسؤول',
     manager: 'مدير',
@@ -77,11 +91,15 @@ export class OnlineDashboardComponent implements OnInit {
   overviewRangeDescription: string | null = null;
   isTeacher = false;
   isAdmin = false;
+  canViewTodayReports = false;
 
   summaryCards: DashboardSummaryCard[] = [];
   roleMetricCards: DashboardSummaryCard[] = [];
   financialMetricCards: DashboardSummaryCard[] = [];
   transactionsView: DashboardTransactionView[] = [];
+  todayReportsView: DashboardTodayReportView[] = [];
+  reportsLoading = false;
+  reportsLoaded = false;
 
   monthlyRevenueSeries?: ApexAxisChartSeries;
   monthlyRevenueCategories?: string[];
@@ -95,7 +113,7 @@ export class OnlineDashboardComponent implements OnInit {
   upcomingLoading = false;
 
   get pageLoading(): boolean {
-    return this.overviewLoading || this.upcomingLoading;
+    return this.overviewLoading || this.upcomingLoading || this.reportsLoading;
   }
   ngOnInit(): void {
     this.loadDashboardOverview();
@@ -151,6 +169,10 @@ export class OnlineDashboardComponent implements OnInit {
     this.overviewRangeDescription = null;
     this.isTeacher = false;
     this.isAdmin = false;
+    this.canViewTodayReports = false;
+    this.todayReportsView = [];
+    this.reportsLoaded = false;
+    this.reportsLoading = false;
   }
 
   private applyOverviewData(data?: DashboardOverviewDto | null): void {
@@ -161,6 +183,7 @@ export class OnlineDashboardComponent implements OnInit {
 
     this.isTeacher = this.isTeacherRole(data.role);
     this.isAdmin = this.isAdminRole(data.role);
+    this.canViewTodayReports = this.canAccessTodayReports(data.role);
     this.overviewRoleLabel = this.formatRole(data.role);
     this.overviewRangeDescription = this.buildRangeDescription(data.rangeStart, data.rangeEnd, data.rangeLabel);
 
@@ -170,8 +193,159 @@ export class OnlineDashboardComponent implements OnInit {
 
     const charts = data.charts;
     this.transactionsView = this.buildTransactionsView(charts?.transactions);
+    this.loadTodayReports();
     this.buildMonthlyRevenueChart(charts?.monthlyRevenue);
     this.buildFinancialChart(data.metrics);
+  }
+
+  private loadTodayReports(): void {
+    if (!this.canViewTodayReports) {
+      this.todayReportsView = [];
+      this.reportsLoaded = true;
+      return;
+    }
+
+    this.reportsLoading = true;
+    this.reportsLoaded = false;
+
+    const today = this.getTodayDateString();
+    this.circleReportService
+      .getAll(
+        {
+          skipCount: 0,
+          maxResultCount: 10,
+          sortBy: 'creationTime',
+          sortingDirection: 'DESC'
+        },
+        {
+          fromDate: today,
+          toDate: today
+        }
+      )
+      .subscribe({
+        next: (response) => {
+          this.reportsLoading = false;
+          this.reportsLoaded = true;
+          if (!response?.isSuccess) {
+            this.todayReportsView = [];
+            return;
+          }
+
+          this.todayReportsView = this.buildTodayReportsView(response.data?.items);
+        },
+        error: () => {
+          this.reportsLoading = false;
+          this.reportsLoaded = true;
+          this.todayReportsView = [];
+        }
+      });
+  }
+
+  private getTodayDateString(): string {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private buildTodayReportsView(reports?: CircleReportListDto[] | null): DashboardTodayReportView[] {
+    if (!Array.isArray(reports)) {
+      return [];
+    }
+
+    return reports.map((report, index) => {
+      const keySource = report?.id ?? index;
+      const key = typeof keySource === 'string' ? keySource : String(keySource ?? index);
+      const statusConfig = this.getAttendanceStatusConfig(report?.attendStatueId);
+
+      return {
+        key,
+        student: this.getReportStudentDisplay(report, index),
+        circle: this.getReportCircleDisplay(report),
+        teacher: this.getReportTeacherDisplay(report),
+        minutes: this.formatReportMinutes(report?.minutes),
+        date: this.formatTransactionDate(report?.creationTime ? String(report.creationTime) : undefined),
+        status: statusConfig.label,
+        statusClass: statusConfig.class
+      } satisfies DashboardTodayReportView;
+    });
+  }
+
+  private getAttendanceStatusConfig(status?: number | null): { label: string; class: string } {
+    switch (status) {
+      case AttendStatusEnum.Attended:
+        return { label: 'حضر', class: 'status-pill--success' };
+      case AttendStatusEnum.ExcusedAbsence:
+        return { label: 'غائب بعذر', class: 'status-pill--warning' };
+      case AttendStatusEnum.UnexcusedAbsence:
+        return { label: 'غائب بدون عذر', class: 'status-pill--danger' };
+      default:
+        return { label: 'غير محدد', class: 'status-pill--muted' };
+    }
+  }
+
+  private formatReportMinutes(value: unknown): string {
+    const minutes = this.coerceNumber(value);
+    if (minutes === null) {
+      return '—';
+    }
+
+    return `${this.formatNumber(minutes)} دقيقة`;
+  }
+
+  private getReportStudentDisplay(report: CircleReportListDto | null | undefined, index: number): string {
+    const raw = report as Record<string, unknown> | undefined;
+    const display =
+      (typeof report?.studentName === 'string' ? report.studentName : '') ||
+      (typeof raw?.['student'] === 'string' ? (raw['student'] as string) : '') ||
+      (typeof raw?.['studentFullName'] === 'string' ? (raw['studentFullName'] as string) : '');
+
+    if (display.trim()) {
+      return display.trim();
+    }
+
+    if (typeof report?.studentId === 'number') {
+      return this.translate.instant('طالب رقم {{id}}', { id: report.studentId });
+    }
+
+    return this.translate.instant('طالب رقم {{id}}', { id: index + 1 });
+  }
+
+  private getReportCircleDisplay(report: CircleReportListDto | null | undefined): string {
+    const raw = report as Record<string, unknown> | undefined;
+    const display =
+      (typeof report?.circleName === 'string' ? report.circleName : '') ||
+      (typeof raw?.['circle'] === 'string' ? (raw['circle'] as string) : '') ||
+      (typeof raw?.['circleTitle'] === 'string' ? (raw['circleTitle'] as string) : '');
+
+    if (display.trim()) {
+      return display.trim();
+    }
+
+    if (typeof report?.circleId === 'number') {
+      return this.translate.instant('حلقة رقم {{id}}', { id: report.circleId });
+    }
+
+    return '—';
+  }
+
+  private getReportTeacherDisplay(report: CircleReportListDto | null | undefined): string {
+    const raw = report as Record<string, unknown> | undefined;
+    const display =
+      (typeof report?.teacherName === 'string' ? report.teacherName : '') ||
+      (typeof raw?.['teacher'] === 'string' ? (raw['teacher'] as string) : '') ||
+      (typeof raw?.['teacherFullName'] === 'string' ? (raw['teacherFullName'] as string) : '');
+
+    if (display.trim()) {
+      return display.trim();
+    }
+
+    if (typeof report?.teacherId === 'number') {
+      return this.translate.instant('معلم رقم {{id}}', { id: report.teacherId });
+    }
+
+    return '—';
   }
 
   get visibleRoleMetricCards(): DashboardSummaryCard[] {
@@ -825,6 +999,15 @@ private toArabicMonthLabel(input: string): string {
 
     const normalized = role.trim().replace(/\s+|_/g, '').toLowerCase();
     return normalized === 'admin';
+  }
+
+  private canAccessTodayReports(role?: string | null): boolean {
+    if (typeof role !== 'string') {
+      return false;
+    }
+
+    const normalized = role.trim().replace(/\s+|_/g, '').toLowerCase();
+    return ['admin', 'manager', 'supervisor', 'branchleader', 'teacher'].includes(normalized);
   }
 
   loadUpcomingCircles(take = 4): void {


### PR DESCRIPTION
### Motivation
- Provide admins/managers/teachers quick access to today’s circle reports directly from the online dashboard to improve monitoring of attendance and minutes. 
- Surface minutes and attendance status in the dashboard tables for clearer visibility of recent activity.

### Description
- Added a new "تقارير اليوم" table in `online-dashboard.component.html` that shows student, circle, teacher, minutes, date, and status and an empty-state card when no reports exist. 
- Introduced `CircleReportService` and `AttendStatusEnum` imports and wired a new `loadTodayReports()` flow in `online-dashboard.component.ts` to fetch reports for the current day and populate `todayReportsView`. 
- Added new state and view models (`DashboardTodayReportView`, `todayReportsView`, `reportsLoading`, `reportsLoaded`, `canViewTodayReports`) and updated `pageLoading` and `resetOverviewData()` to account for the new loading state. 
- Implemented various helpers to normalize and format report data: `buildTodayReportsView()`, `getAttendanceStatusConfig()`, `formatReportMinutes()`, `getReportStudentDisplay()`, `getReportCircleDisplay()`, `getReportTeacherDisplay()`, `getTodayDateString()`, and added `canAccessTodayReports()` to determine role access. 
- Minor template change: added a `دقائق` header to the recent transactions table.

### Testing
- Ran a local build and type-check to validate compilation and new imports via `ng build` which completed successfully. 
- Executed linting checks with `ng lint` with no new lint failures. 
- Local unit/integration tests were executed via `ng test` and the test suite passed without new failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab404675883229e0e1d3d063f6fb4)